### PR TITLE
feat(nodedev): custom node builder & installer — scaffold, install, materialize, live palette

### DIFF
--- a/apps/nodes-ui/nodes.rrapp
+++ b/apps/nodes-ui/nodes.rrapp
@@ -1,0 +1,3 @@
+{
+  "id": "rocketride.nodes"
+}

--- a/apps/nodes-ui/package.json
+++ b/apps/nodes-ui/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@rocketride/nodes-ui",
+  "version": "1.2.0",
+  "private": true,
+  "description": "Node catalog — browse and install community nodes",
+  "license": "MIT",
+  "appManifest": {
+    "id": "rocketride.nodes",
+    "publisher": "Aparavi Software AG",
+    "name": "Node Catalog",
+    "description": "Browse nodes published by the community and install them into your workspace",
+    "categories": [
+      "tools"
+    ],
+    "mode": "free",
+    "authenticated": true,
+    "showStatusBar": true
+  },
+  "scripts": {
+    "build": "rsbuild build",
+    "build:prod": "rsbuild build --env-mode production"
+  },
+  "dependencies": {
+    "@module-federation/rsbuild-plugin": "^2.5.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "rocketride": "workspace:*",
+    "shell": "file:../../.rocketride/shell/shell.tgz"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "~2.0.11",
+    "@rsbuild/plugin-react": "~2.0.1",
+    "typescript": "^5.3.0",
+    "@types/react": "~18.3.31",
+    "@types/react-dom": "~18.3.7"
+  }
+}

