### PR TITLE
docs(llm_qwen): absolute URL for the sync_models link the docs site cannot resolve

### DIFF
--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -113,7 +113,7 @@ Rate-limit and connection errors are classified as retryable by the shared chat 
 
 ## Keeping the model list current
 
-Profiles are maintained by the model sync tool, see [tools/sync_models](../../../../tools/sync_models/README.md):
+Profiles are maintained by the model sync tool, see [tools/sync_models](https://github.com/rocketride-org/rocketride-server/tree/develop/tools/sync_models#readme):
 
 ```bash
 python tools/sync_models/src/sync_models.py --provider llm_qwen --enable-discovery --apply


### PR DESCRIPTION
Unblocks the docs deploy, which has failed on every run since Aug 24 with `Docusaurus found broken links!` — a single link: `/nodes/llm_qwen` referencing `../../../../tools/sync_models/README.md`, valid on GitHub but resolving outside the published docs tree.

One line: the relative path becomes the absolute GitHub URL (`tree/develop/tools/sync_models#readme`), which renders correctly in both places.

Why it matters now beyond hygiene: #2140's Bing verification tag merged but cannot reach `docs.rocketride.org` until a docs build goes green — the site has been serving a 4-day-old build. Once this lands and `docs.yml` passes, the tag renders and the Bing property can be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the model synchronization documentation link to point directly to its GitHub location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->