### PR TITLE
docs(nodes/llm_qwen): fix broken link to sync_models tool

### DIFF
--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -113,7 +113,7 @@ Rate-limit and connection errors are classified as retryable by the shared chat 
 
 ## Keeping the model list current
 
-Profiles are maintained by the model sync tool, see [tools/sync_models](../../../../tools/sync_models/README.md):
+Profiles are maintained by the model sync tool, see [tools/sync_models](https://github.com/rocketride-org/rocketride-server/blob/develop/tools/sync_models/README.md):
 
 ```bash
 python tools/sync_models/src/sync_models.py --provider llm_qwen --enable-discovery --apply


### PR DESCRIPTION
## Summary

`nodes/src/nodes/llm_qwen/README.md` linked at `../../../../tools/sync_models/README.md`, which resolves to `/tools/sync_models/README.md` in the built docs URL space. The docs subpackage does not include `tools/`, so Docusaurus's broken-link check throws and the Docs workflow fails on every push touching a node README.

Last two Docs runs on develop failed with exactly this signature:
- [33194679866](https://github.com/rocketride-org/rocketride-server/actions/runs/33194679866) (feat: hackjudge_account)
- [33188398058](https://github.com/rocketride-org/rocketride-server/actions/runs/33188398058) (seo(docs) #2140)

## Fix

Point the link at the file on GitHub. Docusaurus treats absolute URLs as external and skips them, users see the same content, docs deploy unblocks.

## Why now

Blocks the deploy of #2140 (Bing Webmaster verification meta tag) and every subsequent docs change. Since the fix is a one-line link swap in the same domain, folding it into the SEO unblock rather than filing separately.

## Out of scope

Same failure mode may exist on other node READMEs that link repo-relative into `tools/` or `scripts/`. Not sweeping in this PR to keep it minimal and reviewable. Filing a follow-up would let a bulk pass replace all such links in one go.

## Test plan

- [ ] CI: Docs workflow builds green on this PR's push to develop
- [ ] After merge: docs.rocketride.org shows the msvalidate meta tag from #2140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Qwen node documentation with a direct link to the model synchronization tool guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->