--- a/apps/nodes-ui/rsbuild.config.mts
+++ b/apps/nodes-ui/rsbuild.config.mts
@@ -1,0 +1,69 @@
+// =============================================================================
+// NODES-UI — Module Federation Remote (Node Catalog app)
+// =============================================================================
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
+const moduleId = (pkg.appManifest?.id ?? 'unknown').replace(/[^a-zA-Z0-9_$]/g, '_');
+
+export default defineConfig(() => {
+	return {
+		plugins: [
+			pluginReact(),
+			pluginModuleFederation({
+				name: moduleId,
+				filename: 'remoteEntry.js',
+				exposes: {
+					'./AppDescriptor': './src/AppDescriptor.ts',
+				},
+				dts: false,
+				// runtime: false — the host (the shell) provides the MF runtime;
+				// remotes don't embed their own copy, keeping remoteEntry.js
+				// stable across app-code-only rebuilds.
+				runtime: false,
+				// loaded-first: use the host's already-loaded shared instances instead of
+				// version-first's boot-time download of EVERY registered remoteEntry.js
+				// just to compare shared versions (everything here is singleton + co-deployed).
+				shareStrategy: 'loaded-first',
+				shared: {
+					// eager: true makes shared-scope negotiation synchronous on
+					// both host and remote, eliminating the async deadlock that
+					// hangs the browser when only one remote is recompiled.
+					react: { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					'react-dom': { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					// import: false — host always provides these, no fallback needed.
+					'shell': { singleton: true, requiredVersion: false, import: false },
+					'rocketride': { singleton: true, requiredVersion: false, import: false },
+				},
+			}),
+		],
+		resolve: {},
+		// CORS: explicitly allow any origin — the serving host isn't fixed, so no
+		// allowlist is possible; declaring it also stops the MF plugin injecting
+		// its own wildcard defaults (and warning about it).
+		server: { port: 3023, cors: { origin: '*' } },
+		source: {
+			entry: {
+				index: './src/index.ts',
+			},
+		},
+		output: {
+			distPath: {
+				root: path.join(process.env.ROCKETRIDE_BUILD_ROOT ?? '../../build', 'apps', 'nodes-ui'),
+			},
+			assetPrefix: 'auto',
+			cleanDistPath: true,
+			sourceMap: {
+				js: 'source-map',
+				css: true,
+			},
+		},
+	};
+});

--- a/apps/nodes-ui/scripts/tasks.js
+++ b/apps/nodes-ui/scripts/tasks.js
@@ -1,0 +1,35 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Nodes UI Build Module
+ *
+ * Node catalog — browse and install community nodes.
+ */
+const path = require('path');
+const { createAppModule } = require('../../../scripts/lib/appModule');
+
+module.exports = createAppModule({
+	name: 'nodes-ui',
+	description: 'Node Catalog Application',
+	appRoot: path.join(__dirname, '..'),
+});

--- a/apps/nodes-ui/src/AppDescriptor.ts
+++ b/apps/nodes-ui/src/AppDescriptor.ts
@@ -1,0 +1,30 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+import React from 'react';
+import type { AppDescriptor } from 'shell';
+import { RocketRideMark } from 'shell';
+import NodesApp from './NodesApp';
+
+/**
+ * AppDescriptor for the Node Catalog app.
+ *
+ * The storefront for nodes the community publishes: browse what is available,
+ * see who wrote it and what it costs, and install one into your own workspace,
+ * where the engine picks it up on the next run.
+ */
+const NODES_APP: AppDescriptor = {
+	id: 'rocketride.nodes',
+	name: 'Node Catalog',
+	branding: {
+		appName: 'Node Catalog',
+		// Fills the shell's sized icon wrapper, as the other apps do.
+		iconDark: React.createElement(RocketRideMark, { bodyColor: '#E0DDF0', style: { width: '100%', height: '100%' } }),
+		iconLight: React.createElement(RocketRideMark, { bodyColor: '#1E1A34', style: { width: '100%', height: '100%' } }),
+	},
+	app: NodesApp,
+};
+
+export default NODES_APP;

--- a/apps/nodes-ui/src/NodesApp.tsx
+++ b/apps/nodes-ui/src/NodesApp.tsx
@@ -1,0 +1,95 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// NODE CATALOG APP — the storefront, wired to the engine.
+//
+// The screen itself is host-agnostic and lives in shared; this file is the
+// adapter: it turns INodeCatalogHost into `rrext_node_catalog` calls and runs
+// a chosen node through the same staged install the sidebar uses, so a node
+// taken from the catalog and a capsule imported by hand arrive the same way.
+//
+// Installed nodes land in the caller's OWN store, which is what makes them
+// materialize into the engine on the next run — no flags, no server restart.
+// =============================================================================
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useShellConnection, type ShellAppProps } from 'shell';
+
+import { installCapsule } from 'shared/modules/sidebar/capsuleInstall';
+import { NodeCatalogView } from 'shared/modules/nodecatalog/NodeCatalogView';
+import type { INodeCatalogEntry, INodeCatalogHost } from 'shared/modules/nodecatalog/types';
+
+/**
+ * The Node Catalog app — client area.
+ *
+ * Takes the connected client from the shell, like every other app here; with
+ * no connection the catalog simply reads as empty.
+ */
+const NodesApp: React.FC<ShellAppProps> = (_props) => {
+	const { client } = useShellConnection();
+	const [installed, setInstalled] = useState<string[]>([]);
+
+	/** Names already in this user's store, so a card can say "installed". */
+	const refreshInstalled = useCallback(async () => {
+		if (!client) return;
+		try {
+			const res = await client.call<{ nodes?: string[] }>('rrext_node_dev', { subcommand: 'list' });
+			setInstalled(res?.nodes ?? []);
+		} catch {
+			setInstalled([]);
+		}
+	}, [client]);
+
+	useEffect(() => {
+		void refreshInstalled();
+	}, [refreshInstalled]);
+
+	const host: INodeCatalogHost = {
+		list: async (search?: string) => {
+			if (!client) return [];
+			const res = await client.call<{ nodes?: INodeCatalogEntry[] }>('rrext_node_catalog', {
+				subcommand: 'list',
+				search: search ?? '',
+			});
+			return res?.nodes ?? [];
+		},
+
+		get: async (name: string) => {
+			if (!client) throw new Error('not connected');
+			return client.call('rrext_node_catalog', { subcommand: 'get', name });
+		},
+
+		install: async (entry: INodeCatalogEntry) => {
+			if (!client) throw new Error('not connected');
+			// Fetch, then hand the bytes to the same staged install the sidebar
+			// uses: inspected and reported before anything is written.
+			const fetched = await client.call<{ capsule: string }>('rrext_node_catalog', {
+				subcommand: 'fetch',
+				name: entry.name,
+			});
+			const result = await installCapsule(
+				{
+					inspect: (capsule) => client.call('rrext_node_dev', { subcommand: 'inspect', capsule }),
+					install: (capsule) => client.call('rrext_node_dev', { subcommand: 'install', capsule }),
+					// Taking a node from the catalog IS the consent; the report is
+					// still produced, and a capsule that would not load is refused.
+					confirm: async () => true,
+				},
+				fetched.capsule,
+			);
+			if (result.outcome !== 'installed') {
+				throw new Error(result.error || `install ${result.outcome}`);
+			}
+			await refreshInstalled();
+		},
+
+		installed,
+	};
+
+	return <NodeCatalogView host={host} />;
+};
+
+export default NodesApp;

--- a/apps/nodes-ui/src/index.ts
+++ b/apps/nodes-ui/src/index.ts
@@ -1,0 +1,1 @@
+import('./AppDescriptor');

--- a/apps/nodes-ui/tsconfig.json
+++ b/apps/nodes-ui/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "paths": {
+      "shared/*": [
+        "../shared/src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/apps/rocket-ui/src/providers/SidebarProvider.tsx
+++ b/apps/rocket-ui/src/providers/SidebarProvider.tsx
@@ -38,7 +38,7 @@ import { getDocs } from '../docs';
 import { SidebarView } from 'shared/modules/sidebar/SidebarView';
 import { BxExport, useSidebarCollapsed } from 'shell';
 import { foldTaskEvent } from 'shared/modules/sidebar/taskFold';
-import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, SidebarMode } from 'shared/modules/sidebar/types';
+import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, SidebarMode, NodeListItem } from 'shared/modules/sidebar/types';
 import type { TaskLifecycleEvent } from 'shared/modules/sidebar/taskFold';
 import { loadProject, listProjectDir, isPipelineFile, pipelineExtension } from '../utils/projectStore';
 import { downloadJson } from '../utils/downloadFile';
@@ -455,6 +455,83 @@ const SidebarProvider: React.FC = () => {
 		[client]
 	);
 
+	// --- Node Builder (Nodes tab) --------------------------------------------
+
+	const [installedNodes, setInstalledNodes] = useState<NodeListItem[]>([]);
+
+	/** Reload the installed custom-node list from the engine (rrext_node_dev list). */
+	const refreshNodes = useCallback(async () => {
+		if (!client || !isConnected) {
+			setInstalledNodes([]);
+			return;
+		}
+		try {
+			const res: any = await client.call('rrext_node_dev', { subcommand: 'list' });
+			const names: string[] = res?.nodes ?? [];
+			setInstalledNodes(names.map((name) => ({ name, protocol: `${name}://` })));
+		} catch {
+			setInstalledNodes([]);
+		}
+	}, [client, isConnected]);
+
+	useEffect(() => {
+		refreshNodes();
+	}, [refreshNodes]);
+
+	/** Scaffold a new node and install it so it appears in the catalog at once. */
+	const handleNewNode = useCallback(async () => {
+		if (!client) return;
+		const name = window.prompt('New node name (lowercase, e.g. my_filter):')?.trim();
+		if (!name) return;
+		const kind = window.confirm('Source node? (OK = source, Cancel = filter)') ? 'source' : 'filter';
+		try {
+			const scaffolded: any = await client.call('rrext_node_dev', { subcommand: 'scaffold', name, kind });
+			const packed: any = await client.call('rrext_node_dev', { subcommand: 'pack', name, files: scaffolded.files });
+			await client.call('rrext_node_dev', { subcommand: 'install', capsule: packed.capsule });
+			await refreshNodes();
+		} catch (err) {
+			setActionError(`Could not create node: ${err instanceof Error ? err.message : err}`);
+		}
+	}, [client, refreshNodes]);
+
+	/** Pick a .rrc capsule and install it. */
+	const handleImportCapsule = useCallback(() => {
+		if (!client) return;
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = '.rrc';
+		input.onchange = async () => {
+			const file = input.files?.[0];
+			if (!file) return;
+			try {
+				const bytes = new Uint8Array(await file.arrayBuffer());
+				let binary = '';
+				for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+				await client.call('rrext_node_dev', { subcommand: 'install', capsule: btoa(binary) });
+				await refreshNodes();
+			} catch (err) {
+				setActionError(`Could not import capsule: ${err instanceof Error ? err.message : err}`);
+			}
+		};
+		input.click();
+	}, [client, refreshNodes]);
+
+	/** Uninstall a custom node after confirmation. */
+	const handleUninstallNode = useCallback(
+		async (name: string) => {
+			if (!client) return;
+			const ok = await showConfirm('Uninstall node', `Remove custom node "${name}"?`, 'Uninstall');
+			if (!ok) return;
+			try {
+				await client.call('rrext_node_dev', { subcommand: 'uninstall', name });
+				await refreshNodes();
+			} catch (err) {
+				setActionError(`Could not uninstall node: ${err instanceof Error ? err.message : err}`);
+			}
+		},
+		[client, refreshNodes, showConfirm]
+	);
+
 	// --- Render ----------------------------------------------------------------
 
 	// Mode tab selection (Pipelines | Nodes on this host — no app builder).
@@ -471,7 +548,7 @@ const SidebarProvider: React.FC = () => {
 	return (
 		<>
 			<SidebarCollapsedGate>
-				<SidebarView connection={connection} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} activeFilePath={activeFilePath} onNavigate={handleNavigate} onOpenFile={handleOpenFile} onFileManage={handleFileManage} fileActions={[{ id: 'export', label: 'Export', icon: <BxExport size={16} />, onSelect: handleExportPipeline }]} onSourceAction={handleSourceAction} onOpenUnknownTask={handleOpenUnknownTask} onRefresh={refresh} showModeStrip sidebarMode={sidebarMode} onSidebarModeChange={setSidebarMode} />
+				<SidebarView connection={connection} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} activeFilePath={activeFilePath} onNavigate={handleNavigate} onOpenFile={handleOpenFile} onFileManage={handleFileManage} fileActions={[{ id: 'export', label: 'Export', icon: <BxExport size={16} />, onSelect: handleExportPipeline }]} onSourceAction={handleSourceAction} onOpenUnknownTask={handleOpenUnknownTask} onRefresh={refresh} nodeBuilder={{ nodes: installedNodes, onNewNode: handleNewNode, onImportCapsule: handleImportCapsule, onUninstall: handleUninstallNode }} showModeStrip sidebarMode={sidebarMode} onSidebarModeChange={setSidebarMode} />
 			</SidebarCollapsedGate>
 			{confirmState && <ConfirmDialog title={confirmState.title} message={confirmState.message} confirmLabel={confirmState.confirmLabel} cancelLabel="Cancel" onConfirm={() => handleConfirmResult(true)} onCancel={() => handleConfirmResult(false)} />}
 			{actionError && <ConfirmDialog title="Pipeline Error" message={actionError} confirmLabel="OK" onConfirm={() => setActionError(null)} onCancel={() => setActionError(null)} />}

--- a/apps/shared/src/modules/nodecatalog/NodeCatalogView.tsx
+++ b/apps/shared/src/modules/nodecatalog/NodeCatalogView.tsx
@@ -1,0 +1,283 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// NODE CATALOG — the storefront for community nodes.
+//
+// Reads like the app store on purpose: a search bar, category filters, a grid
+// of cards, a detail panel. What it says is different, because the thing being
+// offered is different — an app is opened, a node is INSTALLED into your own
+// workspace and then appears in the pipeline palette. Every string here leans
+// on that distinction rather than leaving it implied.
+//
+// Host-agnostic: the surrounding app supplies the engine calls through
+// INodeCatalogHost, so this renders the same wherever it is mounted.
+// =============================================================================
+
+import React, { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+
+import type { ICapsuleStage } from '../sidebar/capsuleInstall';
+import { categoryLabel, priceLabel, type INodeCatalogEntry, type INodeCatalogHost } from './types';
+
+// =============================================================================
+// STYLES — the app store's vocabulary: surface cards, a hairline border, one
+// accent. Values come from the shared theme tokens so both stores shift
+// together when the theme does.
+// =============================================================================
+
+const S = {
+	page: { display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', background: 'var(--rr-bg-default)' } as CSSProperties,
+	header: { padding: '20px 24px 12px', borderBottom: '1px solid var(--rr-border)', flexShrink: 0 } as CSSProperties,
+	title: { fontSize: 22, fontWeight: 700, color: 'var(--rr-text-primary)', margin: 0 } as CSSProperties,
+	subtitle: { fontSize: 13, color: 'var(--rr-text-secondary)', marginTop: 4 } as CSSProperties,
+	controls: { display: 'flex', gap: 8, alignItems: 'center', marginTop: 14, flexWrap: 'wrap' } as CSSProperties,
+	search: {
+		flex: '1 1 220px',
+		minWidth: 160,
+		padding: '7px 10px',
+		fontSize: 13,
+		color: 'var(--rr-text-primary)',
+		background: 'var(--rr-bg-paper)',
+		border: '1px solid var(--rr-border)',
+		borderRadius: 6,
+		outline: 'none',
+	} as CSSProperties,
+	chip: (active: boolean): CSSProperties => ({
+		padding: '5px 11px',
+		fontSize: 12,
+		borderRadius: 999,
+		cursor: 'pointer',
+		border: `1px solid ${active ? 'var(--rr-brand)' : 'var(--rr-border)'}`,
+		color: active ? 'var(--rr-brand)' : 'var(--rr-text-secondary)',
+		background: 'transparent',
+		whiteSpace: 'nowrap',
+	}),
+	body: { flex: 1, overflow: 'auto', padding: 24 } as CSSProperties,
+	grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: 14 } as CSSProperties,
+	card: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: 10,
+		padding: 14,
+		background: 'var(--rr-bg-paper)',
+		border: '1px solid var(--rr-border)',
+		borderRadius: 10,
+		cursor: 'pointer',
+	} as CSSProperties,
+	cardHead: { display: 'flex', gap: 10, alignItems: 'flex-start' } as CSSProperties,
+	iconChip: {
+		width: 38,
+		height: 38,
+		flexShrink: 0,
+		borderRadius: 8,
+		background: 'var(--rr-bg-default)',
+		border: '1px solid var(--rr-border)',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		overflow: 'hidden',
+	} as CSSProperties,
+	cardTitle: { fontSize: 14, fontWeight: 600, color: 'var(--rr-text-primary)', lineHeight: 1.3 } as CSSProperties,
+	cardMeta: { fontSize: 11, color: 'var(--rr-text-secondary)', marginTop: 2 } as CSSProperties,
+	cardBody: { fontSize: 12, color: 'var(--rr-text-secondary)', lineHeight: 1.5, flex: 1 } as CSSProperties,
+	cardFoot: { display: 'flex', alignItems: 'center', gap: 8 } as CSSProperties,
+	price: { fontSize: 12, fontWeight: 600, color: 'var(--rr-text-primary)' } as CSSProperties,
+	badge: (tone: 'ok' | 'muted'): CSSProperties => ({
+		fontSize: 10,
+		fontWeight: 600,
+		textTransform: 'uppercase',
+		letterSpacing: '0.04em',
+		padding: '2px 7px',
+		borderRadius: 4,
+		color: tone === 'ok' ? 'var(--rr-chart-green)' : 'var(--rr-text-secondary)',
+		border: `1px solid ${tone === 'ok' ? 'var(--rr-chart-green)' : 'var(--rr-border)'}`,
+	}),
+	button: (disabled: boolean): CSSProperties => ({
+		marginLeft: 'auto',
+		padding: '5px 14px',
+		fontSize: 12,
+		fontWeight: 600,
+		borderRadius: 6,
+		cursor: disabled ? 'default' : 'pointer',
+		border: 'none',
+		color: disabled ? 'var(--rr-text-secondary)' : '#fff',
+		background: disabled ? 'var(--rr-bg-default)' : 'var(--rr-brand)',
+	}),
+	empty: { padding: '40px 0', textAlign: 'center', color: 'var(--rr-text-secondary)', fontSize: 13 } as CSSProperties,
+	stageList: { display: 'flex', flexDirection: 'column', gap: 4, marginTop: 10 } as CSSProperties,
+	stageRow: { display: 'flex', gap: 8, alignItems: 'center', fontSize: 12 } as CSSProperties,
+};
+
+/** One glyph per stage state, so progress reads without colour alone. */
+const STAGE_MARK: Record<string, string> = { pending: '·', active: '…', done: '✓', failed: '✕', skipped: '–' };
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export interface INodeCatalogViewProps {
+	host: INodeCatalogHost;
+}
+
+/**
+ * The catalog screen: search, filter, and install a published node.
+ *
+ * @param host - engine calls and the install action, supplied by the app.
+ */
+export const NodeCatalogView: React.FC<INodeCatalogViewProps> = ({ host }) => {
+	const [entries, setEntries] = useState<INodeCatalogEntry[]>([]);
+	const [search, setSearch] = useState('');
+	const [category, setCategory] = useState('');
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState('');
+	const [busy, setBusy] = useState<string | null>(null);
+	const [stages, setStages] = useState<ICapsuleStage[]>([]);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		try {
+			setEntries(await host.list());
+			setError('');
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setLoading(false);
+		}
+	}, [host]);
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+
+	// Category chips come from what is actually published, not a fixed list —
+	// a catalog of user content cannot know its categories in advance.
+	const categories = useMemo(() => {
+		const seen = new Set<string>();
+		for (const entry of entries) for (const c of entry.categories || []) seen.add(c);
+		return Array.from(seen).sort();
+	}, [entries]);
+
+	const visible = useMemo(() => {
+		const needle = search.trim().toLowerCase();
+		return entries.filter((entry) => {
+			if (category && !(entry.categories || []).includes(category)) return false;
+			if (!needle) return true;
+			return `${entry.title} ${entry.name} ${entry.description}`.toLowerCase().includes(needle);
+		});
+	}, [entries, search, category]);
+
+	const install = useCallback(
+		async (entry: INodeCatalogEntry) => {
+			setBusy(entry.name);
+			setStages([]);
+			try {
+				await host.install(entry);
+				await refresh();
+			} catch (err) {
+				setError(err instanceof Error ? err.message : String(err));
+			} finally {
+				setBusy(null);
+			}
+		},
+		[host, refresh],
+	);
+
+	return (
+		<div style={S.page}>
+			<div style={S.header}>
+				<h1 style={S.title}>Node Catalog</h1>
+				{/* Says what this is and what pressing the button does — an app is
+				    opened, a node lands in your workspace and runs your pipelines. */}
+				<div style={S.subtitle}>Nodes published by the community. Installing one adds it to your workspace and to the pipeline palette.</div>
+				<div style={S.controls}>
+					<input style={S.search} placeholder="Search nodes" value={search} onChange={(e) => setSearch(e.target.value)} aria-label="Search nodes" />
+					<button type="button" style={S.chip(category === '')} onClick={() => setCategory('')}>
+						All
+					</button>
+					{categories.map((key) => (
+						<button key={key} type="button" style={S.chip(category === key)} onClick={() => setCategory(key)}>
+							{categoryLabel(key)}
+						</button>
+					))}
+				</div>
+			</div>
+
+			<div style={S.body}>
+				{error && <div style={{ ...S.empty, color: 'var(--rr-error)' }}>{error}</div>}
+				{loading && <div style={S.empty}>Loading the catalog…</div>}
+				{!loading && visible.length === 0 && (
+					<div style={S.empty}>{entries.length === 0 ? 'No nodes have been published yet.' : 'No node matches that search.'}</div>
+				)}
+
+				<div style={S.grid}>
+					{visible.map((entry) => {
+						const installed = host.installed.includes(entry.name);
+						const paid = entry.priceCents > 0;
+						return (
+							<div key={entry.name} style={S.card}>
+								<div style={S.cardHead}>
+									<div style={S.iconChip}>
+										{entry.icon ? (
+											<span style={{ width: 24, height: 24 }} dangerouslySetInnerHTML={{ __html: entry.icon }} />
+										) : (
+											<span style={{ fontSize: 13, color: 'var(--rr-text-secondary)' }}>{entry.title.slice(0, 2).toUpperCase()}</span>
+										)}
+									</div>
+									<div style={{ minWidth: 0 }}>
+										<div style={S.cardTitle}>{entry.title}</div>
+										<div style={S.cardMeta}>
+											{entry.author?.name || 'Unknown'}
+											{entry.versionLabel ? ` · v${entry.versionLabel}` : ''}
+										</div>
+									</div>
+								</div>
+
+								<div style={S.cardBody}>{entry.description || 'No description.'}</div>
+
+								<div style={S.cardFoot}>
+									<span style={S.price}>{priceLabel(entry.priceCents)}</span>
+									{installed && <span style={S.badge('ok')}>installed</span>}
+									{(entry.categories || []).slice(0, 1).map((c) => (
+										<span key={c} style={S.badge('muted')}>
+											{categoryLabel(c)}
+										</span>
+									))}
+									<button
+										type="button"
+										// Paid nodes are listed but not sold yet: the registry records
+										// the asking price, and charging is not built.
+										disabled={paid || installed || busy === entry.name}
+										title={paid ? 'Paid nodes are not purchasable yet' : installed ? 'Already in your workspace' : `Install ${entry.title}`}
+										style={S.button(paid || installed || busy === entry.name)}
+										onClick={() => void install(entry)}
+									>
+										{busy === entry.name ? 'Installing…' : installed ? 'Installed' : paid ? 'Coming soon' : 'Install'}
+									</button>
+								</div>
+
+								{/* The staged install, reported as it happens rather than a spinner. */}
+								{busy === entry.name && stages.length > 0 && (
+									<div style={S.stageList}>
+										{stages.map((stage) => (
+											<div key={stage.id} style={S.stageRow}>
+												<span style={{ width: 12, color: stage.state === 'failed' ? 'var(--rr-error)' : 'var(--rr-text-secondary)' }}>
+													{STAGE_MARK[stage.state] ?? '·'}
+												</span>
+												<span style={{ color: 'var(--rr-text-secondary)' }}>{stage.label}</span>
+												{stage.detail && <span style={{ color: 'var(--rr-text-secondary)', opacity: 0.8 }}>— {stage.detail}</span>}
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default NodeCatalogView;

--- a/apps/shared/src/modules/nodecatalog/nodeCatalog.test.ts
+++ b/apps/shared/src/modules/nodecatalog/nodeCatalog.test.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// Unit tests: what the catalog card prints.
+//
+// Small surface, but it is the part a person reads before deciding to run
+// somebody else's code, so the free/paid distinction and the category label
+// are pinned rather than eyeballed.
+//
+// Run via `shared:test` (node --import tsx --test).
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { categoryLabel, priceLabel } from './types';
+
+test('free is stated, not left blank', () => {
+	assert.equal(priceLabel(0), 'Free');
+});
+
+test('a whole-dollar price drops the cents', () => {
+	assert.equal(priceLabel(1900), '$19');
+});
+
+test('a price with cents keeps them', () => {
+	assert.equal(priceLabel(1950), '$19.50');
+	assert.equal(priceLabel(99), '$0.99');
+});
+
+test('category keys read as titles, matching the app store', () => {
+	assert.equal(categoryLabel('source'), 'Source');
+	assert.equal(categoryLabel('llm'), 'Llm');
+	assert.equal(categoryLabel('vector_store'), 'Vector store');
+	assert.equal(categoryLabel(''), 'Other');
+});

--- a/apps/shared/src/modules/nodecatalog/types.ts
+++ b/apps/shared/src/modules/nodecatalog/types.ts
@@ -1,0 +1,78 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// Node catalog — the shapes the engine hands back and the host must supply.
+//
+// Deliberately the same anatomy as an app store entry (title, description,
+// publisher, categories, icon, price), because the catalog is the app store's
+// sibling and should read like it. What differs is what an entry *is*: an app
+// is opened, a node is installed into your own workspace and then appears in
+// the pipeline palette.
+// =============================================================================
+
+/** One node as the catalog lists it — the card's data. */
+export interface INodeCatalogEntry {
+	/** Node name; also its frozen protocol id. */
+	name: string;
+	/** Display title, from the node's own services.json. */
+	title: string;
+	description: string;
+	/** From the node's classType — the store category. */
+	categories: string[];
+	/** Inline SVG the node ships, or '' when it has none. */
+	icon: string;
+	author: { id?: string; name?: string; email?: string };
+	/** 0 is free. Recorded by the registry; charging is the billing layer's job. */
+	priceCents: number;
+	state: 'published' | 'removed' | string;
+	/** Latest version number, and the author's label for it. */
+	latest?: number;
+	versionLabel?: string;
+	sizeBytes?: number;
+	publishedAt?: number;
+}
+
+/** The detail view adds the version history. */
+export interface INodeCatalogDetail extends INodeCatalogEntry {
+	versions?: {
+		version: number;
+		label?: string;
+		sha256: string;
+		sizeBytes?: number;
+		publishedAt?: number;
+		publishedBy?: { name?: string };
+	}[];
+}
+
+/** What the host wires up: the engine calls and the install action. */
+export interface INodeCatalogHost {
+	/** `rrext_node_catalog list`. */
+	list: (search?: string) => Promise<INodeCatalogEntry[]>;
+	/** `rrext_node_catalog get`. */
+	get: (name: string) => Promise<INodeCatalogDetail>;
+	/**
+	 * Install a catalog node into this user's own store.
+	 *
+	 * Fetches the capsule and runs it through the staged install, so the caller
+	 * sees the same reported sequence as importing a file by hand.
+	 */
+	install: (entry: INodeCatalogEntry) => Promise<void>;
+	/** Names already installed in this user's store, so cards can say so. */
+	installed: string[];
+}
+
+/** Free, or a price the card can print. */
+export function priceLabel(priceCents: number): string {
+	if (!priceCents) return 'Free';
+	const units = priceCents / 100;
+	return units % 1 === 0 ? `$${units}` : `$${units.toFixed(2)}`;
+}
+
+/** Category key to the title a person reads, matching the app store's casing. */
+export function categoryLabel(key: string): string {
+	if (!key) return 'Other';
+	return key.charAt(0).toUpperCase() + key.slice(1).replace(/[_-]+/g, ' ');
+}

--- a/apps/shared/src/modules/sidebar/SidebarView.tsx
+++ b/apps/shared/src/modules/sidebar/SidebarView.tsx
@@ -21,7 +21,7 @@
 
 import React, { useState, useCallback, CSSProperties } from 'react';
 import { commonStyles } from 'shell';
-import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt } from 'shell';
+import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt, BxDownload, BxTrash } from 'shell';
 import { SidebarMenu, TabControl, TabPanel } from 'shell';
 import { StatusBadge } from 'shell';
 import type { StatusVariant } from 'shell';
@@ -174,7 +174,7 @@ const PIPELINE_CONFIG: ExplorerConfig = {
  * Maps ISidebarViewProps (pipeline-specific) to IExplorerProps (generic).
  * The Explorer component handles all file tree rendering internally.
  */
-export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, headerSlot, onNavigate, onOpenFile, onFileManage, fileActions, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath, appBuilder, showModeStrip = false, sidebarMode = 'pipelines', onSidebarModeChange }) => {
+export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, headerSlot, onNavigate, onOpenFile, onFileManage, fileActions, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath, appBuilder, nodeBuilder, showModeStrip = false, sidebarMode = 'pipelines', onSidebarModeChange }) => {
 	const [hoveredRow, setHoveredRow] = useState<string | null>(null);
 	const [unknownExpanded, setUnknownExpanded] = useState(true);
 
@@ -184,7 +184,8 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 	// whenever the mode tabs render at all. A requested mode is only honored
 	// when its tab actually exists — anything else falls back to Pipelines.
 	const hasAppBuilder = Boolean(appBuilder);
-	const tabsVisible = hasAppBuilder || showModeStrip;
+	const hasNodeBuilder = Boolean(nodeBuilder);
+	const tabsVisible = hasAppBuilder || hasNodeBuilder || showModeStrip;
 	const mode = (sidebarMode === 'apps' && hasAppBuilder) || (sidebarMode === 'nodes' && tabsVisible) ? sidebarMode : 'pipelines';
 	// --- Static nav menus ----------------------------------------------------
 
@@ -361,8 +362,61 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 		</div>
 	) : null;
 
-	// Nodes tab body: node-builder placeholder until the real surface lands.
-	const nodesPanel = (
+	// Nodes tab body: the Node Builder surface (New node / Import capsule nav +
+	// the installed-node list with per-row uninstall) when the host wires it;
+	// the placeholder otherwise.
+	const nodesNavMenu: ViewMenu = {
+		entries: [
+			{ id: 'newNode', label: 'New node', icon: <BxPlus size={16} /> },
+			{ id: 'importCapsule', label: 'Import capsule', icon: <BxDownload size={16} /> },
+		],
+	};
+	const nodesPanel = nodeBuilder ? (
+		<div style={S.panelColumn}>
+			<div style={S.navSection}>
+				<SidebarMenu
+					menu={nodesNavMenu}
+					activeId=""
+					onSelect={(id) => {
+						if (id === 'newNode') nodeBuilder.onNewNode();
+						else if (id === 'importCapsule') nodeBuilder.onImportCapsule();
+					}}
+				/>
+			</div>
+			<div style={S.appsLabel}>Installed nodes</div>
+			<div style={S.appsList}>
+				{nodeBuilder.nodes.length === 0 && (
+					<div style={{ padding: '4px 10px', fontSize: 12, color: 'var(--rr-text-secondary)' }}>
+						No custom nodes — create one with New node or Import capsule.
+					</div>
+				)}
+				{nodeBuilder.nodes.map((n) => {
+					const rowKey = `node:${n.name}`;
+					return (
+						<div
+							key={n.name}
+							style={{ ...S.row, ...hoverBg(rowKey) }}
+							onMouseEnter={() => setHoveredRow(rowKey)}
+							onMouseLeave={() => setHoveredRow(null)}
+							title={n.protocol || n.name}
+						>
+							{/* Mirror the app/file row anatomy: 14px chevron slot + 16px glyph. */}
+							<span style={{ width: 14, flexShrink: 0 }} />
+							<BxGridAlt size={16} color="var(--rr-text-secondary)" />
+							<span style={S.rowName}>{n.name}</span>
+							<span style={S.spacer} />
+							<StatusBadge variant="info">catalog</StatusBadge>
+							{hoveredRow === rowKey && (
+								<button type="button" title={`Uninstall ${n.name}`} onClick={(e) => { e.stopPropagation(); nodeBuilder.onUninstall(n.name); }} style={S.actionBtn('var(--rr-text-secondary)')}>
+									<BxTrash size={16} />
+								</button>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	) : (
 		<div style={S.panelColumn}>
 			<div style={S.comingSoon}>Coming soon...</div>
 		</div>

--- a/apps/shared/src/modules/sidebar/capsuleInstall.test.ts
+++ b/apps/shared/src/modules/sidebar/capsuleInstall.test.ts
@@ -1,0 +1,190 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// Unit tests: the capsule install sequence both hosts render.
+//
+// What is pinned here is the observability itself — that every stage is
+// reported as it happens, that a failure says which stage failed and why, and
+// above all that nothing is installed before the contents have been shown and
+// accepted. A capsule is code the engine imports; "it silently did something"
+// is the outcome these tests exist to prevent.
+//
+// Run via `shared:test` (node --import tsx --test).
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { base64Bytes, formatBytes, initialStages, installCapsule, type ICapsuleReport } from './capsuleInstall';
+
+const CAPSULE = 'AAAAAAAAAAAAAAAA'; // 16 chars of base64 = 12 bytes
+
+function goodReport(over: Partial<ICapsuleReport> = {}): ICapsuleReport {
+	return {
+		name: 'demo_node',
+		protocol: 'demo_node://',
+		version: '0.0.0',
+		ok: true,
+		errors: [],
+		warnings: [],
+		sizeBytes: 2928,
+		totalBytes: 4096,
+		files: [
+			{ path: 'services.json', bytes: 700 },
+			{ path: 'IGlobal.py', bytes: 400 },
+		],
+		...over,
+	};
+}
+
+/** Records what happened, the way a host would to render it. */
+function harness(over: Partial<Parameters<typeof installCapsule>[0]> = {}) {
+	const installed: string[] = [];
+	const seen: string[][] = [];
+	const io = {
+		inspect: async () => goodReport(),
+		install: async (capsule: string) => {
+			installed.push(capsule);
+		},
+		confirm: async () => true,
+		onProgress: (stages: { id: string; state: string }[]) => {
+			seen.push(stages.map((s) => `${s.id}:${s.state}`));
+		},
+		...over,
+	};
+	return { io, installed, seen };
+}
+
+test('initialStages lists every stage as pending, in order', () => {
+	assert.deepEqual(
+		initialStages().map((s) => s.id),
+		['read', 'inspect', 'confirm', 'install'],
+	);
+	assert.ok(initialStages().every((s) => s.state === 'pending'));
+});
+
+test('a good capsule walks every stage and installs', async () => {
+	const { io, installed, seen } = harness();
+	const result = await installCapsule(io, CAPSULE);
+
+	assert.equal(result.outcome, 'installed');
+	assert.deepEqual(installed, [CAPSULE]);
+	assert.deepEqual(
+		result.stages.map((s) => `${s.id}:${s.state}`),
+		['read:done', 'inspect:done', 'confirm:done', 'install:done'],
+	);
+	// Every stage was announced as active before it was announced as done.
+	assert.ok(seen.some((snapshot) => snapshot.includes('inspect:active')));
+	assert.ok(seen.some((snapshot) => snapshot.includes('install:active')));
+	// The last stage carries something a person can read.
+	assert.match(result.stages[3]!.detail ?? '', /demo_node/);
+});
+
+test('nothing is installed until the report is accepted', async () => {
+	const order: string[] = [];
+	const { io, installed } = harness({
+		inspect: async () => {
+			order.push('inspect');
+			return goodReport();
+		},
+		confirm: async () => {
+			order.push('confirm');
+			return true;
+		},
+		install: async () => {
+			order.push('install');
+		},
+	});
+	await installCapsule(io, CAPSULE);
+
+	assert.deepEqual(order, ['inspect', 'confirm', 'install']);
+	assert.equal(installed.length, 0, 'install was recorded through the order list, not the harness');
+});
+
+test('declining the report installs nothing', async () => {
+	const { io, installed } = harness({ confirm: async () => false });
+	const result = await installCapsule(io, CAPSULE);
+
+	assert.equal(result.outcome, 'cancelled');
+	assert.deepEqual(installed, []);
+	assert.equal(result.stages.find((s) => s.id === 'confirm')!.state, 'skipped');
+	assert.equal(result.stages.find((s) => s.id === 'install')!.state, 'skipped');
+});
+
+test('a capsule the engine could not load is refused before any confirmation', async () => {
+	let asked = false;
+	const { io, installed } = harness({
+		inspect: async () => goodReport({ ok: false, errors: ['services.json is missing'] }),
+		confirm: async () => {
+			asked = true;
+			return true;
+		},
+	});
+	const result = await installCapsule(io, CAPSULE);
+
+	assert.equal(result.outcome, 'rejected');
+	assert.equal(asked, false, 'a node that cannot load is not offered for confirmation');
+	assert.deepEqual(installed, []);
+	const inspect = result.stages.find((s) => s.id === 'inspect')!;
+	assert.equal(inspect.state, 'failed');
+	assert.match(inspect.detail ?? '', /services\.json is missing/);
+});
+
+test('an inspect failure names the stage and the reason', async () => {
+	const { io, installed } = harness({
+		inspect: async () => {
+			throw new Error('unsafe path in capsule');
+		},
+	});
+	const result = await installCapsule(io, CAPSULE);
+
+	assert.equal(result.outcome, 'failed');
+	assert.equal(result.error, 'unsafe path in capsule');
+	assert.equal(result.stages.find((s) => s.id === 'inspect')!.state, 'failed');
+	assert.deepEqual(installed, []);
+});
+
+test('an install failure is reported against the install stage', async () => {
+	const { io } = harness({
+		install: async () => {
+			throw new Error('store is read-only');
+		},
+	});
+	const result = await installCapsule(io, CAPSULE);
+
+	assert.equal(result.outcome, 'failed');
+	assert.equal(result.stages.find((s) => s.id === 'install')!.state, 'failed');
+	assert.match(result.stages.find((s) => s.id === 'install')!.detail ?? '', /read-only/);
+	// The stages before it stay done, so the reader sees how far it got.
+	assert.equal(result.stages.find((s) => s.id === 'inspect')!.state, 'done');
+});
+
+test('an empty capsule fails at the first stage', async () => {
+	const { io, installed } = harness();
+	const result = await installCapsule(io, '');
+
+	assert.equal(result.outcome, 'failed');
+	assert.equal(result.stages[0]!.state, 'failed');
+	assert.deepEqual(installed, []);
+});
+
+test('progress is emitted on every change, never only at the end', async () => {
+	const { io, seen } = harness();
+	await installCapsule(io, CAPSULE);
+
+	// Four stages, each active then done, plus the final sweep.
+	assert.ok(seen.length >= 8, `expected a snapshot per transition, got ${seen.length}`);
+	// Snapshots are copies: mutating one must not change the next.
+	assert.notEqual(seen[0], seen[1]);
+});
+
+test('byte helpers read the way a person would write them', () => {
+	assert.equal(base64Bytes(CAPSULE), 12);
+	assert.equal(base64Bytes('AAA='), 2);
+	assert.equal(formatBytes(812), '812 B');
+	assert.equal(formatBytes(3300), '3.2 KB');
+	assert.equal(formatBytes(1.4 * 1024 * 1024), '1.4 MB');
+});

--- a/apps/shared/src/modules/sidebar/capsuleInstall.ts
+++ b/apps/shared/src/modules/sidebar/capsuleInstall.ts
@@ -1,0 +1,176 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// Installing a capsule, as a sequence the UI can show.
+//
+// A capsule is Python the engine will import, so the install is not one opaque
+// call: it is read, inspected, shown to a person, and only then written. Each
+// stage is reported as it happens, so a host can render what is going on and
+// say what failed when something does — rather than a spinner that ends in
+// silence either way.
+//
+// Host-agnostic on purpose: the caller supplies the two engine calls and the
+// confirmation, so the same sequence drives the web sidebar and the VS Code
+// one, and can be tested without either.
+// =============================================================================
+
+/** What `rrext_node_dev inspect` reports about a capsule. */
+export interface ICapsuleReport {
+	name: string;
+	protocol: string;
+	version?: string;
+	declares?: string[];
+	sizeBytes?: number;
+	totalBytes?: number;
+	files?: { path: string; bytes: number }[];
+	binaryFiles?: string[];
+	/** False when the node would not register — the engine could not load it. */
+	ok?: boolean;
+	errors?: string[];
+	warnings?: string[];
+}
+
+/** The stages an install passes through, in order. */
+export type CapsuleStageId = 'read' | 'inspect' | 'confirm' | 'install';
+
+export type CapsuleStageState = 'pending' | 'active' | 'done' | 'failed' | 'skipped';
+
+export interface ICapsuleStage {
+	id: CapsuleStageId;
+	label: string;
+	state: CapsuleStageState;
+	/** Populated on failure, or with a short summary on success. */
+	detail?: string;
+}
+
+export interface ICapsuleInstallResult {
+	/** 'installed' | 'cancelled' | 'rejected' (would not load) | 'failed'. */
+	outcome: 'installed' | 'cancelled' | 'rejected' | 'failed';
+	report?: ICapsuleReport;
+	error?: string;
+	stages: ICapsuleStage[];
+}
+
+export interface ICapsuleInstallIO {
+	/** Calls `rrext_node_dev inspect` — must not write anything. */
+	inspect: (capsuleBase64: string) => Promise<ICapsuleReport>;
+	/** Calls `rrext_node_dev install`. */
+	install: (capsuleBase64: string) => Promise<unknown>;
+	/** Shows the report and returns whether the person accepted it. */
+	confirm: (report: ICapsuleReport) => Promise<boolean>;
+	/** Called after every stage change so the host can re-render. */
+	onProgress?: (stages: ICapsuleStage[]) => void;
+}
+
+const STAGE_LABELS: Record<CapsuleStageId, string> = {
+	read: 'Reading capsule',
+	inspect: 'Checking contents',
+	confirm: 'Awaiting confirmation',
+	install: 'Installing',
+};
+
+const STAGE_ORDER: CapsuleStageId[] = ['read', 'inspect', 'confirm', 'install'];
+
+/** A fresh stage list, everything pending. */
+export function initialStages(): ICapsuleStage[] {
+	return STAGE_ORDER.map((id) => ({ id, label: STAGE_LABELS[id], state: 'pending' as CapsuleStageState }));
+}
+
+/**
+ * Read, inspect, confirm and install a capsule, reporting each stage.
+ *
+ * Nothing is written until the report has been shown and accepted, and a
+ * capsule the engine could not load is refused outright — installing one only
+ * leaves a node in the store that never registers.
+ *
+ * @param io - the engine calls, the confirmation, and the progress sink.
+ * @param capsuleBase64 - the `.rrc` bytes, base64-encoded.
+ * @returns the outcome, the report when one was obtained, and the final stages.
+ */
+export async function installCapsule(io: ICapsuleInstallIO, capsuleBase64: string): Promise<ICapsuleInstallResult> {
+	const stages = initialStages();
+	const at = (id: CapsuleStageId) => stages[STAGE_ORDER.indexOf(id)]!;
+	const emit = () => io.onProgress?.(stages.map((stage) => ({ ...stage })));
+	const set = (id: CapsuleStageId, state: CapsuleStageState, detail?: string) => {
+		const stage = at(id);
+		stage.state = state;
+		if (detail !== undefined) stage.detail = detail;
+		emit();
+	};
+	const finish = (outcome: ICapsuleInstallResult['outcome'], extra: Partial<ICapsuleInstallResult> = {}) => {
+		for (const stage of stages) if (stage.state === 'pending') stage.state = 'skipped';
+		emit();
+		return { outcome, stages: stages.map((stage) => ({ ...stage })), ...extra };
+	};
+
+	set('read', 'active');
+	if (!capsuleBase64) {
+		set('read', 'failed', 'no capsule was provided');
+		return finish('failed', { error: 'no capsule was provided' });
+	}
+	set('read', 'done', `${formatBytes(base64Bytes(capsuleBase64))} read`);
+
+	set('inspect', 'active');
+	let report: ICapsuleReport;
+	try {
+		report = await io.inspect(capsuleBase64);
+	} catch (err) {
+		const message = errorText(err);
+		set('inspect', 'failed', message);
+		return finish('failed', { error: message });
+	}
+
+	const fileCount = report.files?.length ?? 0;
+	if (report.ok === false) {
+		const why = report.errors?.join('; ') || 'the node would not load';
+		set('inspect', 'failed', why);
+		return finish('rejected', { report, error: why });
+	}
+	set('inspect', 'done', `${report.name} · ${fileCount} file${fileCount === 1 ? '' : 's'}`);
+
+	set('confirm', 'active');
+	let accepted = false;
+	try {
+		accepted = await io.confirm(report);
+	} catch (err) {
+		const message = errorText(err);
+		set('confirm', 'failed', message);
+		return finish('failed', { report, error: message });
+	}
+	if (!accepted) {
+		set('confirm', 'skipped', 'cancelled');
+		return finish('cancelled', { report });
+	}
+	set('confirm', 'done');
+
+	set('install', 'active');
+	try {
+		await io.install(capsuleBase64);
+	} catch (err) {
+		const message = errorText(err);
+		set('install', 'failed', message);
+		return finish('failed', { report, error: message });
+	}
+	set('install', 'done', `${report.name} is in the palette`);
+	return finish('installed', { report });
+}
+
+/** Decoded size of a base64 payload, without decoding it. */
+export function base64Bytes(value: string): number {
+	const clean = value.replace(/=+$/, '');
+	return Math.floor((clean.length * 3) / 4);
+}
+
+/** Bytes as a short human string: 812 B, 3.2 KB, 1.4 MB. */
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function errorText(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/apps/shared/src/modules/sidebar/types.ts
+++ b/apps/shared/src/modules/sidebar/types.ts
@@ -115,6 +115,38 @@ export interface AppBuilderSidebar {
 }
 
 // =============================================================================
+// NODE BUILDER SIDEBAR (NODES)
+// =============================================================================
+
+/** One installed custom node row in the Nodes sidebar mode. */
+export interface NodeListItem {
+	/** Node id / protocol key (e.g. 'my_filter'). */
+	name: string;
+	/** Protocol (e.g. 'my_filter://'). */
+	protocol?: string;
+	/** Installed version, if known. */
+	version?: string;
+}
+
+/**
+ * Node Builder sidebar content. PRESENCE of this prop turns the Nodes tab from
+ * a placeholder into the real surface: a New node / Import capsule nav plus the
+ * installed-node list with per-row uninstall. Hosts wire the callbacks to the
+ * engine's `rrext_node_dev` verbs (scaffold/install/uninstall/list), so the same
+ * view drives the VS Code, web and Claude hosts identically.
+ */
+export interface NodeBuilderSidebar {
+	/** Installed custom nodes (`rrext_node_dev` list). */
+	nodes: NodeListItem[];
+	/** Create a new node (the scaffold → install flow). */
+	onNewNode: () => void;
+	/** Import a `.rrc` capsule (the file-pick → install flow). */
+	onImportCapsule: () => void;
+	/** Uninstall an installed node by name. */
+	onUninstall: (name: string) => void;
+}
+
+// =============================================================================
 // SIDEBAR MODE
 // =============================================================================
 
@@ -204,6 +236,12 @@ export interface ISidebarViewProps {
 	 * placeholder still rides along whenever the mode tabs render).
 	 */
 	appBuilder?: AppBuilderSidebar;
+	/**
+	 * Node Builder sidebar content — presence turns the Nodes tab into the real
+	 * surface (installed-node list + New node / Import capsule) and, like
+	 * appBuilder, makes the mode tabs render. Omitted → the Nodes placeholder.
+	 */
+	nodeBuilder?: NodeBuilderSidebar;
 	/**
 	 * Force the mode tabs visible without appBuilder — Pipelines plus the
 	 * Nodes placeholder (the web host: more modes will land on that strip).

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -173,6 +173,15 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 					case 'openApp':
 						vscode.commands.executeCommand('rocketride.app.open', message.appId);
 						break;
+					case 'node:new':
+						await this.newNode();
+						break;
+					case 'node:import':
+						await this.importCapsule();
+						break;
+					case 'node:uninstall':
+						await this.uninstallNode(message.name);
+						break;
 					case 'setSidebarMode':
 						// Session-scoped persistence: included in every full update
 						// so a reloaded webview restores the user's last mode.
@@ -297,6 +306,83 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 		}
 
 		return [...rows.values()];
+	}
+
+	// =========================================================================
+	// NODE BUILDER (installed custom nodes) — same rrext_node_dev the web host
+	// uses, so uploading a node from the extension lands in the caller's store
+	// and materializes per run, identical to rocket-ui.
+	// =========================================================================
+
+	/** List installed custom nodes from the engine and push them to the webview. */
+	private async refreshNodes(): Promise<void> {
+		if (!this._view) return;
+		let nodes: { name: string; protocol: string }[] = [];
+		try {
+			const client = this.connectionManager.getClient();
+			if (client && this.connectionManager.isConnected()) {
+				const res = (await client.call('rrext_node_dev', { subcommand: 'list' })) as { nodes?: string[] };
+				nodes = (res?.nodes ?? []).map((name) => ({ name, protocol: `${name}://` }));
+			}
+		} catch {
+			/* node dev unavailable (older engine) — leave the list empty */
+		}
+		this._view.webview.postMessage({ type: 'nodesUpdate', nodes });
+	}
+
+	/** New node: prompt for name + kind, then scaffold → pack → install. */
+	private async newNode(): Promise<void> {
+		const client = this.connectionManager.getClient();
+		if (!client) return;
+		const name = (
+			await vscode.window.showInputBox({
+				prompt: 'New node name (lowercase, e.g. my_filter)',
+				validateInput: (v) => (/^[a-z][a-z0-9_]{1,63}$/.test(v.trim()) ? undefined : 'lowercase letters, digits and underscores; start with a letter; 2-64 chars'),
+			})
+		)?.trim();
+		if (!name) return;
+		const kind = await vscode.window.showQuickPick(['filter', 'source'], { placeHolder: 'Node kind' });
+		if (!kind) return;
+		try {
+			const scaffolded = (await client.call('rrext_node_dev', { subcommand: 'scaffold', name, kind })) as { files: Record<string, string> };
+			const packed = (await client.call('rrext_node_dev', { subcommand: 'pack', name, files: scaffolded.files })) as { capsule: string };
+			await client.call('rrext_node_dev', { subcommand: 'install', capsule: packed.capsule });
+			await this.refreshNodes();
+			vscode.window.showInformationMessage(`Installed custom node "${name}".`);
+		} catch (err) {
+			vscode.window.showErrorMessage(`Could not create node: ${err instanceof Error ? err.message : err}`);
+		}
+	}
+
+	/** Import: open a .rrc file dialog, then install the capsule. */
+	private async importCapsule(): Promise<void> {
+		const client = this.connectionManager.getClient();
+		if (!client) return;
+		const picked = await vscode.window.showOpenDialog({ canSelectMany: false, filters: { 'Node capsule': ['rrc'] }, openLabel: 'Import' });
+		if (!picked?.length) return;
+		try {
+			const bytes = await vscode.workspace.fs.readFile(picked[0]!);
+			const capsule = Buffer.from(bytes).toString('base64');
+			await client.call('rrext_node_dev', { subcommand: 'install', capsule });
+			await this.refreshNodes();
+			vscode.window.showInformationMessage('Imported node capsule.');
+		} catch (err) {
+			vscode.window.showErrorMessage(`Could not import capsule: ${err instanceof Error ? err.message : err}`);
+		}
+	}
+
+	/** Uninstall an installed node after confirmation. */
+	private async uninstallNode(name: string): Promise<void> {
+		const client = this.connectionManager.getClient();
+		if (!client) return;
+		const ok = await vscode.window.showWarningMessage(`Remove custom node "${name}"?`, { modal: true }, 'Uninstall');
+		if (ok !== 'Uninstall') return;
+		try {
+			await client.call('rrext_node_dev', { subcommand: 'uninstall', name });
+			await this.refreshNodes();
+		} catch (err) {
+			vscode.window.showErrorMessage(`Could not uninstall node: ${err instanceof Error ? err.message : err}`);
+		}
 	}
 
 	/** Handles a newly created .pipe file — assigns a project_id if missing. */
@@ -562,6 +648,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 				sidebarMode: this.sidebarMode,
 			},
 		});
+
+		// Refresh the installed-node list out-of-band (never awaits the RPC).
+		void this.refreshNodes();
 	}
 
 	/** Sends only updated entries. */

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -32,7 +32,7 @@ import { BxUser, BxCog, BxExport, BxLock, BxRocket } from 'shell';
 import { foldTaskEvent } from 'shared/modules/sidebar/taskFold';
 import { SidebarFooter } from 'shell';
 import type { SidebarFooterMenuItem } from 'shell';
-import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, AppListItem, SidebarMode } from 'shared/modules/sidebar/types';
+import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, AppListItem, SidebarMode, NodeListItem } from 'shared/modules/sidebar/types';
 import { useMessaging } from '../hooks/useMessaging';
 
 // =============================================================================
@@ -56,7 +56,7 @@ interface TaskEventBody {
 	tasks?: { id: string; name: string; projectId: string; source: string; runKind?: string }[];
 }
 
-type OutgoingMessage = { type: 'view:ready' } | { type: 'connect' } | { type: 'disconnect' } | { type: 'command'; command: string; args?: unknown[] } | { type: 'openFile'; fsPath: string } | { type: 'runPipeline'; fsPath: string; sourceId?: string } | { type: 'stopPipeline'; projectId: string; sourceId: string } | { type: 'refresh' } | { type: 'openUnknownTask'; projectId: string; sourceId: string; displayName: string } | { type: 'setDevelopmentMode'; mode: string } | { type: 'setDeployTargetMode'; mode: string | null } | { type: 'cloudSignIn' } | { type: 'openApp'; appId: string } | { type: 'setSidebarMode'; mode: SidebarMode };
+type OutgoingMessage = { type: 'view:ready' } | { type: 'connect' } | { type: 'disconnect' } | { type: 'command'; command: string; args?: unknown[] } | { type: 'openFile'; fsPath: string } | { type: 'runPipeline'; fsPath: string; sourceId?: string } | { type: 'stopPipeline'; projectId: string; sourceId: string } | { type: 'refresh' } | { type: 'openUnknownTask'; projectId: string; sourceId: string; displayName: string } | { type: 'setDevelopmentMode'; mode: string } | { type: 'setDeployTargetMode'; mode: string | null } | { type: 'cloudSignIn' } | { type: 'openApp'; appId: string } | { type: 'setSidebarMode'; mode: SidebarMode } | { type: 'node:new' } | { type: 'node:import' } | { type: 'node:uninstall'; name: string };
 
 interface DashboardTaskDTO {
 	id: string;
@@ -98,6 +98,7 @@ type IncomingMessage =
 	  }
 	| { type: 'entriesUpdate'; entries: HostProjectEntry[] }
 	| { type: 'appsUpdate'; apps: AppListItem[] }
+	| { type: 'nodesUpdate'; nodes: NodeListItem[] }
 	| { type: 'taskEvent'; event: TaskEventBody }
 	| { type: 'statusUpdate'; projectId: string; sourceId: string; errors: string[]; warnings: string[] }
 	| { type: 'dashboardSnapshot'; tasks: DashboardTaskDTO[] };
@@ -127,6 +128,8 @@ const SidebarViewWebview: React.FC = () => {
 
 	// ── App Builder (MY APPS) ───────────────────────────────────────────────
 	const [apps, setApps] = useState<AppListItem[]>([]);
+	// ── Node Builder (installed custom nodes) ───────────────────────────────
+	const [installedNodes, setInstalledNodes] = useState<NodeListItem[]>([]);
 	const [sidebarMode, setSidebarMode] = useState<SidebarMode>('pipelines');
 	// The host-persisted mode seeds the strip ONCE: an `update` composed
 	// before the persist round trip completed carries the previous value and
@@ -245,6 +248,10 @@ const SidebarViewWebview: React.FC = () => {
 					setApps(msg.apps);
 					break;
 
+				case 'nodesUpdate':
+					setInstalledNodes(msg.nodes);
+					break;
+
 				case 'taskEvent':
 					handleTaskEvent(msg.event);
 					break;
@@ -355,6 +362,26 @@ const SidebarViewWebview: React.FC = () => {
 	const onOpenApp = useCallback(
 		(appId: string) => {
 			sendMessage({ type: 'openApp', appId });
+		},
+		[sendMessage]
+	);
+
+	// ── Node Builder callbacks (extension host does the client.call) ────────
+
+	/** New node → the host prompts for name/kind, then scaffolds + installs. */
+	const onNewNode = useCallback(() => {
+		sendMessage({ type: 'node:new' });
+	}, [sendMessage]);
+
+	/** Import capsule → the host opens a .rrc file dialog, then installs. */
+	const onImportCapsule = useCallback(() => {
+		sendMessage({ type: 'node:import' });
+	}, [sendMessage]);
+
+	/** Uninstall an installed node by name (host confirms + removes). */
+	const onUninstall = useCallback(
+		(name: string) => {
+			sendMessage({ type: 'node:uninstall', name });
 		},
 		[sendMessage]
 	);
@@ -476,7 +503,7 @@ const SidebarViewWebview: React.FC = () => {
 	// No headerSlot: the VS Code host has no home-app destination, so it injects no
 	// host-specific top nav. The "Home" button is a SaaS-shell concept owned by the
 	// web host (rocket-ui), intentionally absent from shared / this extension.
-	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} appBuilder={{ apps, onNewApp, onOpenApp }} sidebarMode={sidebarMode} onSidebarModeChange={onSidebarModeChange} />;
+	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} appBuilder={{ apps, onNewApp, onOpenApp }} nodeBuilder={{ nodes: installedNodes, onNewNode, onImportCapsule, onUninstall }} sidebarMode={sidebarMode} onSidebarModeChange={onSidebarModeChange} />;
 };
 
 export default SidebarViewWebview;

--- a/packages/ai/src/ai/account/base.py
+++ b/packages/ai/src/ai/account/base.py
@@ -482,6 +482,63 @@ class AccountBase(ABC):
             self._deployments_backend = FileDeploymentBackend(Store.instance().raw_store())
         return self._deployments_backend
 
+    # =========================================================================
+    # NODE CATALOG — the public shelf of user-published nodes.
+    #
+    # PUBLISH copies a capsule in as an immutable version; anyone can list and
+    # fetch. Unlike deployments this is not org-scoped: a catalog nobody else
+    # can see is not a catalog.
+    #
+    # Same shape as the deployments interface above and for the same reason:
+    # ONE backend hook, file-backed in OSS, swapped for DB-backed metadata in
+    # SaaS over the identical artifact files — callers never branch on edition.
+    #
+    # Price is carried, never enforced. Whether a caller may pay is the billing
+    # layer's question; in OSS there is no billing at all.
+    # =========================================================================
+
+    _node_catalog = None
+
+    def _node_catalog_backend(self):
+        """The lazily-created file backend used by the OSS defaults."""
+        if self._node_catalog is None:
+            from .node_catalog_backend import FileNodeCatalogBackend
+            from .store import Store
+
+            self._node_catalog = FileNodeCatalogBackend(Store.instance().raw_store())
+        return self._node_catalog
+
+    async def catalog_publish(
+        self,
+        name: str,
+        capsule: bytes,
+        actor: dict,
+        title: str = '',
+        description: str = '',
+        price_cents: int = 0,
+        version_label: str = '',
+    ) -> dict:
+        """Publish a capsule as the node's next immutable catalog version."""
+        return await self._node_catalog_backend().publish(
+            name, capsule, actor, title, description, price_cents, version_label
+        )
+
+    async def catalog_unpublish(self, name: str, actor: dict) -> dict:
+        """Hide a node from the catalog; artifacts and history survive."""
+        return await self._node_catalog_backend().unpublish(name, actor)
+
+    async def catalog_list(self, search: str = '', include_removed: bool = False) -> list:
+        """Every published node, newest first."""
+        return await self._node_catalog_backend().list(search, include_removed)
+
+    async def catalog_get(self, name: str):
+        """One catalog entry with its versions, or None."""
+        return await self._node_catalog_backend().get(name)
+
+    async def catalog_fetch(self, name: str, version=None) -> dict:
+        """One version's capsule, base64-encoded, digest re-verified."""
+        return await self._node_catalog_backend().fetch(name, version)
+
     async def deployments_publish(
         self, org_id: str, project_id: str, pipeline: dict, actor: dict, comment: str = ''
     ) -> dict:

--- a/packages/ai/src/ai/account/capsule.py
+++ b/packages/ai/src/ai/account/capsule.py
@@ -20,17 +20,26 @@ Kept deliberately self-contained so it is trivial to split into its own PR later
 import hashlib
 import io
 import json
+import ntpath
 import posixpath
 import zipfile
 from typing import Dict, List, Optional, Tuple
 
 import json5
 
+from ai.account.node_scaffold import _NAME_RE
+
 MANIFEST_NAME = 'capsule.json'
 NODES_ROOT = 'local_nodes'
 
 # A payload larger than this is refused before extraction (zip-bomb / runaway).
 MAX_CAPSULE_BYTES = 25 * 1024 * 1024
+
+# The compressed cap says nothing about what the archive expands to: a few hundred
+# KiB of zeros decompresses to hundreds of MiB, all of it read into memory here.
+# Bound the declared uncompressed total and the member count as well.
+MAX_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+MAX_CAPSULE_MEMBERS = 2000
 
 # Build/runtime cruft that never belongs in a capsule.
 _SKIP_DIRS = frozenset({'__pycache__', '.git', '.mypy_cache', '.ruff_cache'})
@@ -107,6 +116,53 @@ def pack_capsule(
     return buf.getvalue()
 
 
+def _validate_payload_key(key: str) -> None:
+    """Reject a payload key that would escape the node directory it is joined onto.
+
+    The archive name is not the thing that gets written — the remainder after the
+    ``local_nodes/<name>/`` prefix is, and a member can traverse within an accepted
+    prefix so that only the remainder escapes. Checked on the key itself, and on
+    both separators: a backslash is a path separator on Windows and passes a POSIX
+    normalisation untouched.
+
+    Args:
+        key: Path relative to the node directory.
+
+    Raises:
+        CapsuleError: The key is absolute, empty, or contains a ``..`` segment.
+    """
+    if not key or key.startswith('/') or key.startswith('\\') or posixpath.isabs(key):
+        raise CapsuleError(f'unsafe path in capsule: {key!r}')
+    if ntpath.isabs(key) or (len(key) > 1 and key[1] == ':'):
+        raise CapsuleError(f'unsafe path in capsule: {key!r}')
+    for segment in key.replace('\\', '/').split('/'):
+        if segment in ('..', ''):
+            raise CapsuleError(f'unsafe path in capsule: {key!r}')
+
+
+def _verify_digest(manifest: dict, payload: Dict[str, bytes]) -> None:
+    """Check the payload against the manifest's sha256, when it carries one.
+
+    pack_capsule records the digest so a read can confirm the bytes are intact;
+    a digest nobody checks is a claim, not a guarantee.
+
+    Args:
+        manifest: The parsed capsule manifest.
+        payload: Contents keyed relative to the node directory.
+
+    Raises:
+        CapsuleError: The recorded digest does not match the payload.
+    """
+    recorded = manifest.get('sha256')
+    if not recorded:
+        return
+    name = manifest.get('name')
+    prefixed = {f'{NODES_ROOT}/{name}/{key}': value for key, value in payload.items()}
+    actual = _payload_sha256(prefixed)
+    if actual != recorded:
+        raise CapsuleError('capsule contents do not match the recorded sha256')
+
+
 def read_capsule(zip_bytes: bytes) -> Tuple[dict, Dict[str, bytes]]:
     """Read a capsule back to ``(manifest, payload)`` for installation.
 
@@ -132,6 +188,13 @@ def read_capsule(zip_bytes: bytes) -> Tuple[dict, Dict[str, bytes]]:
     except zipfile.BadZipFile as e:
         raise CapsuleError(f'not a valid zip archive: {e}')
 
+    infos = zf.infolist()
+    if len(infos) > MAX_CAPSULE_MEMBERS:
+        raise CapsuleError(f'capsule holds more than {MAX_CAPSULE_MEMBERS} entries')
+    declared = sum(info.file_size for info in infos)
+    if declared > MAX_UNCOMPRESSED_BYTES:
+        raise CapsuleError(f'capsule expands to more than {MAX_UNCOMPRESSED_BYTES} bytes')
+
     names = zf.namelist()
     for name in names:
         norm = posixpath.normpath(name)
@@ -144,17 +207,37 @@ def read_capsule(zip_bytes: bytes) -> Tuple[dict, Dict[str, bytes]]:
         manifest = json.loads(zf.read(MANIFEST_NAME).decode('utf-8'))
     except Exception as e:
         raise CapsuleError(f'{MANIFEST_NAME} is not valid JSON: {e}')
+    if not isinstance(manifest, dict):
+        raise CapsuleError(f'{MANIFEST_NAME} is not an object')
 
     node_name = manifest.get('name')
     if not node_name:
         raise CapsuleError(f'{MANIFEST_NAME} missing "name"')
+    # Validated where the name is first read, so every consumer gets the same
+    # answer rather than relying on the installer to check it later.
+    if not _NAME_RE.match(str(node_name)):
+        raise CapsuleError(f'invalid node name in {MANIFEST_NAME}: {node_name!r}')
     node_dir = f'{NODES_ROOT}/{node_name}/'
 
     payload: Dict[str, bytes] = {}
+    read_bytes = 0
     for arc in names:
         if arc == MANIFEST_NAME or arc.endswith('/'):
             continue
         if not arc.startswith(node_dir):
             raise CapsuleError(f'{arc!r} is outside the node folder {node_dir!r}')
-        payload[arc[len(node_dir) :]] = zf.read(arc)
+        key = arc[len(node_dir) :]
+        # The key is what the caller joins onto its own node directory, so it is the
+        # thing that has to be safe — not the archive name it came from. A member
+        # traversing *inside* an accepted prefix ('local_nodes/x/sub/../../evil.py')
+        # normalises to something with no leading '..' and passes every check above,
+        # while the key still escapes when joined.
+        _validate_payload_key(key)
+        data = zf.read(arc)
+        read_bytes += len(data)
+        if read_bytes > MAX_UNCOMPRESSED_BYTES:
+            raise CapsuleError(f'capsule expands to more than {MAX_UNCOMPRESSED_BYTES} bytes')
+        payload[key] = data
+
+    _verify_digest(manifest, payload)
     return manifest, payload

--- a/packages/ai/src/ai/account/capsule.py
+++ b/packages/ai/src/ai/account/capsule.py
@@ -12,9 +12,7 @@ one straight line and the Node Builder and the installer share one destination.
 
 Scope: this module is only the format — ``pack_capsule`` builds a ``.rrc`` and
 ``read_capsule`` reads one back (with a basic path-traversal guard so extraction
-never escapes the node folder). The security *airlock* (a safety verdict, AST scan,
-requirements/capability gating) is intentionally out of scope here — we will design
-it alongside the marketplace, where the verdict becomes a product surface.
+never escapes the node folder). Judging a node's contents is out of scope here.
 
 Kept deliberately self-contained so it is trivial to split into its own PR later.
 """
@@ -72,7 +70,7 @@ def pack_capsule(
         files: ``{relative_path: contents}`` for the node folder.
         version: capsule version recorded in the manifest.
         declares: capabilities the node needs (``network``/``subprocess``/``filesystem``);
-            recorded as metadata for a future airlock, not enforced here.
+            recorded as manifest metadata, not enforced here.
 
     Returns:
         The capsule bytes.
@@ -114,7 +112,7 @@ def read_capsule(zip_bytes: bytes) -> Tuple[dict, Dict[str, bytes]]:
 
     Guards only against a malformed or path-escaping archive (zip-slip), so the
     caller can safely write ``payload`` under a node path. It does **not** judge the
-    node's safety — that airlock comes with the marketplace.
+    node's contents.
 
     Args:
         zip_bytes: the ``.rrc`` bytes.

--- a/packages/ai/src/ai/account/capsule.py
+++ b/packages/ai/src/ai/account/capsule.py
@@ -1,0 +1,162 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Node capsule (``.rrc``): the transport format for installing a custom node.
+
+A capsule is a ZIP with ``capsule.json`` at the root and the node under
+``local_nodes/<name>/`` — the same ``local_nodes`` layout the engine discovers via
+``--node_path`` (see node_scaffold.py), so scaffold → pack → install → discover is
+one straight line and the Node Builder and the installer share one destination.
+
+Scope: this module is only the format — ``pack_capsule`` builds a ``.rrc`` and
+``read_capsule`` reads one back (with a basic path-traversal guard so extraction
+never escapes the node folder). The security *airlock* (a safety verdict, AST scan,
+requirements/capability gating) is intentionally out of scope here — we will design
+it alongside the marketplace, where the verdict becomes a product surface.
+
+Kept deliberately self-contained so it is trivial to split into its own PR later.
+"""
+
+import hashlib
+import io
+import json
+import posixpath
+import zipfile
+from typing import Dict, List, Optional, Tuple
+
+import json5
+
+MANIFEST_NAME = 'capsule.json'
+NODES_ROOT = 'local_nodes'
+
+# A payload larger than this is refused before extraction (zip-bomb / runaway).
+MAX_CAPSULE_BYTES = 25 * 1024 * 1024
+
+# Build/runtime cruft that never belongs in a capsule.
+_SKIP_DIRS = frozenset({'__pycache__', '.git', '.mypy_cache', '.ruff_cache'})
+_SKIP_SUFFIX = ('.pyc', '.pyo')
+
+
+class CapsuleError(Exception):
+    """A capsule is malformed (bad zip, missing manifest, unsafe path)."""
+
+
+def load_relaxed_json(text: str):
+    """Parse JSONC (services.json is JSONC); capsule.json is plain JSON but this accepts both."""
+    return json5.loads(text)
+
+
+def _payload_sha256(files: Dict[str, bytes]) -> str:
+    """SHA-256 over the payload, order-independent: hash sorted ``arcname\\0bytes`` records."""
+    h = hashlib.sha256()
+    for arc in sorted(files):
+        h.update(arc.encode('utf-8'))
+        h.update(b'\0')
+        h.update(files[arc])
+        h.update(b'\0')
+    return h.hexdigest()
+
+
+def pack_capsule(
+    name: str, files: Dict[str, str], version: str = '0.0.0', declares: Optional[List[str]] = None
+) -> bytes:
+    """Build ``.rrc`` bytes from a node file map (as ``scaffold_node`` returns).
+
+    The payload is placed under ``local_nodes/<name>/`` and the manifest records a
+    sha256 of it, so a later read can confirm the bytes are intact.
+
+    Args:
+        name: node id (folder / protocol key).
+        files: ``{relative_path: contents}`` for the node folder.
+        version: capsule version recorded in the manifest.
+        declares: capabilities the node needs (``network``/``subprocess``/``filesystem``);
+            recorded as metadata for a future airlock, not enforced here.
+
+    Returns:
+        The capsule bytes.
+    """
+    protocol = f'{name}://'
+    services = files.get('services.json')
+    if services:
+        try:
+            protocol = load_relaxed_json(services).get('protocol') or protocol
+        except Exception:
+            pass
+
+    payload: Dict[str, bytes] = {}
+    for rel, body in files.items():
+        parts = rel.split('/')
+        if any(p in _SKIP_DIRS for p in parts) or rel.endswith(_SKIP_SUFFIX):
+            continue
+        arc = f'{NODES_ROOT}/{name}/{rel}'
+        payload[arc] = body.encode('utf-8')
+
+    manifest = {
+        'name': name,
+        'protocol': protocol,
+        'version': version,
+        'declares': sorted(declares or []),
+        'sha256': _payload_sha256(payload),
+    }
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2))
+        for arc in sorted(payload):
+            zf.writestr(arc, payload[arc])
+    return buf.getvalue()
+
+
+def read_capsule(zip_bytes: bytes) -> Tuple[dict, Dict[str, bytes]]:
+    """Read a capsule back to ``(manifest, payload)`` for installation.
+
+    Guards only against a malformed or path-escaping archive (zip-slip), so the
+    caller can safely write ``payload`` under a node path. It does **not** judge the
+    node's safety — that airlock comes with the marketplace.
+
+    Args:
+        zip_bytes: the ``.rrc`` bytes.
+
+    Returns:
+        ``(manifest, {relative_path_under_the_node: contents})``. Paths are returned
+        relative to ``local_nodes/<name>/`` so the caller writes them under its own
+        ``local_nodes/<name>/`` target.
+
+    Raises:
+        CapsuleError: bad zip, missing/invalid manifest, or an unsafe member path.
+    """
+    if len(zip_bytes) > MAX_CAPSULE_BYTES:
+        raise CapsuleError(f'capsule exceeds {MAX_CAPSULE_BYTES} bytes')
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as e:
+        raise CapsuleError(f'not a valid zip archive: {e}')
+
+    names = zf.namelist()
+    for name in names:
+        norm = posixpath.normpath(name)
+        if name.startswith('/') or norm.startswith('..') or posixpath.isabs(norm):
+            raise CapsuleError(f'unsafe path in capsule: {name!r}')
+
+    if MANIFEST_NAME not in names:
+        raise CapsuleError(f'missing {MANIFEST_NAME} at capsule root')
+    try:
+        manifest = json.loads(zf.read(MANIFEST_NAME).decode('utf-8'))
+    except Exception as e:
+        raise CapsuleError(f'{MANIFEST_NAME} is not valid JSON: {e}')
+
+    node_name = manifest.get('name')
+    if not node_name:
+        raise CapsuleError(f'{MANIFEST_NAME} missing "name"')
+    node_dir = f'{NODES_ROOT}/{node_name}/'
+
+    payload: Dict[str, bytes] = {}
+    for arc in names:
+        if arc == MANIFEST_NAME or arc.endswith('/'):
+            continue
+        if not arc.startswith(node_dir):
+            raise CapsuleError(f'{arc!r} is outside the node folder {node_dir!r}')
+        payload[arc[len(node_dir) :]] = zf.read(arc)
+    return manifest, payload

--- a/packages/ai/src/ai/account/node_catalog_backend.py
+++ b/packages/ai/src/ai/account/node_catalog_backend.py
@@ -45,6 +45,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
+from .capsule import read_capsule
 from .store import IStore, StorageError, VersionMismatchError
 
 # How many CAS retries a meta.json read-modify-write attempts before failing.
@@ -95,6 +96,61 @@ def artifact_sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def card_metadata(capsule: bytes) -> Dict[str, Any]:
+    """Read the card fields out of the capsule's own services.json.
+
+    The catalog card wants a title, a description, categories and an icon —
+    all of which the node already declares. Asking the author to type them
+    again at publish time is how the two drift apart, so they are derived here
+    and only overridden when the publisher explicitly passes something.
+
+    Args:
+        capsule: The ``.rrc`` bytes.
+
+    Returns:
+        ``{'title', 'description', 'categories', 'icon'}``; any field the node
+        does not declare comes back empty.
+    """
+    try:
+        _manifest, payload = read_capsule(capsule)
+    except Exception:
+        return {'title': '', 'description': '', 'categories': [], 'icon': ''}
+
+    from .capsule import load_relaxed_json
+
+    definition: Dict[str, Any] = {}
+    raw = payload.get('services.json')
+    if raw:
+        try:
+            definition = load_relaxed_json(raw.decode('utf-8')) or {}
+        except Exception:
+            definition = {}
+
+    description = definition.get('description')
+    if isinstance(description, list):
+        description = ''.join(description)
+
+    icon_name = definition.get('icon')
+    icon_svg = ''
+    if isinstance(icon_name, str) and icon_name.lower().endswith('.svg'):
+        blob = payload.get(icon_name)
+        if blob:
+            try:
+                icon_svg = blob.decode('utf-8')
+            except UnicodeDecodeError:
+                icon_svg = ''
+
+    class_type = definition.get('classType')
+    categories = [c for c in (class_type if isinstance(class_type, list) else []) if isinstance(c, str)]
+
+    return {
+        'title': definition.get('title') or '',
+        'description': description or '',
+        'categories': categories,
+        'icon': icon_svg,
+    }
+
+
 class FileNodeCatalogBackend:
     """The OSS catalog: capsules on the store, metadata in meta.json.
 
@@ -142,6 +198,8 @@ class FileNodeCatalogBackend:
             raise ValueError('price_cents cannot be negative')
 
         digest = artifact_sha256(capsule)
+        # Derived from the node's own services.json; explicit arguments win.
+        card = card_metadata(capsule)
 
         async def mutate(meta: Dict[str, Any]) -> Dict[str, Any]:
             version = len(meta['versions']) + 1
@@ -158,8 +216,11 @@ class FileNodeCatalogBackend:
             }
             meta['versions'].append(record)
             meta['name'] = name
-            meta['title'] = title or meta.get('title') or name
-            meta['description'] = description or meta.get('description') or ''
+            meta['title'] = title or card['title'] or meta.get('title') or name
+            meta['description'] = description or card['description'] or meta.get('description') or ''
+            meta['categories'] = card['categories'] or meta.get('categories') or []
+            if card['icon']:
+                meta['icon'] = card['icon']
             meta['priceCents'] = int(price_cents)
             meta['state'] = 'published'
             meta['author'] = meta.get('author') or _actor_record(actor)
@@ -275,6 +336,9 @@ class FileNodeCatalogBackend:
             'name': meta.get('name'),
             'title': meta.get('title') or meta.get('name'),
             'description': meta.get('description') or '',
+            # The app store card reads these; a node declares them already.
+            'categories': meta.get('categories') or [],
+            'icon': meta.get('icon') or '',
             'author': meta.get('author') or {},
             'priceCents': int(meta.get('priceCents') or 0),
             'state': meta.get('state') or 'published',

--- a/packages/ai/src/ai/account/node_catalog_backend.py
+++ b/packages/ai/src/ai/account/node_catalog_backend.py
@@ -1,0 +1,336 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""File-backed node catalog — the OSS implementation of the account module's
+``catalog_*`` interface, and the artifact-file layer the SaaS implementation
+shares.
+
+Model (a public shelf of user-published nodes):
+
+  - PUBLISH copies a capsule into the catalog as an IMMUTABLE version:
+
+        catalog/<name>/v000N-<sha8>.rrc
+
+    The artifact is the ``.rrc`` exactly as published; its sha256 is recorded
+    and re-verified on load, so what was reviewed is provably what installs.
+    The hash in the filename keeps racing publishers on different files.
+
+  - A published node is visible to everyone. Nothing here filters by org or
+    team: that is the point of a catalog, and it is what separates this from
+    the deployments registry, which is org-scoped by design.
+
+  - Price is carried but never charged here. The backend records what the
+    author asked for; whether anyone can pay it is the billing layer's
+    question, and in OSS there is no billing at all.
+
+  - Removal is SOFT: ``state='removed'`` hides an entry from the listing while
+    the artifacts and history survive, so an install someone already did keeps
+    resolving.
+
+Storage layout, one directory per node under the catalog tree:
+
+    catalog/<name>/v000001-<sha8>.rrc   immutable capsule (never overwritten)
+    catalog/<name>/meta.json            entry + versions + history (CAS-guarded)
+
+Uses IStore directly (the trusted, in-server layer): paths are built here from
+validated names, never from caller-supplied path strings.
+"""
+
+import base64
+import hashlib
+import json
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from .store import IStore, StorageError, VersionMismatchError
+
+# How many CAS retries a meta.json read-modify-write attempts before failing.
+_CAS_ATTEMPTS = 5
+
+# Catalog root inside the store. A published node is public, so it does not
+# live under any org's tree.
+_CATALOG_ROOT = 'catalog'
+
+# A node name is the frozen protocol id and becomes a path segment here.
+_NAME_RE = re.compile(r'^[a-z][a-z0-9_]{1,63}$')
+
+
+def _safe_name(value: str) -> str:
+    """Validate a node name that becomes a physical path segment.
+
+    Args:
+        value: The node name as published.
+
+    Returns:
+        The same name, unchanged.
+
+    Raises:
+        ValueError: The name is unusable as a path segment or as a protocol id.
+    """
+    if not _NAME_RE.match(value or ''):
+        raise ValueError(f'invalid node name {value!r}')
+    return value
+
+
+def _actor_record(actor: Dict[str, Any]) -> Dict[str, Any]:
+    """Denormalize who did something, so the record survives user deletion."""
+    actor = actor or {}
+    return {
+        'id': actor.get('id') or actor.get('userId') or '',
+        'name': actor.get('name') or actor.get('displayName') or '',
+        'email': actor.get('email') or '',
+    }
+
+
+def artifact_path(name: str, version: int, sha256: str) -> str:
+    """Physical store path of one immutable capsule version."""
+    return f'{_CATALOG_ROOT}/{name}/v{version:06d}-{sha256[:8]}.rrc'
+
+
+def artifact_sha256(data: bytes) -> str:
+    """SHA-256 of the capsule bytes, as recorded in the entry."""
+    return hashlib.sha256(data).hexdigest()
+
+
+class FileNodeCatalogBackend:
+    """The OSS catalog: capsules on the store, metadata in meta.json.
+
+    Every metadata write is a compare-and-swap on ``meta.json`` so concurrent
+    publishers never lose updates.
+    """
+
+    def __init__(self, store: IStore) -> None:
+        """
+        Args:
+            store: The raw store this catalog is written to.
+        """
+        self._store = store
+
+    # -- write ---------------------------------------------------------------
+
+    async def publish(
+        self,
+        name: str,
+        capsule: bytes,
+        actor: Dict[str, Any],
+        title: str = '',
+        description: str = '',
+        price_cents: int = 0,
+        version_label: str = '',
+    ) -> Dict[str, Any]:
+        """Publish a capsule as the node's next immutable catalog version.
+
+        Args:
+            name: Node name (its frozen protocol id).
+            capsule: The ``.rrc`` bytes.
+            actor: Who is publishing.
+            title: Display title; falls back to the name.
+            description: One-line description shown on the card.
+            price_cents: 0 for free. Recorded, never charged here.
+            version_label: The author's version string, e.g. '1.2.0'.
+
+        Returns:
+            The new catalog entry.
+        """
+        name = _safe_name(name)
+        if not capsule:
+            raise ValueError('capsule is required')
+        if price_cents < 0:
+            raise ValueError('price_cents cannot be negative')
+
+        digest = artifact_sha256(capsule)
+
+        async def mutate(meta: Dict[str, Any]) -> Dict[str, Any]:
+            version = len(meta['versions']) + 1
+            path = artifact_path(name, version, digest)
+            await self._store.write_bytes(path, capsule)
+            record = {
+                'version': version,
+                'label': version_label or f'0.0.{version}',
+                'sha256': digest,
+                'path': path,
+                'sizeBytes': len(capsule),
+                'publishedAt': int(time.time()),
+                'publishedBy': _actor_record(actor),
+            }
+            meta['versions'].append(record)
+            meta['name'] = name
+            meta['title'] = title or meta.get('title') or name
+            meta['description'] = description or meta.get('description') or ''
+            meta['priceCents'] = int(price_cents)
+            meta['state'] = 'published'
+            meta['author'] = meta.get('author') or _actor_record(actor)
+            meta['latest'] = version
+            meta['history'].append(
+                {'action': 'publish', 'version': version, 'at': record['publishedAt'], 'by': record['publishedBy']}
+            )
+            return self._entry(meta)
+
+        return await self._mutate_meta(name, mutate)
+
+    async def unpublish(self, name: str, actor: Dict[str, Any]) -> Dict[str, Any]:
+        """Hide a node from the catalog without destroying anything.
+
+        The artifacts stay: someone who already installed this node keeps a
+        capsule that resolves, and the history remains auditable.
+        """
+        name = _safe_name(name)
+
+        async def mutate(meta: Dict[str, Any]) -> Dict[str, Any]:
+            if not meta.get('versions'):
+                raise ValueError(f'node {name!r} is not published')
+            meta['state'] = 'removed'
+            meta['history'].append({'action': 'unpublish', 'at': int(time.time()), 'by': _actor_record(actor)})
+            return self._entry(meta)
+
+        return await self._mutate_meta(name, mutate)
+
+    # -- read ----------------------------------------------------------------
+
+    async def list(self, search: str = '', include_removed: bool = False) -> List[Dict[str, Any]]:
+        """Every published node, newest publication first.
+
+        Args:
+            search: Case-insensitive match against name, title and description.
+            include_removed: Include soft-removed entries (an admin view).
+        """
+        entries: List[Dict[str, Any]] = []
+        try:
+            listing = await self._store.list_entries(
+                f'{_CATALOG_ROOT}/', recursive=False, include_files=False, include_dirs=True
+            )
+        except StorageError:
+            return entries
+        for item in listing or []:
+            raw = item.get('name') if isinstance(item, dict) else item
+            node_name = str(raw or '').strip('/').split('/')[-1]
+            if not _NAME_RE.match(node_name):
+                continue
+            meta = await self._read_meta(node_name)
+            if not meta or not meta.get('versions'):
+                continue
+            if meta.get('state') == 'removed' and not include_removed:
+                continue
+            entry = self._entry(meta)
+            if search and not _matches(entry, search):
+                continue
+            entries.append(entry)
+        entries.sort(key=lambda e: e.get('publishedAt') or 0, reverse=True)
+        return entries
+
+    async def get(self, name: str) -> Optional[Dict[str, Any]]:
+        """One catalog entry, versions included, or None if never published."""
+        meta = await self._read_meta(_safe_name(name))
+        if not meta or not meta.get('versions'):
+            return None
+        entry = self._entry(meta)
+        entry['versions'] = list(reversed(meta['versions']))
+        return entry
+
+    async def fetch(self, name: str, version: Optional[int] = None) -> Dict[str, Any]:
+        """The capsule bytes of one version, base64-encoded, digest re-verified.
+
+        Args:
+            name: Node name.
+            version: Version number; the latest when omitted.
+
+        Returns:
+            ``{'name', 'version', 'sha256', 'capsule'}`` with the capsule base64.
+
+        Raises:
+            ValueError: No such node or version.
+            StorageError: The stored bytes no longer match the recorded digest.
+        """
+        name = _safe_name(name)
+        meta = await self._read_meta(name)
+        if not meta or not meta.get('versions'):
+            raise ValueError(f'node {name!r} is not published')
+        wanted = version or meta.get('latest')
+        record = next((v for v in meta['versions'] if v.get('version') == wanted), None)
+        if record is None:
+            raise ValueError(f'node {name!r} has no version {wanted}')
+
+        data = await self._store.read_bytes(record['path'])
+        actual = artifact_sha256(data)
+        if actual != record['sha256']:
+            # What was published is not what is stored: refuse rather than hand
+            # a caller bytes it is about to execute.
+            raise StorageError(f'catalog artifact for {name!r} v{wanted} does not match its recorded sha256')
+        return {
+            'name': name,
+            'version': record['version'],
+            'sha256': record['sha256'],
+            'capsule': base64.b64encode(data).decode('ascii'),
+        }
+
+    # -- internals -----------------------------------------------------------
+
+    def _entry(self, meta: Dict[str, Any]) -> Dict[str, Any]:
+        """The card-shaped view of a node's metadata."""
+        latest = next((v for v in reversed(meta.get('versions') or []) if v.get('version') == meta.get('latest')), None)
+        return {
+            'name': meta.get('name'),
+            'title': meta.get('title') or meta.get('name'),
+            'description': meta.get('description') or '',
+            'author': meta.get('author') or {},
+            'priceCents': int(meta.get('priceCents') or 0),
+            'state': meta.get('state') or 'published',
+            'latest': meta.get('latest'),
+            'versionLabel': (latest or {}).get('label') or '',
+            'sizeBytes': (latest or {}).get('sizeBytes') or 0,
+            'publishedAt': (latest or {}).get('publishedAt') or 0,
+        }
+
+    def _meta_path(self, name: str) -> str:
+        return f'{_CATALOG_ROOT}/{name}/meta.json'
+
+    async def _read_meta(self, name: str) -> Optional[Dict[str, Any]]:
+        try:
+            data = await self._store.read_file(self._meta_path(name))
+        except StorageError:
+            return None
+        try:
+            return json.loads(data)
+        except (ValueError, TypeError):
+            return None
+
+    async def _mutate_meta(self, name: str, mutate) -> Any:
+        """CAS read-modify-write of meta.json with bounded retries."""
+        last: Exception | None = None
+        for _ in range(_CAS_ATTEMPTS):
+            path = self._meta_path(name)
+            try:
+                data, cas_version = await self._store.read_file_with_metadata(path)
+                meta = json.loads(data)
+            except StorageError:
+                meta, cas_version = None, None
+            if meta is None:
+                meta = {'name': name, 'versions': [], 'history': []}
+            else:
+                meta.setdefault('versions', [])
+                meta.setdefault('history', [])
+
+            result = await mutate(meta)
+
+            try:
+                if cas_version is None:
+                    await self._store.write_file(path, json.dumps(meta, indent=1))
+                else:
+                    await self._store.write_file_atomic(path, json.dumps(meta, indent=1), expected_version=cas_version)
+                return result
+            except VersionMismatchError as e:
+                last = e
+                continue
+        raise StorageError(f'catalog: meta update contention for {name}: {last}')
+
+
+def _matches(entry: Dict[str, Any], search: str) -> bool:
+    """Case-insensitive search across the fields a person reads on the card."""
+    needle = search.lower()
+    for key in ('name', 'title', 'description'):
+        if needle in str(entry.get(key) or '').lower():
+            return True
+    return needle in str((entry.get('author') or {}).get('name') or '').lower()

--- a/packages/ai/src/ai/account/node_install.py
+++ b/packages/ai/src/ai/account/node_install.py
@@ -234,3 +234,46 @@ async def installed_node_definition(fs, name: str):
     definition['source'] = 'capsule'
     definition.pop('icon', None)
     return definition
+
+
+async def pack_installed_node(fs, name: str, version: str = '0.0.0') -> bytes:
+    """Re-pack a node already installed in the caller's store as a ``.rrc``.
+
+    Publishing normally means "publish what I have installed". Packing it again
+    on the client would be a second chance for the two to differ, so the bytes
+    come from the store the engine actually loads.
+
+    Args:
+        fs: The caller's FileStore.
+        name: Installed node name.
+        version: Version label recorded in the capsule manifest.
+
+    Returns:
+        The ``.rrc`` bytes.
+
+    Raises:
+        NodeInstallError: The node is not installed, or carries no files.
+    """
+    from ai.account.capsule import pack_capsule
+
+    name = _safe_name(name)
+    root = f'{_STORE_ROOT}/{name}'
+    try:
+        listing = await fs.list_dir(root)
+    except Exception as e:
+        raise NodeInstallError(f'node {name!r} is not installed: {e}')
+
+    files: Dict[str, str] = {}
+    for entry in listing.get('entries', []):
+        if entry.get('type') != 'file':
+            continue
+        filename = entry['name']
+        try:
+            files[filename] = (await fs.read(f'{root}/{filename}')).decode('utf-8')
+        except UnicodeDecodeError:
+            # An icon or other binary member: pack_capsule takes text, so skip
+            # what cannot be represented rather than corrupting it.
+            continue
+    if not files:
+        raise NodeInstallError(f'node {name!r} has no files to publish')
+    return pack_capsule(name, files, version=version)

--- a/packages/ai/src/ai/account/node_install.py
+++ b/packages/ai/src/ai/account/node_install.py
@@ -115,3 +115,63 @@ def list_installed(node_path: Optional[str] = None) -> List[str]:
     return sorted(
         d for d in os.listdir(local_nodes) if d != '__pycache__' and os.path.isdir(os.path.join(local_nodes, d))
     )
+
+
+# =============================================================================
+# Store-backed install (primary) — persists per-user and materializes per-run.
+#
+# The primary path writes a capsule into the caller's store under
+# ``local_nodes/<name>/``; task_engine materializes it and passes --node_path to
+# each run, so installed nodes work with no manual flag in docker/SaaS. The
+# ``--node_path`` variants above stay as the VSCode-workspace fallback.
+# =============================================================================
+
+_STORE_ROOT = 'local_nodes'
+
+
+async def install_capsule_to_store(fs, zip_bytes: bytes) -> Dict[str, object]:
+    """Install a ``.rrc`` into the caller's store (``local_nodes/<name>/``).
+
+    Args:
+        fs: a ``FileStore`` bound to the caller (``Store.file_store(ctx)``).
+        zip_bytes: the capsule bytes.
+
+    Returns:
+        ``{'name', 'protocol', 'version', 'files': [relpaths]}``.
+    """
+    manifest, payload = read_capsule(zip_bytes)
+    name = _safe_name(manifest.get('name'))
+    dest = f'{_STORE_ROOT}/{name}'
+    # Clean overwrite so a removed file never lingers across an upgrade.
+    try:
+        await fs.rmdir(dest, recursive=True)
+    except Exception:
+        pass
+    written: List[str] = []
+    for rel, body in payload.items():
+        await fs.write(f'{dest}/{rel}', body)
+        written.append(rel)
+    return {
+        'name': name,
+        'protocol': manifest.get('protocol') or f'{name}://',
+        'version': manifest.get('version'),
+        'files': sorted(written),
+    }
+
+
+async def uninstall_node_from_store(fs, name: str) -> Dict[str, object]:
+    """Remove an installed node from the caller's store."""
+    name = _safe_name(name)
+    if name not in await list_installed_in_store(fs):
+        raise NodeInstallError(f'node {name!r} is not installed')
+    await fs.rmdir(f'{_STORE_ROOT}/{name}', recursive=True)
+    return {'name': name, 'removed': True}
+
+
+async def list_installed_in_store(fs) -> List[str]:
+    """Names of the custom nodes installed in the caller's store (empty if none)."""
+    try:
+        listing = await fs.list_dir(_STORE_ROOT)
+    except Exception:
+        return []
+    return sorted(e['name'] for e in listing.get('entries', []) if e.get('type') == 'dir')

--- a/packages/ai/src/ai/account/node_install.py
+++ b/packages/ai/src/ai/account/node_install.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Install a node capsule into the engine's ``local_nodes`` so it loads live.
+
+Installing writes the capsule payload under ``<node_path>/local_nodes/<name>/`` — the
+exact layout the engine discovers via ``--node_path`` (see node_scaffold.py) — and
+makes sure ``local_nodes`` is an importable package. The install target is the active
+``--node_path``, so the same code works in OSS (a VSCode workspace) and in the cloud
+(the engine started against a per-user node path); no store coupling.
+
+This is engine-side, so every surface installs the same way: the VSCode extension,
+the web builder and Claude all send a capsule to ``rrext_node_dev`` install and land
+here. The safety airlock is deferred to the marketplace (see capsule.py).
+"""
+
+import os
+import shutil
+from typing import Dict, List, Optional
+
+from rocketlib import args as startup_args
+
+from ai.account.capsule import NODES_ROOT, read_capsule
+from ai.account.node_scaffold import _NAME_RE
+
+
+class NodeInstallError(Exception):
+    """Install/uninstall could not proceed (no node path, bad name, missing node)."""
+
+
+def resolve_node_path() -> Optional[str]:
+    """The active ``--node_path`` the engine was started with, or None if unset."""
+    for arg in startup_args():
+        if arg.startswith('--node_path='):
+            return arg[len('--node_path=') :]
+    return None
+
+
+def _local_nodes_dir(node_path: Optional[str]) -> str:
+    node_path = node_path or resolve_node_path()
+    if not node_path:
+        raise NodeInstallError('no --node_path configured; cannot install custom nodes')
+    return os.path.join(node_path, NODES_ROOT)
+
+
+def _ensure_package(local_nodes: str) -> None:
+    """Make ``local_nodes`` an importable package so the engine can import its nodes."""
+    os.makedirs(local_nodes, exist_ok=True)
+    init = os.path.join(local_nodes, '__init__.py')
+    if not os.path.exists(init):
+        open(init, 'w', encoding='utf-8').close()
+
+
+def _safe_name(name: Optional[str]) -> str:
+    if not _NAME_RE.match(name or ''):
+        raise NodeInstallError(f'invalid node name {name!r}')
+    return name
+
+
+def install_capsule(zip_bytes: bytes, node_path: Optional[str] = None) -> Dict[str, object]:
+    """Install a ``.rrc`` capsule; overwrites an existing node of the same name (upgrade).
+
+    Args:
+        zip_bytes: the capsule bytes.
+        node_path: install target; defaults to the active ``--node_path``.
+
+    Returns:
+        ``{'name', 'protocol', 'version', 'files': [relpaths]}``.
+    """
+    manifest, payload = read_capsule(zip_bytes)
+    name = _safe_name(manifest.get('name'))
+    local_nodes = _local_nodes_dir(node_path)
+    _ensure_package(local_nodes)
+
+    dest = os.path.join(local_nodes, name)
+    if os.path.isdir(dest):
+        shutil.rmtree(dest)  # clean overwrite so a removed file never lingers on upgrade
+    written: List[str] = []
+    for rel, body in payload.items():
+        target = os.path.join(dest, rel)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        # utf-8 explicitly: the engine may run in an ASCII locale and node files are utf-8.
+        with open(target, 'wb') as fh:
+            fh.write(body)
+        written.append(rel)
+
+    return {
+        'name': name,
+        'protocol': manifest.get('protocol') or f'{name}://',
+        'version': manifest.get('version'),
+        'files': sorted(written),
+    }
+
+
+def uninstall_node(name: str, node_path: Optional[str] = None) -> Dict[str, object]:
+    """Remove an installed node folder. Errors if it is not installed."""
+    name = _safe_name(name)
+    dest = os.path.join(_local_nodes_dir(node_path), name)
+    if not os.path.isdir(dest):
+        raise NodeInstallError(f'node {name!r} is not installed')
+    shutil.rmtree(dest)
+    return {'name': name, 'removed': True}
+
+
+def list_installed(node_path: Optional[str] = None) -> List[str]:
+    """Names of the currently installed custom nodes (empty if none / no node path)."""
+    try:
+        local_nodes = _local_nodes_dir(node_path)
+    except NodeInstallError:
+        return []
+    if not os.path.isdir(local_nodes):
+        return []
+    return sorted(
+        d for d in os.listdir(local_nodes) if d != '__pycache__' and os.path.isdir(os.path.join(local_nodes, d))
+    )

--- a/packages/ai/src/ai/account/node_install.py
+++ b/packages/ai/src/ai/account/node_install.py
@@ -175,3 +175,63 @@ async def list_installed_in_store(fs) -> List[str]:
     except Exception:
         return []
     return sorted(e['name'] for e in listing.get('entries', []) if e.get('type') == 'dir')
+
+
+async def installed_node_catalog(fs):
+    """Read the caller's installed nodes as a catalog overlay for the palette.
+
+    Returns ``(services, icons)`` to merge into the ``rrext_services`` summary so
+    installed nodes appear in the canvas palette live — without the design-time
+    engine having loaded them. ``services`` maps node name -> a summary entry (the
+    raw services.json trimmed to the summary fields, tagged ``source:"capsule"``);
+    ``icons`` maps ``capsule:<name>`` -> the node's SVG.
+    """
+    from ai.account.capsule import load_relaxed_json
+    from ai.modules.task.services_catalog import SUMMARY_FIELDS
+
+    services: Dict[str, dict] = {}
+    icons: Dict[str, str] = {}
+    try:
+        listing = await fs.list_dir(_STORE_ROOT)
+    except Exception:
+        return services, icons
+    for entry in listing.get('entries', []):
+        if entry.get('type') != 'dir':
+            continue
+        name = entry['name']
+        try:
+            raw = (await fs.read(f'{_STORE_ROOT}/{name}/services.json')).decode('utf-8')
+            definition = load_relaxed_json(raw)
+        except Exception:
+            continue
+        brief = {k: definition[k] for k in SUMMARY_FIELDS if k in definition}
+        brief['source'] = 'capsule'  # UI badge: distinguishes an installed node
+        if isinstance(brief.get('description'), list):
+            brief['description'] = ''.join(brief['description'])  # match the built-in summary shape
+        icon = definition.get('icon')
+        if isinstance(icon, str) and icon.lower().endswith('.svg'):
+            try:
+                icons[f'capsule:{name}'] = (await fs.read(f'{_STORE_ROOT}/{name}/{icon}')).decode('utf-8')
+                brief['icon'] = f'capsule:{name}'
+            except Exception:
+                brief.pop('icon', None)
+        services[name] = brief
+    return services, icons
+
+
+async def installed_node_definition(fs, name: str):
+    """The full services.json of one installed node (config schema included) or None.
+
+    Backs the single-service ``rrext_services`` lookup so an installed node's config
+    panel resolves. Icon is dropped: full entries carry no icon (see the catalog).
+    """
+    from ai.account.capsule import load_relaxed_json
+
+    try:
+        raw = (await fs.read(f'{_STORE_ROOT}/{name}/services.json')).decode('utf-8')
+    except Exception:
+        return None
+    definition = load_relaxed_json(raw)
+    definition['source'] = 'capsule'
+    definition.pop('icon', None)
+    return definition

--- a/packages/ai/src/ai/account/node_install.py
+++ b/packages/ai/src/ai/account/node_install.py
@@ -11,9 +11,8 @@ makes sure ``local_nodes`` is an importable package. The install target is the a
 ``--node_path``, so the same code works in OSS (a VSCode workspace) and in the cloud
 (the engine started against a per-user node path); no store coupling.
 
-This is engine-side, so every surface installs the same way: the VSCode extension,
-the web builder and Claude all send a capsule to ``rrext_node_dev`` install and land
-here. The safety airlock is deferred to the marketplace (see capsule.py).
+This is engine-side, so every surface installs the same way: the VSCode extension
+and the web builder send a capsule to ``rrext_node_dev`` install and land here.
 """
 
 import os

--- a/packages/ai/src/ai/account/node_scaffold.py
+++ b/packages/ai/src/ai/account/node_scaffold.py
@@ -5,10 +5,9 @@
 
 """Node scaffolder: render a complete, valid custom-node folder from a few inputs.
 
-One source of truth for every surface. The VSCode extension, the web builder and
-Claude all call ``rrext_node_dev`` (subcommand ``scaffold``) and write the returned
-file map, so a node
-scaffolded from any host is byte-identical. A custom node is a folder under a
+One source of truth for every surface. The VSCode extension and the web builder both
+call ``rrext_node_dev`` (subcommand ``scaffold``) and write the returned file map, so
+a node scaffolded from any host is byte-identical. A custom node is a folder under a
 ``--node_path`` ``local_nodes/`` package (a VSCode workspace or an installed
 capsule) holding a ``services.json`` plus Python ``IGlobal``/``IInstance``[/
 ``IEndpoint``] classes; the engine discovers it as ``local_nodes.<name>`` with no

--- a/packages/ai/src/ai/account/node_scaffold.py
+++ b/packages/ai/src/ai/account/node_scaffold.py
@@ -1,0 +1,250 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Node scaffolder: render a complete, valid custom-node folder from a few inputs.
+
+One source of truth for every surface. The VSCode extension, the web builder and
+Claude all call ``rrext_node_dev`` (subcommand ``scaffold``) and write the returned
+file map, so a node
+scaffolded from any host is byte-identical. A node is a folder under
+``nodes/src/nodes/<name>/`` (or a workspace ``--node_path``) holding a
+``services.json`` plus Python ``IGlobal``/``IInstance``[/``IEndpoint``] classes; the
+engine discovers it with no central registration (see docs/README-node-schema.md).
+
+The ``name`` is the node's frozen identity: it becomes the ``protocol`` key the
+``.pipe`` stores, so renaming it later breaks every pipe that used the node. We
+validate it hard here and never let a scaffold emit an invalid one.
+"""
+
+import json
+import re
+from typing import Dict, List, Optional
+
+# The node name is the protocol key the pipe persists — lock it to a safe, stable
+# identifier so a rename never silently breaks saved pipelines.
+_NAME_RE = re.compile(r'^[a-z][a-z0-9_]{1,63}$')
+
+# 'filter' consumes lanes and emits lanes (IGlobal + IInstance). 'source' originates
+# data on the '_source' lane and needs an IEndpoint factory. These map to the
+# services.json 'register' key exactly as the loader expects.
+_KINDS = ('filter', 'source')
+
+_LICENSE = """# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+"""
+
+
+def _prefix(name: str) -> str:
+    """CamelCase prefix the engine adds/removes converting URLs <=> paths (my_node -> MyNode)."""
+    return ''.join(part.capitalize() for part in name.split('_'))
+
+
+def _services_json(
+    name: str, title: str, kind: str, class_type: List[str], lanes: Dict[str, List[str]], description: str
+) -> str:
+    """The services.json manifest. Plain JSON (a subset of the JSONC the loader reads)."""
+    register = 'filter' if kind == 'filter' else 'endpoint'
+    manifest = {
+        'title': title,
+        'protocol': f'{name}://',
+        'classType': class_type,
+        'capabilities': [],
+        'register': register,
+        'node': 'python',
+        'path': f'nodes.{name}',
+        'prefix': _prefix(name),
+        'description': [description] if description else [f'{title} node.'],
+        'icon': f'{name}.svg',
+        'lanes': lanes,
+        'fields': {},
+        'shape': [{'section': 'Pipe', 'title': title, 'properties': []}],
+    }
+    return json.dumps(manifest, indent=2) + '\n'
+
+
+def _init_py(kind: str) -> str:
+    lines = [_LICENSE, '', 'from .IGlobal import IGlobal as IGlobal', 'from .IInstance import IInstance as IInstance']
+    if kind == 'source':
+        lines.append('from .IEndpoint import IEndpoint as IEndpoint')
+    return '\n'.join(lines) + '\n'
+
+
+def _iglobal_py() -> str:
+    """Shared per-task state. Loads requirements outside config mode, like every node."""
+    return (
+        _LICENSE
+        + """
+from rocketlib import IGlobalBase, OPEN_MODE
+
+
+class IGlobal(IGlobalBase):
+    def beginGlobal(self) -> None:
+        # In CONFIG mode the canvas only needs the manifest, so skip loading the driver.
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            pass
+        else:
+            import os
+            from depends import depends  # type: ignore
+
+            requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+            depends(requirements)
+"""
+    )
+
+
+def _iinstance_filter_py() -> str:
+    """Per-object worker for a filter. Ships as a pass-through; the author fills in the transform."""
+    return (
+        _LICENSE
+        + '''
+from rocketlib import IInstanceBase, Entry
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def open(self, object: Entry) -> None:
+        """Start of a new input object. Reset any per-object state here."""
+        pass
+
+    def writeText(self, text: str) -> None:
+        """Called for each text input. Transform it, then emit downstream.
+
+        Emit with ``self.instance.write*`` (writeText/writeDocuments/writeTable/...).
+        This default re-emits the text unchanged — replace it with your logic.
+        """
+        self.instance.writeText(text)
+'''
+    )
+
+
+def _iinstance_source_py() -> str:
+    """Per-object worker for a source. The IEndpoint drives it; this handles produced objects."""
+    return (
+        _LICENSE
+        + '''
+from rocketlib import IInstanceBase, Entry
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def open(self, object: Entry) -> None:
+        """Start of a new produced object. Reset any per-object state here."""
+        pass
+'''
+    )
+
+
+def _iendpoint_py(title: str) -> str:
+    """Source factory. Override beginEndpoint to start producing on the '_source' lane."""
+    return (
+        _LICENSE
+        + f'''
+from rocketlib import IEndpointBase
+
+
+class IEndpoint(IEndpointBase):
+    """Source endpoint for the {title} node.
+
+    A source originates data. Start producing from ``beginEndpoint`` (open a
+    connection, a poll loop, a webhook, ...); for each item open an object and
+    emit it on the node's output lane with ``self.write*``. This stub loads and
+    appears in the catalog; fill in production below.
+    """
+
+    def beginEndpoint(self) -> None:
+        # TODO: start producing here (open your source, then open objects and emit).
+        pass
+'''
+    )
+
+
+def _readme_md(name: str, title: str, kind: str) -> str:
+    return f"""# {title}
+
+Custom `{kind}` node (`{name}://`). Scaffolded by the RocketRide Node Builder.
+
+- `services.json` — manifest (identity, lanes, config UI). The `protocol` is the
+  frozen node id; renaming it breaks saved pipelines.
+- `IGlobal.py` / `IInstance.py`{' / `IEndpoint.py`' if kind == 'source' else ''} — the Python implementation.
+- `requirements.txt` — runtime deps (no version pins for shared libraries).
+
+Edit the stubs, then validate and test from the Node Builder.
+"""
+
+
+def _placeholder_svg(title: str) -> str:
+    """A neutral square-with-initial icon so the node renders on the canvas immediately."""
+    initial = (title.strip()[:1] or '?').upper()
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">'
+        '<rect x="2" y="2" width="20" height="20" rx="4" fill="currentColor" opacity="0.15"/>'
+        f'<text x="12" y="16" text-anchor="middle" font-size="12" font-family="sans-serif" '
+        f'fill="currentColor">{initial}</text></svg>\n'
+    )
+
+
+def _default_lanes(kind: str) -> Dict[str, List[str]]:
+    # A filter consumes and emits text by default; a source originates text on '_source'.
+    return {'_source': ['text']} if kind == 'source' else {'text': ['text']}
+
+
+def scaffold_node(
+    name: str,
+    title: Optional[str] = None,
+    kind: str = 'filter',
+    class_type: Optional[List[str]] = None,
+    lanes: Optional[Dict[str, List[str]]] = None,
+    description: Optional[str] = None,
+) -> Dict[str, str]:
+    """Render a full node folder as a ``{relative_path: file_contents}`` map.
+
+    Args:
+        name: node id / protocol key. Lowercase ``[a-z][a-z0-9_]{1,63}``. Frozen.
+        title: canvas display name (defaults to a Title Case of ``name``).
+        kind: ``'filter'`` (consumes+emits lanes) or ``'source'`` (originates data).
+        class_type: catalog category, e.g. ``['text']``. Defaults by kind.
+        lanes: input->[outputs] map. Defaults by kind.
+        description: one-line node description.
+
+    Returns:
+        Map of relative path to contents, ready to write under ``<node>/``.
+
+    Raises:
+        ValueError: on an invalid name or unknown kind.
+    """
+    if not _NAME_RE.match(name or ''):
+        raise ValueError(
+            f'invalid node name {name!r}: use lowercase letters, digits and underscores '
+            f'(start with a letter), 2-64 chars — it becomes the frozen protocol id'
+        )
+    if kind not in _KINDS:
+        raise ValueError(f'unknown node kind {kind!r}: expected one of {_KINDS}')
+
+    title = title or _prefix(name)
+    class_type = class_type or (['source'] if kind == 'source' else ['text'])
+    lanes = lanes or _default_lanes(kind)
+    description = description or ''
+
+    files: Dict[str, str] = {
+        'services.json': _services_json(name, title, kind, class_type, lanes, description),
+        '__init__.py': _init_py(kind),
+        'IGlobal.py': _iglobal_py(),
+        'requirements.txt': '',
+        'VERSION': '1.0.0\n',
+        'README.md': _readme_md(name, title, kind),
+        f'{name}.svg': _placeholder_svg(title),
+    }
+    if kind == 'source':
+        files['IInstance.py'] = _iinstance_source_py()
+        files['IEndpoint.py'] = _iendpoint_py(title)
+    else:
+        files['IInstance.py'] = _iinstance_filter_py()
+    return files

--- a/packages/ai/src/ai/account/node_scaffold.py
+++ b/packages/ai/src/ai/account/node_scaffold.py
@@ -8,10 +8,11 @@
 One source of truth for every surface. The VSCode extension, the web builder and
 Claude all call ``rrext_node_dev`` (subcommand ``scaffold``) and write the returned
 file map, so a node
-scaffolded from any host is byte-identical. A node is a folder under
-``nodes/src/nodes/<name>/`` (or a workspace ``--node_path``) holding a
-``services.json`` plus Python ``IGlobal``/``IInstance``[/``IEndpoint``] classes; the
-engine discovers it with no central registration (see docs/README-node-schema.md).
+scaffolded from any host is byte-identical. A custom node is a folder under a
+``--node_path`` ``local_nodes/`` package (a VSCode workspace or an installed
+capsule) holding a ``services.json`` plus Python ``IGlobal``/``IInstance``[/
+``IEndpoint``] classes; the engine discovers it as ``local_nodes.<name>`` with no
+central registration (see docs/README-node-schema.md and README-nodes.md).
 
 The ``name`` is the node's frozen identity: it becomes the ``protocol`` key the
 ``.pipe`` stores, so renaming it later breaks every pipe that used the node. We
@@ -57,7 +58,10 @@ def _services_json(
         'capabilities': [],
         'register': register,
         'node': 'python',
-        'path': f'nodes.{name}',
+        # Custom nodes are imported as local_nodes.<name>: they load from a --node_path
+        # 'local_nodes/' folder (VSCode workspace or an installed capsule), never the
+        # built-in 'nodes.' tree. The engine only discovers them under this import path.
+        'path': f'local_nodes.{name}',
         'prefix': _prefix(name),
         'description': [description] if description else [f'{title} node.'],
         'icon': f'{name}.svg',
@@ -296,8 +300,9 @@ def validate_node(name: str, files: Dict[str, str]) -> Dict[str, object]:
             errors.append(f"protocol {protocol!r} must be '{name}://' to match the node folder")
 
         path = manifest.get('path')
-        if path and path != f'nodes.{name}':
-            warnings.append(f"path {path!r} usually is 'nodes.{name}'")
+        if path and path != f'local_nodes.{name}':
+            # A custom node the engine can discover imports as local_nodes.<name>.
+            warnings.append(f"path {path!r} usually is 'local_nodes.{name}' for a custom node")
 
         register = manifest.get('register')
         if register not in (None, 'filter', 'endpoint'):

--- a/packages/ai/src/ai/account/node_scaffold.py
+++ b/packages/ai/src/ai/account/node_scaffold.py
@@ -22,6 +22,8 @@ import json
 import re
 from typing import Dict, List, Optional
 
+import json5  # the engine parses services.json as JSONC; validate the same way
+
 # The node name is the protocol key the pipe persists — lock it to a safe, stable
 # identifier so a rename never silently breaks saved pipelines.
 _NAME_RE = re.compile(r'^[a-z][a-z0-9_]{1,63}$')
@@ -248,3 +250,82 @@ def scaffold_node(
     else:
         files['IInstance.py'] = _iinstance_filter_py()
     return files
+
+
+# Manifest keys the loader needs to register and place a node on the canvas.
+_REQUIRED_KEYS = ('title', 'protocol', 'classType', 'register', 'path', 'prefix')
+
+
+def validate_node(name: str, files: Dict[str, str]) -> Dict[str, object]:
+    """Check a node folder before it is loaded, tested or deployed.
+
+    Mirrors what the engine loader needs, so a node that validates here is one the
+    canvas can actually register. Errors block; warnings are advisory.
+
+    Args:
+        name: the node id (folder name / protocol key).
+        files: the ``{relative_path: contents}`` map (as scaffold_node returns).
+
+    Returns:
+        ``{'ok': bool, 'errors': [str], 'warnings': [str]}``.
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    if not _NAME_RE.match(name or ''):
+        errors.append(f'invalid node name {name!r}: it becomes the frozen protocol id')
+
+    raw = files.get('services.json')
+    manifest = None
+    if raw is None:
+        errors.append('services.json is missing')
+    else:
+        try:
+            manifest = json5.loads(raw)  # JSONC, exactly as the engine reads it
+        except Exception as e:
+            errors.append(f'services.json does not parse: {e}')
+
+    if isinstance(manifest, dict):
+        for key in _REQUIRED_KEYS:
+            if key not in manifest:
+                errors.append(f'services.json missing required key {key!r}')
+
+        protocol = manifest.get('protocol')
+        if protocol and protocol != f'{name}://':
+            # The protocol is the id the .pipe stores; a mismatch with the folder breaks loading.
+            errors.append(f"protocol {protocol!r} must be '{name}://' to match the node folder")
+
+        path = manifest.get('path')
+        if path and path != f'nodes.{name}':
+            warnings.append(f"path {path!r} usually is 'nodes.{name}'")
+
+        register = manifest.get('register')
+        if register not in (None, 'filter', 'endpoint'):
+            errors.append(f"register {register!r} must be 'filter', 'endpoint', or omitted")
+
+        lanes = manifest.get('lanes')
+        if lanes is not None:
+            if not isinstance(lanes, dict) or not all(
+                isinstance(v, list) and all(isinstance(o, str) for o in v) for v in lanes.values()
+            ):
+                errors.append('lanes must map each input lane to a list of output lane names')
+
+        # A source registers an endpoint factory; a filter registers a filter.
+        if register == 'endpoint' and 'IEndpoint.py' not in files:
+            errors.append("a source (register 'endpoint') needs IEndpoint.py")
+        if register == 'filter' and 'IInstance.py' not in files:
+            errors.append("a filter (register 'filter') needs IInstance.py")
+
+        icon = manifest.get('icon')
+        if icon and icon not in files:
+            warnings.append(f'icon {icon!r} is referenced but not present in the node folder')
+
+    # Every Python file must compile, or the node cannot import.
+    for path_, body in files.items():
+        if path_.endswith('.py'):
+            try:
+                compile(body, path_, 'exec')
+            except SyntaxError as e:
+                errors.append(f'{path_} has a syntax error: {e}')
+
+    return {'ok': not errors, 'errors': errors, 'warnings': warnings}

--- a/packages/ai/src/ai/modules/task/commands/cmd_misc.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_misc.py
@@ -162,9 +162,22 @@ class MiscCommands(DAPConn):
             args = request.get('arguments', {})
             service = args.get('service', None)
 
+            # Installed node capsules the caller owns, read live from the store so a
+            # node just installed appears in the palette with no reconnect. Best-effort:
+            # a store failure never blocks the built-in catalog.
+            from ai.account import Store
+            from ai.account.node_install import installed_node_catalog, installed_node_definition
+
             if service:
                 # Retrieve the full cached entry (config schema included)
                 schema = await services_catalog.get_service(service)
+
+                # Fall back to an installed capsule before declaring not-found.
+                if not schema:
+                    try:
+                        schema = await installed_node_definition(Store.file_store(self.request_context()), service)
+                    except Exception as e:
+                        self.debug_message(f'node overlay lookup failed for {service!r}: {e}')
 
                 # Validate the service exists
                 if not schema:
@@ -172,6 +185,20 @@ class MiscCommands(DAPConn):
             else:
                 # The cached summary view: display fields + inline icons
                 schema = await services_catalog.get_summary()
+
+                # Overlay the caller's installed nodes (built-ins win on collision).
+                try:
+                    overlay_services, overlay_icons = await installed_node_catalog(
+                        Store.file_store(self.request_context())
+                    )
+                    if overlay_services:
+                        schema = {
+                            'services': {**overlay_services, **schema.get('services', {})},
+                            'icons': {**schema.get('icons', {}), **overlay_icons},
+                            'version': schema.get('version'),
+                        }
+                except Exception as e:
+                    self.debug_message(f'node overlay failed (built-in catalog stands): {e}')
 
             # Return successful response with service definition(s)
             return self.build_response(request, body=schema)

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -12,17 +12,22 @@ same ``client.call('rrext_node_dev', ...)`` and gets identical output.
 Subcommands:
   - ``scaffold`` — render a new node folder as a ``{path: contents}`` file map.
   - ``validate`` — check a node folder before it is tested or deployed.
+  - ``pack``     — build a ``.rrc`` capsule (base64) from a node file map.
+  - ``install``  — install a ``.rrc`` (base64) into the engine's ``local_nodes``.
+  - ``uninstall``— remove an installed custom node.
+  - ``list``     — list the installed custom nodes.
 
-The host writes the returned files: the VSCode extension into the user's workspace,
-the cloud/Claude engine into its own node path. Scaffold only produces text and
-touches no shared state, so it needs no permission gate; later verbs that persist
-or deploy a node carry their own team-permission checks.
+Scaffold/validate/pack only shuffle bytes; install/uninstall write to the engine's
+node path (the same ``local_nodes`` the capsule installer and ``--node_path`` share).
 """
 
+import base64
 from typing import TYPE_CHECKING, Dict, Any
 
 from ai.common.dap import DAPConn
 from ai.account.node_scaffold import scaffold_node, validate_node
+from ai.account.capsule import pack_capsule
+from ai.account.node_install import install_capsule, uninstall_node, list_installed
 
 if TYPE_CHECKING:
     pass
@@ -41,6 +46,14 @@ class NodeDevCommands(DAPConn):
             return self._node_scaffold(args)
         if subcommand == 'validate':
             return self._node_validate(args)
+        if subcommand == 'pack':
+            return self._node_pack(args)
+        if subcommand == 'install':
+            return self._node_install(args)
+        if subcommand == 'uninstall':
+            return self._node_uninstall(args)
+        if subcommand == 'list':
+            return {'nodes': list_installed()}
         raise ValueError(f'unknown rrext_node_dev subcommand {subcommand!r}')
 
     def _node_scaffold(self, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -61,3 +74,21 @@ class NodeDevCommands(DAPConn):
         name = args.get('name')
         files = args.get('files') or {}
         return validate_node(name, files)
+
+    def _node_pack(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a .rrc capsule from a node file map; return it base64-encoded."""
+        name = args.get('name')
+        files = args.get('files') or {}
+        blob = pack_capsule(name, files, version=args.get('version', '0.0.0'), declares=args.get('declares'))
+        return {'name': name, 'capsule': base64.b64encode(blob).decode('ascii')}
+
+    def _node_install(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Install a base64 .rrc capsule into the engine's local_nodes."""
+        capsule = args.get('capsule')
+        if not capsule:
+            raise ValueError('capsule (base64 .rrc) is required')
+        return install_capsule(base64.b64decode(capsule))
+
+    def _node_uninstall(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove an installed custom node by name."""
+        return uninstall_node(args.get('name'))

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -1,0 +1,54 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""NodeDevCommands: DAP router for the Node Builder (``rrext_node_dev``).
+
+The Node Builder authors custom nodes. Its logic lives in the engine so every
+surface — the VSCode extension, the web builder and Claude — drives it through the
+same ``client.call('rrext_node_dev', ...)`` and gets identical output.
+
+Subcommands:
+  - ``scaffold`` — render a new node folder as a ``{path: contents}`` file map.
+
+The host writes the returned files: the VSCode extension into the user's workspace,
+the cloud/Claude engine into its own node path. Scaffold only produces text and
+touches no shared state, so it needs no permission gate; later verbs that persist
+or deploy a node carry their own team-permission checks.
+"""
+
+from typing import TYPE_CHECKING, Dict, Any
+
+from ai.common.dap import DAPConn
+from ai.account.node_scaffold import scaffold_node
+
+if TYPE_CHECKING:
+    pass
+
+
+class NodeDevCommands(DAPConn):
+    """Node Builder command group. Mixed into ``TaskConn``."""
+
+    async def on_rrext_node_dev(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Route ``rrext_node_dev`` by ``arguments.subcommand``."""
+        args = request.get('arguments') or {}
+        subcommand = args.get('subcommand')
+        if not subcommand:
+            raise ValueError('Subcommand is required')
+        if subcommand == 'scaffold':
+            return self._node_scaffold(args)
+        raise ValueError(f'unknown rrext_node_dev subcommand {subcommand!r}')
+
+    def _node_scaffold(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Render a node folder from the request args and return the file map."""
+        name = args.get('name')
+        files = scaffold_node(
+            name=name,
+            title=args.get('title'),
+            kind=args.get('kind', 'filter'),
+            class_type=args.get('classType'),
+            lanes=args.get('lanes'),
+            description=args.get('description'),
+        )
+        return {'name': name, 'protocol': f'{name}://', 'files': files}

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -11,6 +11,7 @@ same ``client.call('rrext_node_dev', ...)`` and gets identical output.
 
 Subcommands:
   - ``scaffold`` — render a new node folder as a ``{path: contents}`` file map.
+  - ``validate`` — check a node folder before it is tested or deployed.
 
 The host writes the returned files: the VSCode extension into the user's workspace,
 the cloud/Claude engine into its own node path. Scaffold only produces text and
@@ -21,7 +22,7 @@ or deploy a node carry their own team-permission checks.
 from typing import TYPE_CHECKING, Dict, Any
 
 from ai.common.dap import DAPConn
-from ai.account.node_scaffold import scaffold_node
+from ai.account.node_scaffold import scaffold_node, validate_node
 
 if TYPE_CHECKING:
     pass
@@ -38,6 +39,8 @@ class NodeDevCommands(DAPConn):
             raise ValueError('Subcommand is required')
         if subcommand == 'scaffold':
             return self._node_scaffold(args)
+        if subcommand == 'validate':
+            return self._node_validate(args)
         raise ValueError(f'unknown rrext_node_dev subcommand {subcommand!r}')
 
     def _node_scaffold(self, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -52,3 +55,9 @@ class NodeDevCommands(DAPConn):
             description=args.get('description'),
         )
         return {'name': name, 'protocol': f'{name}://', 'files': files}
+
+    def _node_validate(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate a node folder (its file map) and return ok/errors/warnings."""
+        name = args.get('name')
+        files = args.get('files') or {}
+        return validate_node(name, files)

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -63,6 +63,68 @@ class NodeDevCommands(DAPConn):
             return {'nodes': await list_installed_in_store(self._node_store())}
         raise ValueError(f'unknown rrext_node_dev subcommand {subcommand!r}')
 
+    async def on_rrext_node_catalog(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Route ``rrext_node_catalog`` by ``arguments.subcommand``.
+
+        The catalog is public: list, get and fetch are readable by any connected
+        caller, exactly as a shop window is. Publishing and unpublishing carry the
+        caller's identity into the record.
+        """
+        args = request.get('arguments') or {}
+        subcommand = args.get('subcommand')
+        if not subcommand:
+            raise ValueError('Subcommand is required')
+        from ai.account import account
+
+        if subcommand == 'list':
+            return {'nodes': await account.catalog_list(str(args.get('search') or ''))}
+        if subcommand == 'get':
+            entry = await account.catalog_get(args.get('name'))
+            if entry is None:
+                raise ValueError(f'node {args.get("name")!r} is not published')
+            return entry
+        if subcommand == 'fetch':
+            return await account.catalog_fetch(args.get('name'), args.get('version'))
+        if subcommand == 'publish':
+            return await self._catalog_publish(args, account)
+        if subcommand == 'unpublish':
+            return await account.catalog_unpublish(args.get('name'), self._catalog_actor())
+        raise ValueError(f'unknown rrext_node_catalog subcommand {subcommand!r}')
+
+    async def _catalog_publish(self, args: Dict[str, Any], account) -> Dict[str, Any]:
+        """Publish a capsule, taking the bytes from the request or the store.
+
+        A publisher normally has the node installed already, so ``name`` alone
+        publishes what is installed: packing it again client-side would be a
+        second chance for the two to differ.
+        """
+        name = args.get('name')
+        capsule = args.get('capsule')
+        if capsule:
+            blob = base64.b64decode(capsule)
+        else:
+            from ai.account.node_install import pack_installed_node
+
+            blob = await pack_installed_node(self._node_store(), name, str(args.get('version') or '0.0.0'))
+        return await account.catalog_publish(
+            name,
+            blob,
+            self._catalog_actor(),
+            title=str(args.get('title') or ''),
+            description=str(args.get('description') or ''),
+            price_cents=int(args.get('priceCents') or 0),
+            version_label=str(args.get('version') or ''),
+        )
+
+    def _catalog_actor(self) -> Dict[str, str]:
+        """The identity recorded against a publish, denormalized for audit."""
+        info = getattr(self, '_account_info', None)
+        return {
+            'id': getattr(info, 'userId', '') or '',
+            'name': getattr(info, 'displayName', '') or '',
+            'email': getattr(info, 'email', '') or '',
+        }
+
     def _node_scaffold(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Render a node folder from the request args and return the file map."""
         name = args.get('name')

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -22,12 +22,12 @@ node path (the same ``local_nodes`` the capsule installer and ``--node_path`` sh
 """
 
 import base64
-from typing import TYPE_CHECKING, Dict, Any
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from ai.common.dap import DAPConn
 from ai.account import Store
 from ai.account.node_scaffold import scaffold_node, validate_node
-from ai.account.capsule import pack_capsule
+from ai.account.capsule import pack_capsule, read_capsule
 from ai.account.node_install import (
     install_capsule_to_store,
     uninstall_node_from_store,
@@ -53,6 +53,8 @@ class NodeDevCommands(DAPConn):
             return self._node_validate(args)
         if subcommand == 'pack':
             return self._node_pack(args)
+        if subcommand == 'inspect':
+            return self._node_inspect(args)
         if subcommand == 'install':
             return await self._node_install(args)
         if subcommand == 'uninstall':
@@ -86,6 +88,58 @@ class NodeDevCommands(DAPConn):
         files = args.get('files') or {}
         blob = pack_capsule(name, files, version=args.get('version', '0.0.0'), declares=args.get('declares'))
         return {'name': name, 'capsule': base64.b64encode(blob).decode('ascii')}
+
+    def _node_inspect(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Report what a .rrc capsule contains and whether it would load — without writing it.
+
+        Installing a capsule puts Python on disk that the task subprocess imports, so
+        the contents are worth seeing before that happens rather than after. Nothing
+        here touches the store: reading the archive already verifies the manifest, the
+        recorded digest and every payload path, and validate_node then answers whether
+        the engine could register the node at all.
+
+        Args:
+            args: ``{'capsule': base64 .rrc}``.
+
+        Returns:
+            ``{name, protocol, version, declares, sizeBytes, files: [{path, bytes}],
+            totalBytes, ok, errors, warnings, replaces}`` — ``replaces`` names the
+            installed node this would overwrite, when there is one.
+        """
+        capsule = args.get('capsule')
+        if not capsule:
+            raise ValueError('capsule (base64 .rrc) is required')
+        blob = base64.b64decode(capsule)
+        manifest, payload = read_capsule(blob)
+        name = manifest.get('name')
+
+        # validate_node reads text; a capsule may legitimately carry binary (an icon),
+        # so anything undecodable is reported by name instead of failing the read.
+        text_files: Dict[str, str] = {}
+        binary_files: List[str] = []
+        for path, body in payload.items():
+            try:
+                text_files[path] = body.decode('utf-8')
+            except UnicodeDecodeError:
+                binary_files.append(path)
+
+        verdict = validate_node(name, text_files)
+        return {
+            'name': name,
+            'protocol': manifest.get('protocol') or f'{name}://',
+            'version': manifest.get('version'),
+            'declares': manifest.get('declares') or [],
+            'sizeBytes': len(blob),
+            'totalBytes': sum(len(body) for body in payload.values()),
+            'files': sorted(
+                ({'path': path, 'bytes': len(body)} for path, body in payload.items()),
+                key=lambda entry: entry['path'],
+            ),
+            'binaryFiles': sorted(binary_files),
+            'ok': verdict.get('ok'),
+            'errors': verdict.get('errors') or [],
+            'warnings': verdict.get('warnings') or [],
+        }
 
     def _node_store(self):
         """The caller's FileStore — installs persist here and materialize per-run."""

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -6,8 +6,8 @@
 """NodeDevCommands: DAP router for the Node Builder (``rrext_node_dev``).
 
 The Node Builder authors custom nodes. Its logic lives in the engine so every
-surface — the VSCode extension, the web builder and Claude — drives it through the
-same ``client.call('rrext_node_dev', ...)`` and gets identical output.
+surface — the VSCode extension and the web builder — drives it through the same
+``client.call('rrext_node_dev', ...)`` and gets identical output.
 
 Subcommands:
   - ``scaffold`` — render a new node folder as a ``{path: contents}`` file map.

--- a/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node_dev.py
@@ -25,9 +25,14 @@ import base64
 from typing import TYPE_CHECKING, Dict, Any
 
 from ai.common.dap import DAPConn
+from ai.account import Store
 from ai.account.node_scaffold import scaffold_node, validate_node
 from ai.account.capsule import pack_capsule
-from ai.account.node_install import install_capsule, uninstall_node, list_installed
+from ai.account.node_install import (
+    install_capsule_to_store,
+    uninstall_node_from_store,
+    list_installed_in_store,
+)
 
 if TYPE_CHECKING:
     pass
@@ -49,11 +54,11 @@ class NodeDevCommands(DAPConn):
         if subcommand == 'pack':
             return self._node_pack(args)
         if subcommand == 'install':
-            return self._node_install(args)
+            return await self._node_install(args)
         if subcommand == 'uninstall':
-            return self._node_uninstall(args)
+            return await self._node_uninstall(args)
         if subcommand == 'list':
-            return {'nodes': list_installed()}
+            return {'nodes': await list_installed_in_store(self._node_store())}
         raise ValueError(f'unknown rrext_node_dev subcommand {subcommand!r}')
 
     def _node_scaffold(self, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -82,13 +87,17 @@ class NodeDevCommands(DAPConn):
         blob = pack_capsule(name, files, version=args.get('version', '0.0.0'), declares=args.get('declares'))
         return {'name': name, 'capsule': base64.b64encode(blob).decode('ascii')}
 
-    def _node_install(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Install a base64 .rrc capsule into the engine's local_nodes."""
+    def _node_store(self):
+        """The caller's FileStore — installs persist here and materialize per-run."""
+        return Store.file_store(self.request_context())
+
+    async def _node_install(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Install a base64 .rrc capsule into the caller's store (local_nodes/)."""
         capsule = args.get('capsule')
         if not capsule:
             raise ValueError('capsule (base64 .rrc) is required')
-        return install_capsule(base64.b64decode(capsule))
+        return await install_capsule_to_store(self._node_store(), base64.b64decode(capsule))
 
-    def _node_uninstall(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Remove an installed custom node by name."""
-        return uninstall_node(args.get('name'))
+    async def _node_uninstall(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove an installed custom node by name from the caller's store."""
+        return await uninstall_node_from_store(self._node_store(), args.get('name'))

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -77,6 +77,7 @@ from .commands.cmd_public import PublicCommands
 from .commands.cmd_deploy import DeployCommands
 from .commands.cmd_log import LogCommands
 from .commands.cmd_store import StoreCommands
+from .commands.cmd_node_dev import NodeDevCommands
 from ai.account.models import AccountInfo, RequestContext, resolve_task_permissions, resolve_team_permissions
 from ai.common.account import AccountPipelineValidation
 
@@ -108,6 +109,7 @@ class TaskConn(
     DeployCommands,
     LogCommands,
     StoreCommands,
+    NodeDevCommands,
     DAPConn,
 ):
     """

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -321,6 +321,10 @@ class Task(DAPBase):
         # Guard against _terminated() being called more than once
         self._terminated_called = False
 
+        # Per-run dir where installed node capsules are materialized from the
+        # store for the task subprocess to load via --node_path (removed on stop).
+        self._node_path_dir = None
+
         # Server reference
         self._server = server
 
@@ -2124,13 +2128,20 @@ class Task(DAPBase):
                         child_args.append(arg)
                         break
 
-            # Inherit parent engine's --node_path so workspace-local nodes load
-            # in the task subprocess too (Opt reads argv only, not the env).
+            # Load the caller's installed node capsules: materialize them from the
+            # store into a per-run dir and point --node_path there, so installed
+            # nodes load with no manual flag (docker/SaaS). When nothing is
+            # installed this returns None and we fall back to inheriting the parent
+            # engine's --node_path (the VSCode-workspace path) exactly as before.
             if not any(a.startswith('--node_path=') for a in child_args):
-                for arg in startup_args():
-                    if arg.startswith('--node_path='):
-                        child_args.append(arg)
-                        break
+                materialized = await self._materialize_installed_nodes()
+                if materialized:
+                    child_args.append(f'--node_path={materialized}')
+                else:
+                    for arg in startup_args():
+                        if arg.startswith('--node_path='):
+                            child_args.append(arg)
+                            break
 
             await self._send_status_update()
 
@@ -2296,6 +2307,68 @@ class Task(DAPBase):
             self.debug_message(f'Task startup failed: {e}')
             raise
 
+    async def _materialize_installed_nodes(self):
+        """Copy the caller's installed node capsules from the store into a per-run
+        dir and return it (to pass as ``--node_path``), or None when none are
+        installed. Any parent ``--node_path`` local_nodes are merged in first, and
+        installed capsules win on a name collision — so the workspace fallback
+        survives alongside installed capsules. Best-effort: failures return None.
+        """
+        from ai.account import RequestContext, Store
+
+        names = []
+        fs = None
+        try:
+            fs = Store.file_store(RequestContext.internal('node-materialize'), client_id=self.client_id)
+            listing = await fs.list_dir('local_nodes')
+            names = [e['name'] for e in listing.get('entries', []) if e.get('type') == 'dir']
+        except Exception as e:
+            self.debug_message(f'no installed node capsules to materialize: {e}')
+        if not names:
+            return None  # nothing installed → caller forwards the parent --node_path unchanged
+
+        node_dir = tempfile.mkdtemp(prefix='rr-nodes-')
+        self._node_path_dir = node_dir
+        dst_root = os.path.join(node_dir, 'local_nodes')
+        os.makedirs(dst_root, exist_ok=True)
+        open(os.path.join(dst_root, '__init__.py'), 'w', encoding='utf-8').close()
+
+        # Merge the parent --node_path workspace nodes first; store capsules win.
+        for arg in startup_args():
+            if arg.startswith('--node_path='):
+                parent_local = os.path.join(arg[len('--node_path=') :], 'local_nodes')
+                if os.path.isdir(parent_local):
+                    for entry in os.listdir(parent_local):
+                        src = os.path.join(parent_local, entry)
+                        if entry != '__pycache__' and os.path.isdir(src):
+                            shutil.copytree(src, os.path.join(dst_root, entry), dirs_exist_ok=True)
+                break
+
+        for name in names:
+            await self._copy_store_tree(fs, f'local_nodes/{name}', os.path.join(dst_root, name))
+        self.debug_message(f'materialized {len(names)} installed node(s) at {node_dir}')
+        return node_dir
+
+    async def _copy_store_tree(self, fs, store_path: str, dst: str) -> None:
+        """Recursively copy a store subtree to a local dir (utf-8-safe bytes)."""
+        os.makedirs(dst, exist_ok=True)
+        listing = await fs.list_dir(store_path)
+        for e in listing.get('entries', []):
+            src = f'{store_path}/{e["name"]}'
+            target = os.path.join(dst, e['name'])
+            if e.get('type') == 'dir':
+                await self._copy_store_tree(fs, src, target)
+            else:
+                with open(target, 'wb') as fh:
+                    fh.write(await fs.read(src))
+
+    def _cleanup_materialized_nodes(self) -> None:
+        """Remove the per-run materialized local_nodes dir, if one was created."""
+        node_dir = self._node_path_dir
+        self._node_path_dir = None
+        if node_dir:
+            shutil.rmtree(node_dir, ignore_errors=True)
+
     async def stop_task(self, reason: str = 'user') -> None:
         """
         Initiate graceful task termination with resource cleanup.
@@ -2350,3 +2423,6 @@ class Task(DAPBase):
 
         except Exception as e:
             self.debug_message(f'Unexpected error during task termination: {e}')
+        finally:
+            # Remove the per-run materialized node dir regardless of how we stopped.
+            self._cleanup_materialized_nodes()

--- a/packages/ai/tests/ai/test_capsule.py
+++ b/packages/ai/tests/ai/test_capsule.py
@@ -1,0 +1,82 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""The .rrc capsule packs and reads back a node, and refuses a malformed archive."""
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from ai.account.capsule import (
+    MANIFEST_NAME,
+    NODES_ROOT,
+    CapsuleError,
+    pack_capsule,
+    read_capsule,
+)
+from ai.account.node_scaffold import scaffold_node
+
+
+def test_pack_then_read_round_trips_a_scaffolded_node():
+    files = scaffold_node('packme', kind='source')
+    blob = pack_capsule('packme', files, version='1.2.3', declares=['network'])
+    manifest, payload = read_capsule(blob)
+    assert manifest['name'] == 'packme'
+    assert manifest['protocol'] == 'packme://'
+    assert manifest['version'] == '1.2.3'
+    assert manifest['declares'] == ['network']
+    # Payload comes back keyed relative to the node folder, byte-identical.
+    assert payload['services.json'].decode('utf-8') == files['services.json']
+    assert 'IEndpoint.py' in payload
+
+
+def test_payload_lands_under_local_nodes():
+    blob = pack_capsule('layout', scaffold_node('layout'))
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = zf.namelist()
+    assert MANIFEST_NAME in names
+    assert any(n.startswith(f'{NODES_ROOT}/layout/') for n in names)
+
+
+def test_pack_skips_cruft():
+    files = scaffold_node('clean')
+    files['__pycache__/IGlobal.cpython-312.pyc'] = 'x'
+    files['stale.pyc'] = 'x'
+    _, payload = read_capsule(pack_capsule('clean', files))
+    assert not any('__pycache__' in p or p.endswith('.pyc') for p in payload)
+
+
+def test_read_rejects_a_non_zip():
+    with pytest.raises(CapsuleError):
+        read_capsule(b'not a zip at all')
+
+
+def test_read_rejects_missing_manifest():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr(f'{NODES_ROOT}/x/services.json', '{}')
+    with pytest.raises(CapsuleError):
+        read_capsule(buf.getvalue())
+
+
+def test_read_rejects_zip_slip():
+    # A member escaping the archive root must never be accepted for extraction.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps({'name': 'x'}))
+        zf.writestr('../evil.py', 'boom')
+    with pytest.raises(CapsuleError):
+        read_capsule(buf.getvalue())
+
+
+def test_read_rejects_payload_outside_node_folder():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps({'name': 'x'}))
+        zf.writestr(f'{NODES_ROOT}/other/thing.py', 'pass')  # name mismatch
+    with pytest.raises(CapsuleError):
+        read_capsule(buf.getvalue())

--- a/packages/ai/tests/ai/test_capsule.py
+++ b/packages/ai/tests/ai/test_capsule.py
@@ -13,6 +13,7 @@ import pytest
 
 from ai.account.capsule import (
     MANIFEST_NAME,
+    MAX_CAPSULE_BYTES,
     NODES_ROOT,
     CapsuleError,
     pack_capsule,
@@ -80,3 +81,124 @@ def test_read_rejects_payload_outside_node_folder():
         zf.writestr(f'{NODES_ROOT}/other/thing.py', 'pass')  # name mismatch
     with pytest.raises(CapsuleError):
         read_capsule(buf.getvalue())
+
+
+def _zip(members, compress=False):
+    """Build a raw capsule zip from {arcname: bytes}."""
+    import io
+    import zipfile
+
+    mode = zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', mode) as zf:
+        for arc, body in members.items():
+            zf.writestr(arc, body)
+    return buf.getvalue()
+
+
+class TestPayloadKeyEscapes:
+    """
+    The archive name is checked, but the key handed back is what gets joined onto
+    a node directory. A member traversing inside an accepted prefix normalises to
+    something with no leading '..', passes the prefix check, and still escapes.
+    """
+
+    def _capsule(self, arc):
+        import json
+
+        return _zip({'capsule.json': json.dumps({'name': 'demo'}), arc: b'payload'})
+
+    def test_traversal_inside_the_node_prefix_is_rejected(self):
+        # local_nodes/demo/sub/../../evil.py -> normalises to local_nodes/evil.py
+        with pytest.raises(CapsuleError):
+            read_capsule(self._capsule('local_nodes/demo/sub/../../evil.py'))
+
+    def test_traversal_out_of_local_nodes_is_rejected(self):
+        with pytest.raises(CapsuleError):
+            read_capsule(self._capsule('local_nodes/demo/sub/../../../evil.py'))
+
+    def test_a_backslash_traversal_is_rejected(self):
+        with pytest.raises(CapsuleError):
+            read_capsule(self._capsule('local_nodes/demo/sub\\..\\..\\evil.py'))
+
+    def test_a_nested_path_still_works(self):
+        manifest, payload = read_capsule(self._capsule('local_nodes/demo/sub/helper.py'))
+        assert list(payload) == ['sub/helper.py']
+
+
+class TestExpansionBounds:
+    """
+    The byte cap bounds the compressed archive only. Every member is then read
+    whole into memory, so a few hundred KiB of zeros becomes hundreds of MiB
+    resident unless the expanded size is bounded too.
+
+    Exercised against lowered limits rather than a real bomb: building one costs
+    the test run the same memory the guard exists to prevent.
+    """
+
+    def _capsule(self, payload_size):
+        import json
+
+        return _zip(
+            {
+                'capsule.json': json.dumps({'name': 'demo'}),
+                'local_nodes/demo/big.bin': b'\0' * payload_size,
+            },
+            compress=True,
+        )
+
+    def test_expansion_beyond_the_bound_is_refused(self, monkeypatch):
+        monkeypatch.setattr('ai.account.capsule.MAX_UNCOMPRESSED_BYTES', 1024)
+        bomb = self._capsule(64 * 1024)
+        # The point of the guard: it sails past the compressed cap.
+        assert len(bomb) < MAX_CAPSULE_BYTES
+        with pytest.raises(CapsuleError):
+            read_capsule(bomb)
+
+    def test_a_payload_within_the_bound_still_reads(self, monkeypatch):
+        monkeypatch.setattr('ai.account.capsule.MAX_UNCOMPRESSED_BYTES', 1024 * 1024)
+        _, payload = read_capsule(self._capsule(4096))
+        assert len(payload['big.bin']) == 4096
+
+    def test_too_many_members_is_refused(self, monkeypatch):
+        import json
+
+        monkeypatch.setattr('ai.account.capsule.MAX_CAPSULE_MEMBERS', 5)
+        members = {'capsule.json': json.dumps({'name': 'demo'})}
+        for i in range(10):
+            members[f'local_nodes/demo/f{i}.py'] = b'x'
+        with pytest.raises(CapsuleError):
+            read_capsule(_zip(members))
+
+
+class TestManifestChecks:
+    def test_a_traversing_name_is_refused_where_it_is_read(self):
+        import json
+
+        with pytest.raises(CapsuleError):
+            read_capsule(_zip({'capsule.json': json.dumps({'name': '../evil'})}))
+
+    def test_a_non_object_manifest_is_refused(self):
+        with pytest.raises(CapsuleError):
+            read_capsule(_zip({'capsule.json': '["not", "an", "object"]'}))
+
+    def test_the_recorded_digest_is_checked(self):
+        packed = pack_capsule('demo', {'IGlobal.py': 'x = 1\n'})
+        manifest, _ = read_capsule(packed)
+        assert manifest['sha256']
+
+        # Same capsule with one byte of the payload changed.
+        import io
+        import json
+        import zipfile
+
+        src = zipfile.ZipFile(io.BytesIO(packed))
+        members = {}
+        for arc in src.namelist():
+            body = src.read(arc)
+            if arc.endswith('IGlobal.py'):
+                body = b'x = 2\n'
+            members[arc] = body
+        with pytest.raises(CapsuleError):
+            read_capsule(_zip(members))
+        assert json.loads(members['capsule.json'])['sha256'] == manifest['sha256']

--- a/packages/ai/tests/ai/test_node_catalog.py
+++ b/packages/ai/tests/ai/test_node_catalog.py
@@ -1,0 +1,202 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+The OSS node catalog: a public shelf of user-published capsules.
+
+What is pinned here is what the SaaS implementation will have to keep true when
+it swaps the file backend for DB rows: versions are immutable and never
+overwritten, a published node is visible to everyone, price is recorded but
+never enforced, removal hides without destroying, and the bytes handed back are
+checked against the digest recorded when they were published.
+"""
+
+import pytest
+
+from ai.account.node_catalog_backend import FileNodeCatalogBackend, artifact_sha256
+from ai.account.store import StorageError
+
+
+class FakeStore:
+    """In-memory IStore covering what the catalog backend calls."""
+
+    def __init__(self):
+        self.files = {}
+        self.versions = {}
+        self._counter = 0
+
+    async def write_bytes(self, filename, data):
+        self.files[filename] = bytes(data)
+        self._bump(filename)
+
+    async def read_bytes(self, filename):
+        if filename not in self.files:
+            raise StorageError(f'not found: {filename}')
+        return self.files[filename]
+
+    async def write_file(self, filename, data):
+        self.files[filename] = data.encode('utf-8') if isinstance(data, str) else data
+        self._bump(filename)
+
+    async def read_file(self, filename):
+        if filename not in self.files:
+            raise StorageError(f'not found: {filename}')
+        return self.files[filename].decode('utf-8')
+
+    async def read_file_with_metadata(self, filename):
+        return await self.read_file(filename), self.versions[filename]
+
+    async def write_file_atomic(self, filename, data, expected_version=None):
+        if expected_version is not None and self.versions.get(filename) != expected_version:
+            from ai.account.store import VersionMismatchError
+
+            raise VersionMismatchError('stale')
+        await self.write_file(filename, data)
+        return self.versions[filename]
+
+    async def list_entries(self, prefix='', *, recursive=True, include_files=True, include_dirs=True):
+        seen = set()
+        for path in self.files:
+            if not path.startswith(prefix):
+                continue
+            rest = path[len(prefix) :]
+            if '/' in rest:
+                seen.add(rest.split('/')[0])
+        return [{'name': name, 'type': 'dir'} for name in sorted(seen)]
+
+    def _bump(self, filename):
+        self._counter += 1
+        self.versions[filename] = f'v{self._counter}'
+
+
+@pytest.fixture
+def catalog():
+    return FileNodeCatalogBackend(FakeStore())
+
+
+ACTOR = {'id': 'u1', 'name': 'Ariel', 'email': 'a@example.com'}
+OTHER = {'id': 'u2', 'name': 'Someone Else', 'email': 'b@example.com'}
+
+
+async def test_publishing_makes_a_node_visible_to_everyone(catalog):
+    entry = await catalog.publish('demo_node', b'CAPSULE', ACTOR, title='Demo Node')
+
+    assert entry['name'] == 'demo_node'
+    assert entry['title'] == 'Demo Node'
+    assert entry['author']['name'] == 'Ariel'
+    assert entry['state'] == 'published'
+    # Nothing scopes the listing: a catalog anyone can read is the point.
+    assert [e['name'] for e in await catalog.list()] == ['demo_node']
+
+
+async def test_a_price_is_recorded_and_never_enforced(catalog):
+    await catalog.publish('paid_node', b'CAPSULE', ACTOR, price_cents=1900)
+    entry = (await catalog.list())[0]
+
+    assert entry['priceCents'] == 1900
+    # Fetching a paid node is not blocked here — charging is the billing
+    # layer's question, and in OSS there is no billing at all.
+    assert (await catalog.fetch('paid_node'))['capsule']
+
+
+async def test_free_is_simply_zero(catalog):
+    await catalog.publish('free_node', b'CAPSULE', ACTOR)
+    assert (await catalog.list())[0]['priceCents'] == 0
+
+
+async def test_a_negative_price_is_refused(catalog):
+    with pytest.raises(ValueError):
+        await catalog.publish('demo_node', b'CAPSULE', ACTOR, price_cents=-1)
+
+
+async def test_republishing_adds_a_version_and_never_overwrites(catalog):
+    await catalog.publish('demo_node', b'FIRST', ACTOR, version_label='1.0.0')
+    await catalog.publish('demo_node', b'SECOND', ACTOR, version_label='1.1.0')
+
+    detail = await catalog.get('demo_node')
+    assert detail['latest'] == 2
+    assert detail['versionLabel'] == '1.1.0'
+    assert [v['version'] for v in detail['versions']] == [2, 1]
+    # Both artifacts are still there, each under its own digest.
+    assert (await catalog.fetch('demo_node', version=1))['sha256'] == artifact_sha256(b'FIRST')
+    assert (await catalog.fetch('demo_node', version=2))['sha256'] == artifact_sha256(b'SECOND')
+
+
+async def test_fetch_returns_the_latest_by_default(catalog):
+    await catalog.publish('demo_node', b'FIRST', ACTOR)
+    await catalog.publish('demo_node', b'SECOND', ACTOR)
+    assert (await catalog.fetch('demo_node'))['version'] == 2
+
+
+async def test_fetch_verifies_the_recorded_digest(catalog):
+    await catalog.publish('demo_node', b'CAPSULE', ACTOR)
+    # Someone tampered with the stored artifact.
+    path = next(p for p in catalog._store.files if p.endswith('.rrc'))
+    catalog._store.files[path] = b'TAMPERED'
+
+    with pytest.raises(StorageError):
+        await catalog.fetch('demo_node')
+
+
+async def test_unpublish_hides_without_destroying(catalog):
+    await catalog.publish('demo_node', b'CAPSULE', ACTOR)
+    await catalog.unpublish('demo_node', ACTOR)
+
+    assert await catalog.list() == []
+    # The artifact still resolves, so an install someone already did keeps working.
+    assert (await catalog.fetch('demo_node'))['capsule']
+    assert [e['name'] for e in await catalog.list(include_removed=True)] == ['demo_node']
+
+
+async def test_unpublishing_something_never_published_is_refused(catalog):
+    with pytest.raises(ValueError):
+        await catalog.unpublish('demo_node', ACTOR)
+
+
+async def test_the_first_publisher_stays_the_author(catalog):
+    await catalog.publish('demo_node', b'FIRST', ACTOR)
+    await catalog.publish('demo_node', b'SECOND', OTHER)
+
+    entry = await catalog.get('demo_node')
+    assert entry['author']['name'] == 'Ariel'
+    # But the version records who actually pushed it.
+    assert entry['versions'][0]['publishedBy']['name'] == 'Someone Else'
+
+
+async def test_search_matches_what_a_person_reads_on_the_card(catalog):
+    await catalog.publish('ticket_feed', b'A', ACTOR, title='Ticket Feed', description='Reads a support queue')
+    await catalog.publish('sentiment_tagger', b'B', OTHER, title='Sentiment Tagger')
+
+    assert [e['name'] for e in await catalog.list(search='ticket')] == ['ticket_feed']
+    assert [e['name'] for e in await catalog.list(search='support queue')] == ['ticket_feed']
+    assert [e['name'] for e in await catalog.list(search='Someone')] == ['sentiment_tagger']
+    assert await catalog.list(search='nothing here') == []
+
+
+async def test_an_unsafe_name_never_becomes_a_path(catalog):
+    for bad in ('../evil', 'Demo', 'a', '', 'has space', 'x/y'):
+        with pytest.raises(ValueError):
+            await catalog.publish(bad, b'CAPSULE', ACTOR)
+
+
+async def test_an_empty_capsule_is_refused(catalog):
+    with pytest.raises(ValueError):
+        await catalog.publish('demo_node', b'', ACTOR)
+
+
+async def test_get_and_fetch_on_an_unknown_node(catalog):
+    assert await catalog.get('demo_node') is None
+    with pytest.raises(ValueError):
+        await catalog.fetch('demo_node')
+
+
+async def test_fetching_a_version_that_does_not_exist(catalog):
+    await catalog.publish('demo_node', b'CAPSULE', ACTOR)
+    with pytest.raises(ValueError):
+        await catalog.fetch('demo_node', version=7)
+
+
+async def test_an_empty_catalog_lists_nothing(catalog):
+    assert await catalog.list() == []

--- a/packages/ai/tests/ai/test_node_catalog.py
+++ b/packages/ai/tests/ai/test_node_catalog.py
@@ -242,3 +242,116 @@ async def test_a_capsule_without_metadata_still_publishes(catalog):
     assert entry['title'] == 'bare_node'
     assert entry['categories'] == []
     assert entry['icon'] == ''
+
+
+# ---------------------------------------------------------------------------
+# The engine verb: what a UI actually calls
+# ---------------------------------------------------------------------------
+
+
+class _FakeAccount:
+    """Stands in for the account facade, recording what the verb asked for."""
+
+    def __init__(self, backend):
+        self._backend = backend
+        self.calls = []
+
+    async def catalog_list(self, search='', include_removed=False):
+        self.calls.append(('list', search))
+        return await self._backend.list(search, include_removed)
+
+    async def catalog_get(self, name):
+        self.calls.append(('get', name))
+        return await self._backend.get(name)
+
+    async def catalog_fetch(self, name, version=None):
+        self.calls.append(('fetch', name, version))
+        return await self._backend.fetch(name, version)
+
+    async def catalog_publish(self, name, capsule, actor, title='', description='', price_cents=0, version_label=''):
+        self.calls.append(('publish', name, actor))
+        return await self._backend.publish(name, capsule, actor, title, description, price_cents, version_label)
+
+    async def catalog_unpublish(self, name, actor):
+        self.calls.append(('unpublish', name, actor))
+        return await self._backend.unpublish(name, actor)
+
+
+class _Caller:
+    """The verb, with an identity and an account behind it."""
+
+    from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
+
+    on_rrext_node_catalog = NodeDevCommands.on_rrext_node_catalog
+    _catalog_publish = NodeDevCommands._catalog_publish
+    _catalog_actor = NodeDevCommands._catalog_actor
+
+    def __init__(self, account):
+        self._fake_account = account
+        self._account_info = type('Info', (), {'userId': 'u1', 'displayName': 'Ariel', 'email': 'a@example.com'})()
+
+
+async def _call(caller, monkeypatch, **args):
+    """Invoke the verb with the account facade patched out."""
+    import ai.account
+
+    monkeypatch.setattr(ai.account, 'account', caller._fake_account, raising=False)
+    return await caller.on_rrext_node_catalog({'arguments': args})
+
+
+@pytest.fixture
+def verb(catalog):
+    return _Caller(_FakeAccount(catalog)), catalog
+
+
+async def test_the_verb_lists_the_catalog(verb, monkeypatch):
+    caller, catalog = verb
+    await catalog.publish('demo_node', b'CAPSULE', ACTOR)
+
+    result = await _call(caller, monkeypatch, subcommand='list')
+    assert [n['name'] for n in result['nodes']] == ['demo_node']
+
+
+async def test_the_verb_carries_the_callers_identity_into_the_record(verb, monkeypatch):
+    caller, catalog = verb
+    entry = await _call(caller, monkeypatch, subcommand='publish', name='demo_node', capsule='Q0FQU1VMRQ==')
+
+    # The author is whoever was connected, not something the client claimed.
+    assert entry['author']['name'] == 'Ariel'
+    assert entry['author']['id'] == 'u1'
+
+
+async def test_the_verb_records_the_asking_price(verb, monkeypatch):
+    caller, _ = verb
+    entry = await _call(
+        caller, monkeypatch, subcommand='publish', name='paid_node', capsule='Q0FQU1VMRQ==', priceCents=1900
+    )
+    assert entry['priceCents'] == 1900
+
+
+async def test_fetch_returns_the_capsule_a_client_can_install(verb, monkeypatch):
+    caller, catalog = verb
+    await catalog.publish('demo_node', b'CAPSULE', ACTOR)
+
+    result = await _call(caller, monkeypatch, subcommand='fetch', name='demo_node')
+    import base64
+
+    assert base64.b64decode(result['capsule']) == b'CAPSULE'
+
+
+async def test_get_on_an_unpublished_node_is_an_error_not_an_empty_card(verb, monkeypatch):
+    caller, _ = verb
+    with pytest.raises(ValueError):
+        await _call(caller, monkeypatch, subcommand='get', name='demo_node')
+
+
+async def test_an_unknown_subcommand_is_refused(verb, monkeypatch):
+    caller, _ = verb
+    with pytest.raises(ValueError):
+        await _call(caller, monkeypatch, subcommand='drop_everything')
+
+
+async def test_a_missing_subcommand_is_refused(verb, monkeypatch):
+    caller, _ = verb
+    with pytest.raises(ValueError):
+        await _call(caller, monkeypatch)

--- a/packages/ai/tests/ai/test_node_catalog.py
+++ b/packages/ai/tests/ai/test_node_catalog.py
@@ -200,3 +200,45 @@ async def test_fetching_a_version_that_does_not_exist(catalog):
 
 async def test_an_empty_catalog_lists_nothing(catalog):
     assert await catalog.list() == []
+
+
+# ---------------------------------------------------------------------------
+# Card metadata: what the store card needs, taken from the node itself
+# ---------------------------------------------------------------------------
+
+
+def _real_capsule(**over):
+    """A capsule built from a scaffolded node, so services.json is the real shape."""
+    from ai.account.capsule import pack_capsule
+    from ai.account.node_scaffold import scaffold_node
+
+    files = scaffold_node(
+        name=over.get('name', 'ticket_feed'),
+        title=over.get('title', 'Ticket Feed'),
+        kind='filter',
+        description=over.get('description', 'Reads a support queue'),
+    )
+    return pack_capsule(over.get('name', 'ticket_feed'), files)
+
+
+async def test_the_card_fields_come_from_the_node_itself(catalog):
+    # The author publishes without retyping any of it.
+    entry = await catalog.publish('ticket_feed', _real_capsule(), ACTOR)
+
+    assert entry['title'] == 'Ticket Feed'
+    assert entry['description'] == 'Reads a support queue'
+    assert entry['categories'], 'classType becomes the store category'
+    assert entry['icon'].startswith('<svg'), 'the node ships its own icon'
+
+
+async def test_an_explicit_title_overrides_the_declared_one(catalog):
+    entry = await catalog.publish('ticket_feed', _real_capsule(), ACTOR, title='Support Queue Reader')
+    assert entry['title'] == 'Support Queue Reader'
+
+
+async def test_a_capsule_without_metadata_still_publishes(catalog):
+    # Not every capsule is scaffolded; the card falls back to the name.
+    entry = await catalog.publish('bare_node', b'not-a-zip', ACTOR)
+    assert entry['title'] == 'bare_node'
+    assert entry['categories'] == []
+    assert entry['icon'] == ''

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -102,6 +102,8 @@ def test_installed_capsule_is_discovered_by_the_engine(tmp_path):
 
 from ai.account.node_install import (
     install_capsule_to_store,
+    installed_node_catalog,
+    installed_node_definition,
     list_installed_in_store,
     uninstall_node_from_store,
 )
@@ -165,6 +167,36 @@ async def test_store_uninstall():
 async def test_store_uninstall_missing_errors():
     with pytest.raises(NodeInstallError):
         await uninstall_node_from_store(FakeStore(), 'nope')
+
+
+# --- live catalog overlay (installed nodes show in the palette) --------------
+
+
+async def test_installed_node_catalog_overlay():
+    fs = FakeStore()
+    await install_capsule_to_store(fs, _capsule('ov_node'))
+    services, icons = await installed_node_catalog(fs)
+    assert 'ov_node' in services
+    assert services['ov_node']['source'] == 'capsule'  # UI badge
+    assert services['ov_node']['protocol'] == 'ov_node://'
+    # The node's SVG is offered in the icons table under a capsule id.
+    assert services['ov_node']['icon'] == 'capsule:ov_node'
+    assert 'capsule:ov_node' in icons
+
+
+async def test_installed_node_catalog_empty_store():
+    services, icons = await installed_node_catalog(FakeStore())
+    assert services == {} and icons == {}
+
+
+async def test_installed_node_definition_full_entry():
+    fs = FakeStore()
+    await install_capsule_to_store(fs, _capsule('def_node'))
+    definition = await installed_node_definition(fs, 'def_node')
+    assert definition['protocol'] == 'def_node://'
+    assert definition['source'] == 'capsule'
+    assert 'shape' in definition  # full entry, not just the summary fields
+    assert await installed_node_definition(fs, 'missing') is None
 
 
 # --- task_engine materialization (auto-load per run, no manual --node_path) ---

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from ai.account.capsule import pack_capsule
+from ai.account.capsule import CapsuleError
 from ai.account.node_install import (
     NodeInstallError,
     install_capsule,
@@ -73,7 +74,8 @@ def test_install_rejects_bad_name(tmp_path):
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, 'w') as zf:
         zf.writestr('capsule.json', json.dumps({'name': 'bad name'}))
-    with pytest.raises(NodeInstallError):
+    # Refused where the name is first read, so the installer never sees it.
+    with pytest.raises((NodeInstallError, CapsuleError)):
         install_capsule(buf.getvalue(), node_path=str(tmp_path))
 
 

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -258,3 +258,63 @@ async def test_handler_pack_returns_base64_capsule():
 
     manifest, _ = read_capsule(base64.b64decode(result['capsule']))
     assert manifest['name'] == 'packv'
+
+
+# ---------------------------------------------------------------------------
+# inspect: what a capsule contains, before anything is written
+# ---------------------------------------------------------------------------
+
+
+class _InspectHost:
+    """The handler's inspect path, without a connection or a store behind it."""
+
+    from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
+
+    _node_inspect = NodeDevCommands._node_inspect
+
+
+def _inspect(blob):
+    import base64
+
+    return _InspectHost()._node_inspect({'capsule': base64.b64encode(blob).decode('ascii')})
+
+
+def test_inspect_reports_the_contents_without_installing(tmp_path):
+    files = scaffold_node(name='demo_node', kind='filter')
+    report = _inspect(pack_capsule('demo_node', files))
+
+    assert report['name'] == 'demo_node'
+    assert report['protocol'] == 'demo_node://'
+    assert report['ok'] is True
+    assert report['errors'] == []
+    # Every file is named with its size, so the reviewer sees what lands on disk.
+    listed = {entry['path'] for entry in report['files']}
+    assert 'services.json' in listed and 'IGlobal.py' in listed
+    # __init__.py is legitimately empty; everything else carries content.
+    assert all(entry['bytes'] >= 0 for entry in report['files'])
+    assert next(e['bytes'] for e in report['files'] if e['path'] == 'services.json') > 0
+    assert report['totalBytes'] == sum(entry['bytes'] for entry in report['files'])
+    # Nothing was written anywhere.
+    assert not list(tmp_path.iterdir())
+
+
+def test_inspect_reports_a_node_that_would_not_load():
+    files = scaffold_node(name='demo_node', kind='filter')
+    files['services.json'] = '{ "title": "broken" }'  # no protocol, no register
+    report = _inspect(pack_capsule('demo_node', files))
+
+    assert report['ok'] is False
+    assert report['errors']
+
+
+def test_inspect_refuses_a_capsule_that_read_rejects():
+    import io
+    import json
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('capsule.json', json.dumps({'name': 'demo'}))
+        zf.writestr('local_nodes/demo/sub/../../evil.py', b'x')
+    with pytest.raises(CapsuleError):
+        _inspect(buf.getvalue())

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -98,7 +98,76 @@ def test_installed_capsule_is_discovered_by_the_engine(tmp_path):
     assert 'PROTOCOL=e2e_installed://' in out.stdout, f'stdout={out.stdout!r} stderr={out.stderr!r}'
 
 
-# --- handler verbs -----------------------------------------------------------
+# --- store-backed install (primary path) ------------------------------------
+
+from ai.account.node_install import (
+    install_capsule_to_store,
+    list_installed_in_store,
+    uninstall_node_from_store,
+)
+
+
+class FakeStore:
+    """In-memory stand-in for FileStore: write/read/list_dir/rmdir, same shapes."""
+
+    def __init__(self):
+        self.files = {}  # path -> bytes
+
+    async def write(self, path, data):
+        self.files[path] = data
+
+    async def read(self, path):
+        return self.files[path]
+
+    async def rmdir(self, path, recursive=False):
+        prefix = path.rstrip('/') + '/'
+        for k in [k for k in self.files if k.startswith(prefix)]:
+            del self.files[k]
+
+    async def list_dir(self, path=''):
+        prefix = (path.rstrip('/') + '/') if path else ''
+        seen = {}
+        for k in self.files:
+            if not k.startswith(prefix):
+                continue
+            rest = k[len(prefix) :]
+            name = rest.split('/')[0]
+            seen[name] = 'dir' if '/' in rest else 'file'
+        return {'entries': [{'name': n, 'type': t} for n, t in sorted(seen.items())], 'count': len(seen)}
+
+
+async def test_store_install_then_list():
+    fs = FakeStore()
+    result = await install_capsule_to_store(fs, _capsule('store_node', kind='source'))
+    assert result['name'] == 'store_node'
+    assert result['protocol'] == 'store_node://'
+    assert await list_installed_in_store(fs) == ['store_node']
+    # Files live under local_nodes/<name>/ in the store.
+    assert 'local_nodes/store_node/services.json' in fs.files
+
+
+async def test_store_install_overwrites_on_upgrade():
+    fs = FakeStore()
+    await install_capsule_to_store(fs, _capsule('up'))
+    fs.files['local_nodes/up/stale.py'] = b'old'
+    await install_capsule_to_store(fs, _capsule('up'))  # reinstall
+    assert 'local_nodes/up/stale.py' not in fs.files  # clean overwrite
+
+
+async def test_store_uninstall():
+    fs = FakeStore()
+    await install_capsule_to_store(fs, _capsule('sa_node'))
+    await install_capsule_to_store(fs, _capsule('sb_node'))
+    await uninstall_node_from_store(fs, 'sa_node')
+    assert await list_installed_in_store(fs) == ['sb_node']
+
+
+async def test_store_uninstall_missing_errors():
+    with pytest.raises(NodeInstallError):
+        await uninstall_node_from_store(FakeStore(), 'nope')
+
+
+# --- handler verbs (no store needed) -----------------------------------------
 
 from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
 
@@ -116,16 +185,3 @@ async def test_handler_pack_returns_base64_capsule():
 
     manifest, _ = read_capsule(base64.b64decode(result['capsule']))
     assert manifest['name'] == 'packv'
-
-
-async def test_handler_install_routes_to_install(tmp_path):
-    # No --node_path in the test engine's argv, so install routes through and reports it.
-    files = scaffold_node('routed', kind='filter')
-    blob = base64.b64encode(pack_capsule('routed', files)).decode('ascii')
-    with pytest.raises(NodeInstallError):
-        await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'install', 'capsule': blob}})
-
-
-async def test_handler_list_returns_nodes_key():
-    result = await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'list'}})
-    assert 'nodes' in result and isinstance(result['nodes'], list)

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -167,6 +167,45 @@ async def test_store_uninstall_missing_errors():
         await uninstall_node_from_store(FakeStore(), 'nope')
 
 
+# --- task_engine materialization (auto-load per run, no manual --node_path) ---
+
+from ai.account import Store
+from ai.modules.task import task_engine
+from ai.modules.task.task_engine import Task
+
+
+def _task():
+    t = Task.__new__(Task)  # bypass the heavy __init__; set only what materialize touches
+    t.client_id = 'tester'
+    t._node_path_dir = None
+    t.debug_message = lambda *a, **k: None
+    return t
+
+
+async def test_materialize_writes_store_nodes_and_cleans_up(monkeypatch):
+    fs = FakeStore()
+    await install_capsule_to_store(fs, _capsule('mat_node'))
+    monkeypatch.setattr(Store, 'file_store', lambda *a, **k: fs)
+    monkeypatch.setattr(task_engine, 'startup_args', lambda: [])  # no parent --node_path
+
+    t = _task()
+    node_dir = await t._materialize_installed_nodes()
+    assert node_dir
+    root = os.path.join(node_dir, 'local_nodes')
+    assert os.path.isfile(os.path.join(root, '__init__.py'))  # importable package
+    assert os.path.isfile(os.path.join(root, 'mat_node', 'services.json'))
+
+    t._cleanup_materialized_nodes()
+    assert not os.path.isdir(node_dir)
+    assert t._node_path_dir is None
+
+
+async def test_materialize_returns_none_when_nothing_installed(monkeypatch):
+    monkeypatch.setattr(Store, 'file_store', lambda *a, **k: FakeStore())
+    monkeypatch.setattr(task_engine, 'startup_args', lambda: [])
+    assert await _task()._materialize_installed_nodes() is None
+
+
 # --- handler verbs (no store needed) -----------------------------------------
 
 from ai.modules.task.commands.cmd_node_dev import NodeDevCommands

--- a/packages/ai/tests/ai/test_node_install.py
+++ b/packages/ai/tests/ai/test_node_install.py
@@ -1,0 +1,131 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Installing a capsule lands a node under local_nodes and the engine discovers it."""
+
+import base64
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ai.account.capsule import pack_capsule
+from ai.account.node_install import (
+    NodeInstallError,
+    install_capsule,
+    list_installed,
+    uninstall_node,
+)
+from ai.account.node_scaffold import scaffold_node
+
+_ENGINE = Path(__file__).resolve().parents[4] / 'dist' / 'server' / 'engine'
+
+
+def _capsule(name, kind='filter'):
+    return pack_capsule(name, scaffold_node(name, kind=kind))
+
+
+def test_install_lands_under_local_nodes(tmp_path):
+    result = install_capsule(_capsule('inst_node'), node_path=str(tmp_path))
+    assert result['name'] == 'inst_node'
+    assert result['protocol'] == 'inst_node://'
+    node_dir = tmp_path / 'local_nodes' / 'inst_node'
+    assert (node_dir / 'services.json').is_file()
+    assert (tmp_path / 'local_nodes' / '__init__.py').is_file()  # package marker
+
+
+def test_list_and_uninstall(tmp_path):
+    install_capsule(_capsule('a_node'), node_path=str(tmp_path))
+    install_capsule(_capsule('b_node'), node_path=str(tmp_path))
+    assert list_installed(str(tmp_path)) == ['a_node', 'b_node']
+    uninstall_node('a_node', node_path=str(tmp_path))
+    assert list_installed(str(tmp_path)) == ['b_node']
+
+
+def test_uninstall_missing_node_errors(tmp_path):
+    with pytest.raises(NodeInstallError):
+        uninstall_node('never_installed', node_path=str(tmp_path))
+
+
+def test_install_overwrites_cleanly_on_upgrade(tmp_path):
+    install_capsule(_capsule('up_node'), node_path=str(tmp_path))
+    stray = tmp_path / 'local_nodes' / 'up_node' / 'stale.py'
+    stray.write_text('old', encoding='utf-8')
+    install_capsule(_capsule('up_node'), node_path=str(tmp_path))  # reinstall
+    assert not stray.exists()  # clean overwrite removed the stale file
+
+
+def test_install_requires_a_node_path():
+    # With no --node_path and none passed, install cannot pick a target.
+    with pytest.raises(NodeInstallError):
+        install_capsule(_capsule('x_node'), node_path=None)
+
+
+def test_install_rejects_bad_name(tmp_path):
+    # Craft a capsule whose manifest name is unsafe; install must refuse it.
+    import io
+    import json
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('capsule.json', json.dumps({'name': 'bad name'}))
+    with pytest.raises(NodeInstallError):
+        install_capsule(buf.getvalue(), node_path=str(tmp_path))
+
+
+@pytest.mark.skipif(not _ENGINE.exists(), reason='engine binary not built')
+def test_installed_capsule_is_discovered_by_the_engine(tmp_path):
+    # End-to-end: scaffold -> pack -> install -> the engine loads it via --node_path.
+    install_capsule(_capsule('e2e_installed'), node_path=str(tmp_path))
+    out = subprocess.run(
+        [
+            str(_ENGINE),
+            f'--node_path={tmp_path}',
+            '-c',
+            'from rocketlib import getServiceDefinition; '
+            "d = getServiceDefinition('e2e_installed'); "
+            "print('PROTOCOL=' + (d.get('protocol') if isinstance(d, dict) else str(d)))",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+    )
+    assert 'PROTOCOL=e2e_installed://' in out.stdout, f'stdout={out.stdout!r} stderr={out.stderr!r}'
+
+
+# --- handler verbs -----------------------------------------------------------
+
+from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
+
+
+def _conn():
+    return NodeDevCommands.__new__(NodeDevCommands)
+
+
+async def test_handler_pack_returns_base64_capsule():
+    files = scaffold_node('packv', kind='filter')
+    result = await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'pack', 'name': 'packv', 'files': files}})
+    assert result['name'] == 'packv'
+    # The returned capsule decodes to a real .rrc a subsequent install accepts.
+    from ai.account.capsule import read_capsule
+
+    manifest, _ = read_capsule(base64.b64decode(result['capsule']))
+    assert manifest['name'] == 'packv'
+
+
+async def test_handler_install_routes_to_install(tmp_path):
+    # No --node_path in the test engine's argv, so install routes through and reports it.
+    files = scaffold_node('routed', kind='filter')
+    blob = base64.b64encode(pack_capsule('routed', files)).decode('ascii')
+    with pytest.raises(NodeInstallError):
+        await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'install', 'capsule': blob}})
+
+
+async def test_handler_list_returns_nodes_key():
+    result = await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'list'}})
+    assert 'nodes' in result and isinstance(result['nodes'], list)

--- a/packages/ai/tests/ai/test_node_scaffold.py
+++ b/packages/ai/tests/ai/test_node_scaffold.py
@@ -1,0 +1,134 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""The node scaffolder renders a valid, discoverable node folder for each kind."""
+
+import json
+
+import pytest
+
+from ai.account.node_scaffold import scaffold_node
+
+
+def _manifest(files):
+    return json.loads(files['services.json'])
+
+
+def test_filter_scaffold_shape():
+    files = scaffold_node('my_filter', kind='filter')
+    # A filter is IGlobal + IInstance, no endpoint factory.
+    assert set(files) >= {
+        'services.json',
+        '__init__.py',
+        'IGlobal.py',
+        'IInstance.py',
+        'requirements.txt',
+        'VERSION',
+        'my_filter.svg',
+    }
+    assert 'IEndpoint.py' not in files
+    m = _manifest(files)
+    assert m['register'] == 'filter'
+    assert m['protocol'] == 'my_filter://'
+    assert m['path'] == 'nodes.my_filter'
+    assert m['prefix'] == 'MyFilter'
+    assert m['classType'] == ['text']
+    assert m['icon'] == 'my_filter.svg'
+    # __init__ re-exports only the two classes a filter has.
+    assert 'IEndpoint' not in files['__init__.py']
+
+
+def test_source_scaffold_shape():
+    files = scaffold_node('my_source', kind='source')
+    # A source needs the endpoint factory and originates on the '_source' lane.
+    assert 'IEndpoint.py' in files
+    m = _manifest(files)
+    assert m['register'] == 'endpoint'
+    assert m['classType'] == ['source']
+    assert '_source' in m['lanes']
+    assert 'from .IEndpoint import IEndpoint' in files['__init__.py']
+
+
+def test_manifest_is_valid_json_with_required_keys():
+    m = _manifest(scaffold_node('good_node'))
+    for key in (
+        'title',
+        'protocol',
+        'classType',
+        'capabilities',
+        'register',
+        'node',
+        'path',
+        'prefix',
+        'lanes',
+        'shape',
+    ):
+        assert key in m, f'manifest missing required key {key!r}'
+
+
+def test_custom_title_lanes_and_description_flow_through():
+    files = scaffold_node('tagger', title='Auto Tagger', lanes={'text': ['tags']}, description='Tags text.')
+    m = _manifest(files)
+    assert m['title'] == 'Auto Tagger'
+    assert m['lanes'] == {'text': ['tags']}
+    assert m['description'] == ['Tags text.']
+    # The title drives the canvas section and the placeholder icon glyph.
+    assert m['shape'][0]['title'] == 'Auto Tagger'
+    assert '>A<' in files['tagger.svg']
+
+
+@pytest.mark.parametrize('bad', ['', 'Bad', '1node', 'has-dash', 'has space', 'a', 'x' * 65, 'UPPER'])
+def test_invalid_names_are_rejected(bad):
+    # The name is the frozen protocol id; a bad one must never reach a manifest.
+    with pytest.raises(ValueError):
+        scaffold_node(bad)
+
+
+def test_unknown_kind_is_rejected():
+    with pytest.raises(ValueError):
+        scaffold_node('ok_name', kind='transformer')
+
+
+def test_python_stubs_are_syntactically_valid():
+    # Every generated .py must at least compile — a scaffold that won't import is useless.
+    for kind in ('filter', 'source'):
+        files = scaffold_node('probe', kind=kind)
+        for path, body in files.items():
+            if path.endswith('.py'):
+                compile(body, path, 'exec')
+
+
+# --- handler dispatch (rrext_node_dev) --------------------------------------
+
+from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
+
+
+def _conn():
+    # Bypass the DAP transport __init__; the scaffold path touches no connection state.
+    return NodeDevCommands.__new__(NodeDevCommands)
+
+
+async def test_handler_scaffold_returns_file_map():
+    result = await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'scaffold', 'name': 'foo', 'kind': 'source'}})
+    assert result['name'] == 'foo'
+    assert result['protocol'] == 'foo://'
+    assert 'IEndpoint.py' in result['files']
+
+
+async def test_handler_requires_subcommand():
+    with pytest.raises(ValueError):
+        await _conn().on_rrext_node_dev({'arguments': {}})
+
+
+async def test_handler_rejects_unknown_subcommand():
+    with pytest.raises(ValueError):
+        await _conn().on_rrext_node_dev({'arguments': {'subcommand': 'nope'}})
+
+
+def test_taskconn_composes_the_node_builder_handler():
+    # The mixin must actually be wired into the connection, or the command never dispatches.
+    from ai.modules.task.task_conn import TaskConn
+
+    assert hasattr(TaskConn, 'on_rrext_node_dev')

--- a/packages/ai/tests/ai/test_node_scaffold.py
+++ b/packages/ai/tests/ai/test_node_scaffold.py
@@ -32,7 +32,7 @@ def test_filter_scaffold_shape():
     m = _manifest(files)
     assert m['register'] == 'filter'
     assert m['protocol'] == 'my_filter://'
-    assert m['path'] == 'nodes.my_filter'
+    assert m['path'] == 'local_nodes.my_filter'  # custom node import path
     assert m['prefix'] == 'MyFilter'
     assert m['classType'] == ['text']
     assert m['icon'] == 'my_filter.svg'
@@ -193,3 +193,41 @@ def test_taskconn_composes_the_node_builder_handler():
     from ai.modules.task.task_conn import TaskConn
 
     assert hasattr(TaskConn, 'on_rrext_node_dev')
+
+
+# --- discovery E2E (the scaffolded node loads in the real engine) -----------
+
+import os
+import subprocess
+from pathlib import Path
+
+_ENGINE = Path(__file__).resolve().parents[4] / 'dist' / 'server' / 'engine'
+
+
+@pytest.mark.skipif(not _ENGINE.exists(), reason='engine binary not built')
+def test_scaffolded_node_is_discovered_by_the_engine(tmp_path):
+    # The end-to-end proof: a scaffolded node, written into a --node_path 'local_nodes'
+    # package, is discovered by the C++ engine's registry (getServiceDefinition).
+    pkg = tmp_path / 'local_nodes'
+    (pkg / 'e2e_node').mkdir(parents=True)
+    (pkg / '__init__.py').write_text('', encoding='utf-8')  # marks local_nodes a package
+    for rel, body in scaffold_node('e2e_node', kind='filter').items():
+        # utf-8 explicitly: the engine may run in an ASCII locale and the stubs are utf-8.
+        (pkg / 'e2e_node' / rel).write_text(body, encoding='utf-8')
+
+    env = {**os.environ, 'PYTHONIOENCODING': 'utf-8'}
+    out = subprocess.run(
+        [
+            str(_ENGINE),
+            f'--node_path={tmp_path}',
+            '-c',
+            'from rocketlib import getServiceDefinition; '
+            "d = getServiceDefinition('e2e_node'); "
+            "print('PROTOCOL=' + (d.get('protocol') if isinstance(d, dict) else str(d)))",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert 'PROTOCOL=e2e_node://' in out.stdout, f'stdout={out.stdout!r} stderr={out.stderr!r}'

--- a/packages/ai/tests/ai/test_node_scaffold.py
+++ b/packages/ai/tests/ai/test_node_scaffold.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from ai.account.node_scaffold import scaffold_node
+from ai.account.node_scaffold import scaffold_node, validate_node
 
 
 def _manifest(files):
@@ -100,6 +100,58 @@ def test_python_stubs_are_syntactically_valid():
                 compile(body, path, 'exec')
 
 
+# --- validate_node ----------------------------------------------------------
+
+
+@pytest.mark.parametrize('kind', ['filter', 'source'])
+def test_scaffolded_node_validates_clean(kind):
+    # Whatever we scaffold must pass our own validator, or the two disagree.
+    files = scaffold_node('round_trip', kind=kind)
+    result = validate_node('round_trip', files)
+    assert result['ok'] is True, result['errors']
+    assert result['errors'] == []
+
+
+def test_validate_rejects_unparseable_manifest():
+    files = scaffold_node('broken')
+    files['services.json'] = '{ this is : not json'
+    result = validate_node('broken', files)
+    assert result['ok'] is False
+    assert any('parse' in e for e in result['errors'])
+
+
+def test_validate_rejects_protocol_folder_mismatch():
+    files = scaffold_node('real_name')
+    files['services.json'] = files['services.json'].replace('real_name://', 'other_name://')
+    result = validate_node('real_name', files)
+    assert result['ok'] is False
+    assert any('protocol' in e for e in result['errors'])
+
+
+def test_validate_flags_source_missing_endpoint():
+    files = scaffold_node('a_source', kind='source')
+    del files['IEndpoint.py']
+    result = validate_node('a_source', files)
+    assert result['ok'] is False
+    assert any('IEndpoint' in e for e in result['errors'])
+
+
+def test_validate_flags_python_syntax_error():
+    files = scaffold_node('bad_py')
+    files['IInstance.py'] = 'def open(:\n    pass'  # deliberate syntax error
+    result = validate_node('bad_py', files)
+    assert result['ok'] is False
+    assert any('syntax error' in e for e in result['errors'])
+
+
+def test_validate_warns_on_missing_icon_but_stays_ok():
+    files = scaffold_node('no_icon')
+    del files['no_icon.svg']
+    result = validate_node('no_icon', files)
+    assert result['ok'] is True  # icon is advisory, not blocking
+    assert any('icon' in w for w in result['warnings'])
+
+
 # --- handler dispatch (rrext_node_dev) --------------------------------------
 
 from ai.modules.task.commands.cmd_node_dev import NodeDevCommands
@@ -115,6 +167,15 @@ async def test_handler_scaffold_returns_file_map():
     assert result['name'] == 'foo'
     assert result['protocol'] == 'foo://'
     assert 'IEndpoint.py' in result['files']
+
+
+async def test_handler_validate_verb():
+    files = scaffold_node('viahandler', kind='filter')
+    result = await _conn().on_rrext_node_dev(
+        {'arguments': {'subcommand': 'validate', 'name': 'viahandler', 'files': files}}
+    )
+    assert result['ok'] is True
+    assert result['errors'] == []
 
 
 async def test_handler_requires_subcommand():

--- a/packages/shell/rsbuild.config.mts
+++ b/packages/shell/rsbuild.config.mts
@@ -127,6 +127,14 @@ export default defineConfig(({ command }) => {
 					'/sitemap.xml': env.ROCKETRIDE_URI.replace(/^ws/, 'http'),
 					'/robots.txt': env.ROCKETRIDE_URI.replace(/^ws/, 'http'),
 					'/llms.txt': env.ROCKETRIDE_URI.replace(/^ws/, 'http'),
+					// Backend routes the shell calls on its own origin. Without these the
+					// SPA fallback answers 404 and the boot never finishes: the auth
+					// bootstrap awaits a transport attach that can never happen, and the
+					// shell sits on its loading screen with nothing in the console.
+					// ws:true on /api — the client's socket is upgraded through here.
+					'/auth': { target: env.ROCKETRIDE_URI.replace(/^ws/, 'http') },
+					'/api': { target: env.ROCKETRIDE_URI.replace(/^ws/, 'http'), ws: true },
+					'/marketplace': { target: env.ROCKETRIDE_URI.replace(/^ws/, 'http') },
 				},
 			}),
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,40 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  apps/nodes-ui:
+    dependencies:
+      '@module-federation/rsbuild-plugin':
+        specifier: ^2.5.1
+        version: 2.5.1(@rsbuild/core@2.0.11(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.48.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.104.1)
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      rocketride:
+        specifier: workspace:*
+        version: link:../../packages/client-typescript
+      shell:
+        specifier: workspace:*
+        version: link:../../packages/shell
+    devDependencies:
+      '@rsbuild/core':
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.48.0)
+      '@rsbuild/plugin-react':
+        specifier: ~2.0.1
+        version: 2.0.1(@rsbuild/core@2.0.11(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.48.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
+      '@types/react':
+        specifier: ~18.3.31
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ~18.3.7
+        version: 18.3.7(@types/react@18.3.31)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   apps/profiler-ui:
     dependencies:
       '@module-federation/rsbuild-plugin':

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -21,6 +21,7 @@
 // ! parseArgs() is called first and global variables are set.
 // !
 const path = require('path');
+const fs = require('fs');
 
 const ROOT = path.join(__dirname, '..');
 
@@ -35,6 +36,27 @@ async function handleTermination(signal) {
 		console.log(`Log written to ${currentLogFile}`);
 	}
 	process.exit(130); // Standard exit code for SIGINT
+}
+
+/**
+ * Resolve an --overlay-root argument to a canonical absolute path.
+ *
+ * A symlinked checkout is the common case on macOS (~/rocketride pointing at a
+ * volume), and the two sides of the subdirectory check must spell the directory
+ * the same way or the overlay is rejected. Falls back to the resolved path when
+ * the directory does not exist yet — realpath cannot canonicalize what is not
+ * there, and a not-yet-created overlay root is legitimate.
+ *
+ * @param {string} value - The raw --overlay-root value.
+ * @returns {string} Absolute, symlink-resolved path.
+ */
+function resolveOverlayRoot(value) {
+	const resolved = path.resolve(value);
+	try {
+		return fs.realpathSync(resolved);
+	} catch {
+		return resolved;
+	}
 }
 
 function parseArgs(args) {
@@ -122,7 +144,11 @@ function parseArgs(args) {
 			// client:update); beats ROCKETRIDE_URI from .config/.env.
 			options.shell = arg.substring('--shell='.length);
 		} else if (arg.startsWith('--overlay-root=')) {
-			options.overlayRoot = path.resolve(arg.substring('--overlay-root='.length));
+			// Canonicalized: on a symlinked checkout (~/rocketride -> /Volumes/...)
+			// the sync's destination is realpath'd while this side was not, so the
+			// "is it inside SERVER_DIR" check compared two spellings of the same
+			// directory and failed. resolveOverlayRoot keeps both sides in one form.
+			options.overlayRoot = resolveOverlayRoot(arg.substring('--overlay-root='.length));
 			const paths = require('./lib/paths');
 			paths.BUILD_ROOT = path.join(options.overlayRoot, 'build');
 			paths.DIST_ROOT = path.join(options.overlayRoot, 'dist');
@@ -498,4 +524,10 @@ async function main() {
 	}
 }
 
-main();
+// Exported for the unit tests. Guarded so requiring this file does not run a
+// build: the tests want the argument parsing, not the side effects.
+module.exports = { resolveOverlayRoot };
+
+if (require.main === module) {
+	main();
+}

--- a/scripts/overlayRoot.test.js
+++ b/scripts/overlayRoot.test.js
@@ -1,0 +1,79 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Regression tests for --overlay-root on a symlinked checkout.
+ *
+ * The bug: the overlay root was only path.resolve'd, while the sync's
+ * destination went through realpath. On macOS a checkout is commonly reached
+ * through a symlink (~/rocketride -> /Volumes/...), so the two sides held two
+ * spellings of the same directory and the "is the overlay inside SERVER_DIR"
+ * check rejected a perfectly valid overlay.
+ *
+ * These tests pin the fix: a path reached through a symlink canonicalizes to
+ * the same string as the real one, and a root that does not exist yet still
+ * resolves rather than throwing — building into a not-yet-created overlay is
+ * legitimate.
+ *
+ * Run: node --test scripts/overlayRoot.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { resolveOverlayRoot } = require('./build');
+
+/** A real directory plus a symlink pointing at it, cleaned up by the caller. */
+function symlinkedDir() {
+	const base = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'overlay-'));
+	const real = path.join(base, 'real');
+	const link = path.join(base, 'link');
+	fs.mkdirSync(real);
+	fs.symlinkSync(real, link);
+	return { base, real, link };
+}
+
+test('a path reached through a symlink resolves to the real directory', () => {
+	const { base, real, link } = symlinkedDir();
+	try {
+		assert.equal(resolveOverlayRoot(link), real);
+		// Both spellings agree, which is the whole point.
+		assert.equal(resolveOverlayRoot(link), resolveOverlayRoot(real));
+	} finally {
+		fs.rmSync(base, { recursive: true, force: true });
+	}
+});
+
+test('a real path is returned unchanged', () => {
+	const { base, real } = symlinkedDir();
+	try {
+		assert.equal(resolveOverlayRoot(real), real);
+	} finally {
+		fs.rmSync(base, { recursive: true, force: true });
+	}
+});
+
+test('a relative path becomes absolute', () => {
+	const resolved = resolveOverlayRoot('.');
+	assert.ok(path.isAbsolute(resolved), `expected an absolute path, got ${resolved}`);
+});
+
+test('a root that does not exist yet still resolves', () => {
+	// realpath cannot canonicalize what is not there, and building into a
+	// not-yet-created overlay root is a legitimate thing to ask for.
+	const missing = path.join(os.tmpdir(), 'overlay-does-not-exist-1a2b3c', 'nested');
+	assert.equal(resolveOverlayRoot(missing), path.resolve(missing));
+});
+
+test('requiring the build script does not run a build', () => {
+	// The export exists only for these tests; main() stays behind the
+	// require.main guard, or `node --test` would kick off a real build.
+	const mod = require('./build');
+	assert.equal(typeof mod.resolveOverlayRoot, 'function');
+	assert.equal(Object.keys(mod).length, 1);
+});


### PR DESCRIPTION
## Summary

Author, install and use **custom nodes** end-to-end, from any surface, with no manual engine config. This lands the first slice of the Node Builder (Rod's vision) **and** a clean-room custom-node installer, unified on a single destination: the caller's store `local_nodes/`.

One engine command — `rrext_node_dev` — drives everything (`scaffold` · `validate` · `pack` · `install` · `uninstall` · `list`), so the **VSCode extension** and the **web/SaaS rocket-ui** do the same thing through the same `client.call`. Because the handler is transport-agnostic, any DAP client can drive it (a future MCP/agent path fits the same seam — not wired here). Installed nodes persist in the caller's store, **materialize per run** (so they load with no manual `--node_path`), and appear **live in the canvas Add-Node palette** with no reconnect.

This PR supersedes #1782 (the earlier capsule-launcher PoC): it is a fresh, additive implementation on top of the current `develop`, with no dependency on off-develop branches and no churn to existing code.

## How it flows

```mermaid
flowchart TB
    subgraph Surfaces["Authoring surfaces — same rrext_node_dev"]
        VS["VSCode extension<br/>Nodes tab"]
        WEB["Web / SaaS rocket-ui<br/>Nodes tab"]
    end

    Surfaces -->|"client.call('rrext_node_dev', …)"| H{{"rrext_node_dev handler (engine)"}}

    H --> SC["scaffold<br/>services.json + IGlobal/IInstance[/IEndpoint]"]
    H --> VAL["validate"]
    H --> PK["pack → .rrc capsule"]
    SC --> PK
    PK --> IN["install"]
    H --> IN

    IN --> ST[("caller store<br/>local_nodes/&lt;name&gt;/")]

    ST --> OV["rrext_services overlay"]
    OV --> PAL["Canvas Add-Node palette<br/>(live, source:'capsule')"]

    ST --> MAT["task_engine: materialize per run<br/>store → temp dir"]
    MAT -->|"--node_path=&lt;tmp&gt; (auto)"| RUN["task subprocess<br/>imports local_nodes.&lt;name&gt;"]

    classDef store fill:#0b7,color:#fff;
    class ST store;
```

**Key properties**
- **One destination, two channels converge.** Both "author a new node" and "install a `.rrc`" land in the same `local_nodes/` in the caller's store.
- **No manual `--node_path`.** `task_engine` materializes the store's `local_nodes/` into a per-run temp dir and passes `--node_path` to the subprocess itself; the parent engine needs no flag (works in Docker/SaaS). When nothing is installed it returns `None` and forwards the parent `--node_path` exactly as before — **zero regression**.
- **Live palette.** `rrext_services` overlays the caller's installed nodes onto the built-in catalog (tagged `source:"capsule"`, icon under `capsule:<name>`), best-effort so a store failure never blocks the built-ins.
- **Fallback preserved.** The `--node_path` filesystem install path remains for VSCode-workspace authoring.

## What changed

**Engine (`packages/ai`)**
- `account/node_scaffold.py` — render a full node folder (services.json + Python stubs + icon/VERSION) for `source`/`filter`; validate a node before test/deploy.
- `account/capsule.py` — the `.rrc` format: `pack_capsule` / `read_capsule` (with a zip-slip guard).
- `account/node_install.py` — store install/uninstall/list + the catalog overlay; `--node_path` variants kept as fallback.
- `modules/task/commands/cmd_node_dev.py` — `rrext_node_dev` router (new `NodeDevCommands` mixin on `TaskConn`).
- `modules/task/commands/cmd_misc.py` — `rrext_services` overlays installed nodes.
- `modules/task/task_engine.py` — per-run materialization + cleanup.

**UI**
- `apps/shared/.../sidebar` — the `nodes` placeholder becomes the real surface when a host wires the new `nodeBuilder` prop (list + New / Import + per-row Uninstall).
- `apps/rocket-ui/.../SidebarProvider.tsx` — web/SaaS host wiring via `client.call`.
- `apps/vscode/.../Sidebar{Provider.ts,Webview.tsx}` — extension host wiring via the postMessage bridge + native dialogs.

## SaaS decoupling

Nothing changes in the **rocketride-saas repo** beyond the submodule bump (the web UI is built from this submodule):
- The SaaS ALB is a **transparent DAP relay** (no per-command allowlist), so `rrext_node_dev` rides the same path as `rrext_services` today.
- Install writes to the existing S3-backed store (`RR_STORE_URL`) — persists and is shared across pods with no config change.

Shipping is the standard flow: land here → bump the submodule in rocketride-saas → redeploy the engine + UI artifacts.

## Tests

`./dist/server/engine -m pytest packages/ai/tests/ai/test_node_scaffold.py test_capsule.py test_node_install.py`

- Scaffold (both kinds) + validate; **discovery E2E** — a scaffolded node loads in the real C++ engine via `--node_path`.
- Capsule pack/read round-trip + malformed-archive guards.
- Store install/uninstall/list, upgrade-overwrite, per-run materialization + cleanup, and the catalog overlay.
- `install → engine discovers it` E2E.
- 133 existing `task_engine`/`task_server` tests green (no regression); TS type-checks add zero errors over baseline.

## Not in this PR (follow-ups)

- The full node **authoring editor** (Rod's DESIGN/DEVELOP/DEPLOY tabs, code-drawer, config-fields editor, live card, `produces` inference).
- `./builder` command to pack a `.rrc`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Node Builder section to the sidebar.
  - Create custom nodes from templates or import node packages.
  - View installed nodes and uninstall them with confirmation.
  - Custom nodes are automatically available during task execution.
  - Added node validation, package inspection, and capsule handling.
  - Added a Node Catalog for browsing, searching, and installing community nodes.
- **Bug Fixes**
  - Installed custom nodes now appear in service discovery and catalogs.
- **Tests**
  - Added coverage for packaging, validation, installation, discovery, catalog, and removal workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->