### PR TITLE
fix(task): reset the idle timer on pipeline work, and read the exit code emitters write

### DIFF
--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1489,10 +1489,7 @@ class Task(DAPBase):
         event_type = message.get('event', '')
         body = message.get('body', {})
 
-        # An engine event means the pipeline is working, so a long turn is not idle.
-        # A deploy run is excluded: its ttl is a run window, not an idle timeout, and
-        # nothing else enforces it. Raw 'output' is excluded so a node's background
-        # printing cannot hold a finished task alive.
+        # Pipeline events count as dev-task activity; deploy uses ttl as a run window.
         if self._run_kind == 'dev' and event_type.startswith('apaevt_'):
             self.reset_idle_timer()
 

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1526,8 +1526,8 @@ class Task(DAPBase):
             )
 
         elif event_type == 'apaevt_exit':
-            # Get the exit info
-            exit_code = body.get('exit_code', 1)
+            # exitCode is the spelling every emitter in dap/transport_stdio.py writes.
+            exit_code = body.get('exitCode', 1)
             exit_message = body.get('message', 'Task exited unexpectedly')
 
             # Save it

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1489,6 +1489,22 @@ class Task(DAPBase):
         event_type = message.get('event', '')
         body = message.get('body', {})
 
+        # A structured engine event means the pipeline did something, so a dev task
+        # working through a long turn is not idle. Without this the timer only moved
+        # on inbound data, and a model call or tool loop aged the task toward its TTL
+        # while it was busy.
+        #
+        # A deploy run is excluded because its ttl is a wall-clock run window, not an
+        # idle timeout: task_server_facade sends one for every scheduled run and the
+        # schedule UI sells it as "run for up to N". Resetting it there would turn
+        # every fixed window into an idle timeout.
+        #
+        # The 'output' branch below is excluded too. It carries any line a node
+        # printed, so a chatty background thread would hold a finished task alive,
+        # which is what the timer exists to prevent.
+        if self._run_kind == 'dev' and event_type.startswith('apaevt_'):
+            self.reset_idle_timer()
+
         # Handle service state changes
         if event_type == 'apaevt_status_state':
             service_up = body.get('service', False)

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1489,19 +1489,10 @@ class Task(DAPBase):
         event_type = message.get('event', '')
         body = message.get('body', {})
 
-        # A structured engine event means the pipeline did something, so a dev task
-        # working through a long turn is not idle. Without this the timer only moved
-        # on inbound data, and a model call or tool loop aged the task toward its TTL
-        # while it was busy.
-        #
-        # A deploy run is excluded because its ttl is a wall-clock run window, not an
-        # idle timeout: task_server_facade sends one for every scheduled run and the
-        # schedule UI sells it as "run for up to N". Resetting it there would turn
-        # every fixed window into an idle timeout.
-        #
-        # The 'output' branch below is excluded too. It carries any line a node
-        # printed, so a chatty background thread would hold a finished task alive,
-        # which is what the timer exists to prevent.
+        # An engine event means the pipeline is working, so a long turn is not idle.
+        # A deploy run is excluded: its ttl is a run window, not an idle timeout, and
+        # nothing else enforces it. Raw 'output' is excluded so a node's background
+        # printing cannot hold a finished task alive.
         if self._run_kind == 'dev' and event_type.startswith('apaevt_'):
             self.reset_idle_timer()
 

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -1261,3 +1261,42 @@ async def test_on_event_never_resets_idle_timer_for_a_deploy_run(event_type):
     await Task.on_event(t, {'event': event_type, 'body': {}})
 
     assert t._idle_time == 600
+
+
+@pytest.mark.asyncio
+async def test_on_event_exit_reads_the_key_the_emitters_write():
+    """A clean exit must record code 0, not the fallback.
+
+    Every emitter in dap/transport_stdio.py writes 'exitCode'. Reading 'exit_code'
+    always missed, so a clean exit took the default 1 and _update_completion_status
+    recorded the run as cancelled instead of completed, and the dashboard was told
+    the task errored.
+    """
+    t = _event_task()
+    t._status.exitCode = None
+    t._status.exitMessage = ''
+    t._status.state = 0
+    t._is_restarting = False
+    t._update_completion_status = MagicMock()
+    t._close_run_log = MagicMock()
+
+    await Task.on_event(t, {'event': 'apaevt_exit', 'body': {'exitCode': 0, 'message': 'COMPLETED'}})
+
+    assert t._status.exitCode == 0
+    assert t._status.exitMessage == 'COMPLETED'
+
+
+@pytest.mark.asyncio
+async def test_on_event_exit_still_defaults_when_no_code_is_sent():
+    """A malformed exit with no code keeps the pessimistic default."""
+    t = _event_task()
+    t._status.exitCode = None
+    t._status.exitMessage = ''
+    t._status.state = 0
+    t._is_restarting = False
+    t._update_completion_status = MagicMock()
+    t._close_run_log = MagicMock()
+
+    await Task.on_event(t, {'event': 'apaevt_exit', 'body': {'message': 'Malformed exit message'}})
+
+    assert t._status.exitCode == 1

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -1211,11 +1211,7 @@ def _event_task(run_kind='dev'):
     ],
 )
 async def test_on_event_engine_event_resets_idle_timer_for_a_dev_task(event_type):
-    """Pipeline work is activity: a dev task mid-turn is not idle.
-
-    The timer moved only on inbound data before, so a model call or tool loop aged
-    the task toward its TTL while it was busy.
-    """
+    """Pipeline work is activity: a dev task mid-turn is not idle."""
     t = _event_task()
 
     await Task.on_event(t, {'event': event_type, 'body': {}})
@@ -1225,11 +1221,7 @@ async def test_on_event_engine_event_resets_idle_timer_for_a_dev_task(event_type
 
 @pytest.mark.asyncio
 async def test_on_event_stdout_does_not_reset_idle_timer():
-    """`output` carries any line a node printed, including from a background thread.
-
-    Letting it count would hold a finished task alive, which is what the timer
-    exists to prevent.
-    """
+    """Raw node output must not count as idle-timer activity."""
     t = _event_task()
 
     await Task.on_event(t, {'event': 'output', 'body': {'output': 'still here'}})
@@ -1250,12 +1242,7 @@ async def test_on_event_debugger_passthrough_does_not_reset_idle_timer():
 @pytest.mark.asyncio
 @pytest.mark.parametrize('event_type', ['apaevt_status_counts', 'apaevt_sse', 'apaevt_trace'])
 async def test_on_event_never_resets_idle_timer_for_a_deploy_run(event_type):
-    """A deploy run's ttl is a wall-clock window, not an idle timeout.
-
-    task_server_facade sends one for every scheduled run and the schedule UI sells
-    it as "run for up to N". A source-driven run never calls _send_data, so the
-    timer never resetting is exactly what caps the window.
-    """
+    """A deploy run's ttl is a wall-clock window, not an idle timeout."""
     t = _event_task(run_kind='deploy')
 
     await Task.on_event(t, {'event': event_type, 'body': {}})
@@ -1265,13 +1252,7 @@ async def test_on_event_never_resets_idle_timer_for_a_deploy_run(event_type):
 
 @pytest.mark.asyncio
 async def test_on_event_exit_reads_the_key_the_emitters_write():
-    """A clean exit must record code 0, not the fallback.
-
-    Every emitter in dap/transport_stdio.py writes 'exitCode'. Reading 'exit_code'
-    always missed, so a clean exit took the default 1 and _update_completion_status
-    recorded the run as cancelled instead of completed, and the dashboard was told
-    the task errored.
-    """
+    """A clean exit must record code 0, not the fallback."""
     t = _event_task()
     t._status.exitCode = None
     t._status.exitMessage = ''

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -1175,3 +1175,89 @@ def test_cap_trace_payload_leaves_unserializable_payloads_alone():
     """Unserializable payloads pass through — the transport owns that error."""
     payload = {'bad': object()}
     assert cap_trace_payload(payload) is payload
+
+
+# ---------------------------------------------------------------------------
+# on_event: idle-timer reset
+# ---------------------------------------------------------------------------
+
+
+def _event_task(run_kind='dev'):
+    """A Task wired far enough to run on_event, with the handlers stubbed."""
+    from unittest.mock import AsyncMock
+
+    t = _task()
+    t._run_kind = run_kind
+    t._idle_time = 600
+    t._status_trace = []
+    # The trace branch walks the per-pipe execution stack before anything else.
+    t._status.pipeflow = SimpleNamespace(byPipe={})
+    t._update_status = MagicMock()
+    t._forward_task_event = AsyncMock()
+    t._send_status_update = AsyncMock()
+    return t
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'event_type',
+    [
+        'apaevt_status_counts',
+        'apaevt_status_object',
+        'apaevt_status_message',
+        'apaevt_status_metrics',
+        'apaevt_sse',
+        'apaevt_trace',
+    ],
+)
+async def test_on_event_engine_event_resets_idle_timer_for_a_dev_task(event_type):
+    """Pipeline work is activity: a dev task mid-turn is not idle.
+
+    The timer moved only on inbound data before, so a model call or tool loop aged
+    the task toward its TTL while it was busy.
+    """
+    t = _event_task()
+
+    await Task.on_event(t, {'event': event_type, 'body': {}})
+
+    assert t._idle_time == 0
+
+
+@pytest.mark.asyncio
+async def test_on_event_stdout_does_not_reset_idle_timer():
+    """`output` carries any line a node printed, including from a background thread.
+
+    Letting it count would hold a finished task alive, which is what the timer
+    exists to prevent.
+    """
+    t = _event_task()
+
+    await Task.on_event(t, {'event': 'output', 'body': {'output': 'still here'}})
+
+    assert t._idle_time == 600
+
+
+@pytest.mark.asyncio
+async def test_on_event_debugger_passthrough_does_not_reset_idle_timer():
+    """Debugger traffic is not pipeline work and its cadence is not ours to reason about."""
+    t = _event_task()
+
+    await Task.on_event(t, {'event': 'stopped', 'body': {}})
+
+    assert t._idle_time == 600
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('event_type', ['apaevt_status_counts', 'apaevt_sse', 'apaevt_trace'])
+async def test_on_event_never_resets_idle_timer_for_a_deploy_run(event_type):
+    """A deploy run's ttl is a wall-clock window, not an idle timeout.
+
+    task_server_facade sends one for every scheduled run and the schedule UI sells
+    it as "run for up to N". A source-driven run never calls _send_data, so the
+    timer never resetting is exactly what caps the window.
+    """
+    t = _event_task(run_kind='deploy')
+
+    await Task.on_event(t, {'event': event_type, 'body': {}})
+
+    assert t._idle_time == 600

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -1138,3 +1138,99 @@ def test_build_task_account_info_populates_organization():
     # The task's own team is present with the granted permissions, so a pk_
     # subscriber resolves to a non-empty permission list for its own task.
     assert resolve_task_permissions(info, 'team-1') == ['task.data']
+
+
+# ---------------------------------------------------------------------------
+# _monitor_ttl: the counter itself, and the two halves of the trade
+# ---------------------------------------------------------------------------
+
+
+def _ttl_task(*, ttl, idle):
+    """A task stand-in whose ``_idle_time`` is a real int, not a MagicMock attribute.
+
+    The existing TTL tests assert only on ``stop_task``, so a mutation of the
+    counter passes silently. These assert the counter.
+    """
+    task = MagicMock()
+    task.is_task_complete = MagicMock(return_value=False)
+    task._ttl = ttl
+    task._idle_time = idle
+    return task
+
+
+async def _one_ttl_cycle(monkeypatch, ts, *, check=60):
+    """Drive exactly one iteration of ``_monitor_ttl`` and stop."""
+    from ai.modules.task import task_server as ts_mod
+
+    counter = {'n': 0}
+
+    async def _sleep_one_then_stop(_delay):
+        counter['n'] += 1
+        if counter['n'] > 1:
+            raise _LoopBreak
+
+    monkeypatch.setattr(ts_mod.asyncio, 'sleep', _sleep_one_then_stop)
+    monkeypatch.setattr(ts_mod, 'CONST_TTL_CHECK', check)
+
+    with pytest.raises(_LoopBreak):
+        await TaskServer._monitor_ttl(ts)
+
+
+@pytest.mark.asyncio
+async def test_monitor_ttl_ages_a_silent_task(monkeypatch):
+    """A task nothing has touched still ages, so the reaper is not disabled."""
+    ts = _make_server()
+    ts.stop_task = AsyncMock()
+    task = _ttl_task(ttl=900, idle=0)
+    ts._task_control['tk_quiet'] = _make_control(token='tk_quiet', task=task)
+
+    await _one_ttl_cycle(monkeypatch, ts)
+
+    assert task._idle_time == 60, 'a silent task must accumulate idle time'
+    ts.stop_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_monitor_ttl_reaps_a_task_that_stayed_silent(monkeypatch):
+    """The other half of the trade: an abandoned task is still collected."""
+    ts = _make_server()
+    ts.stop_task = AsyncMock()
+    task = _ttl_task(ttl=900, idle=860)
+    ts._task_control['tk_abandoned'] = _make_control(token='tk_abandoned', task=task)
+
+    await _one_ttl_cycle(monkeypatch, ts)
+
+    ts.stop_task.assert_awaited_once_with('tk_abandoned', reason='ttl')
+
+
+@pytest.mark.asyncio
+async def test_monitor_ttl_spares_a_task_whose_timer_was_reset(monkeypatch):
+    """Work resets the counter, so a busy task survives a cycle it would have died in.
+
+    This is the whole point of the change: on_event zeroes ``_idle_time`` for a
+    working dev task, and the reaper then sees it as young.
+    """
+    ts = _make_server()
+    ts.stop_task = AsyncMock()
+    task = _ttl_task(ttl=900, idle=860)
+    task._idle_time = 0  # what on_event does when the pipeline reports work
+    ts._task_control['tk_busy'] = _make_control(token='tk_busy', task=task)
+
+    await _one_ttl_cycle(monkeypatch, ts)
+
+    assert task._idle_time == 60
+    ts.stop_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_monitor_ttl_leaves_a_zero_ttl_counter_alone(monkeypatch):
+    """``ttl: 0`` skips before the increment, so its idle counter never moves."""
+    ts = _make_server()
+    ts.stop_task = AsyncMock()
+    task = _ttl_task(ttl=0, idle=0)
+    ts._task_control['tk_immortal'] = _make_control(token='tk_immortal', task=task)
+
+    await _one_ttl_cycle(monkeypatch, ts)
+
+    assert task._idle_time == 0
+    ts.stop_task.assert_not_awaited()

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -1146,11 +1146,7 @@ def test_build_task_account_info_populates_organization():
 
 
 def _ttl_task(*, ttl, idle):
-    """A task stand-in whose ``_idle_time`` is a real int, not a MagicMock attribute.
-
-    The existing TTL tests assert only on ``stop_task``, so a mutation of the
-    counter passes silently. These assert the counter.
-    """
+    """A task stand-in whose ``_idle_time`` is a real int, not a MagicMock attribute."""
     task = MagicMock()
     task.is_task_complete = MagicMock(return_value=False)
     task._ttl = ttl
@@ -1205,11 +1201,7 @@ async def test_monitor_ttl_reaps_a_task_that_stayed_silent(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_monitor_ttl_spares_a_task_whose_timer_was_reset(monkeypatch):
-    """Work resets the counter, so a busy task survives a cycle it would have died in.
-
-    This is the whole point of the change: on_event zeroes ``_idle_time`` for a
-    working dev task, and the reaper then sees it as young.
-    """
+    """Work resets the counter, so a busy task survives a cycle it would have died in."""
     ts = _make_server()
     ts.stop_task = AsyncMock()
     task = _ttl_task(ttl=900, idle=860)


### PR DESCRIPTION
## Summary

Two fixes in `Task.on_event`, one commit each.

- Idle timer: `reset_idle_timer` has one caller, so a task working through a long turn ages toward its TTL and gets killed mid-turn. Engine events now reset it, for dev runs only.
- Exit code: `on_event` reads `body['exit_code']`, but every emitter writes `exitCode`, so a clean exit was recorded as a cancelled run.

## Type

fix

## Idle timer

`reset_idle_timer` (`task_engine.py:1706`) says it should fire on "any activity that indicates it's in active use". Its only caller is `task_engine.py:734`, inside `_send_data`, reached from `cmd_data.py:144` and `cmd_cprofile.py:134`. So activity means a client pushed data, and `_idle_time` measures time since the last inbound request rather than time since anything happened. `_monitor_ttl` then kills a task that was busy the whole time: a model call, a tool loop, a transcription. That is why a conversational app ends up on `ttl: 0`, which leaks tasks nothing reclaims.

```python
if self._run_kind == 'dev' and event_type.startswith('apaevt_'):
    self.reset_idle_timer()
```

Nothing arrives on a timer, so the reaper still works. Every `apaevt_*` event is built from a subprocess stdout line by `dap/transport_stdio.py:_process_message`. The engine monitor's 2.5s thread (`Monitor.cpp:33-50`) is a throttle that only emits when work dirtied a counter. `apaevt_status_metrics` fires at object boundaries (`web/metrics/taskhook.py:101`), and the 0.25s `CONST_METRICS_SAMPLE_INTERVAL` loop is server side and never re-enters `on_event`. There is no heartbeat on the stdio channel, so a pipeline that is started and left alone emits nothing and still ages out.

The `dev` guard protects the other meaning of `ttl`. `task_server_facade.py:128-134` sends `ttl` on every deploy run as a run window. A scheduled run never calls `_send_data`, so the timer never resetting is exactly what enforces that window, shown in the UI as "run for up to N" (`SchedulePanel.tsx:296`). Resetting it there would quietly turn every fixed window into an idle timeout.

The `apaevt_` prefix excludes `output` and debugger traffic. `output` carries any line a node printed, so without that guard a background thread printing in a loop could keep a finished task alive for ever.

This does mean a task emitting `apaevt_*` in a loop counts as active, which is the intent: those events exist only because the pipeline produced them. The case that matters is a slow start emitting `apaevt_status_download` through a long pip install, where surviving is the behaviour we want.

`_monitor_ttl`, `_ttl` resolution and the `reason='ttl'` stop path are untouched, so a TTL stop still records as completed rather than cancelled (`run_log.py:1148`).

## Exit code

`on_event` read `body.get('exit_code', 1)`. Every emitter in `dap/transport_stdio.py` (`:895, :914, :928, :939`) writes `exitCode`. The read always missed, so a clean exit took the default 1, the completion branch treated it as a failure, and the run was recorded as Stopped and CANCELLED with an error pushed to the dashboard.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes (ran `ai` and `nodes`, not the C++ or SDK suites, which this does not touch)

`builder ai:test` 2492 passed, 0 failed, from a 2475 baseline. `builder nodes:test` 3831 passed.

`on_event` had no direct test caller, so these are the first. Six event families reset the timer for a dev task, `output` and debugger passthrough do not, and a deploy run is never reset.

The TTL tests now assert the counter rather than only whether `stop_task` was awaited. The two existing ones use a `MagicMock` task, so `_idle_time` mutations passed silently. Added: a silent task ageing, an abandoned one reaped, a task whose timer was reset surviving a cycle it would otherwise have died in, and `ttl: 0` untouched.

Removing the reset fails 6 of the new tests, removing only the deploy guard fails 3, removing only the `apaevt_` guard fails 2, and reverting the exit key fails 1.

### Checked on a real engine

Both fixes were run against a real engine, a real pipeline and a live client, comparing this branch to the same build with one line reverted. The harness shortens `CONST_TTL_CHECK` and records which call site cleared the counter. No product code is stubbed.

Idle timer, running a source driven scan with no data sent to the task at any point:

| build | resets from `on_event` | resets from `_send_data` |
| --- | --- | --- |
| branch | 8 | 0 |
| reset removed | 0 | 0 |

Pipeline work alone resets the timer, and the data path is never involved. Reading `idleTime` from the dashboard, a silent task still shows 60 after a quiet cycle, so the reaper still ages it.

Exit code, same pipeline run to natural completion with no stop requested:

| build | recorded |
| --- | --- |
| branch | `exitCode=0`, Completed, state 5 |
| key reverted | `exitCode=1`, Stopped, state 6 |

## Not in this PR

`ttl` still means two things: an idle timeout for dev runs, a run window for deploy runs. Splitting it is a breaking change to the public API rather than a rename. It is a documented parameter in the Python SDK with a different meaning in each place (`mixins/execution.py:137` "for idle pipelines" against `deploy.py:397` "Run window in seconds"), it is persisted in stored schedules (`types/deploy.py:79`), and it also reaches the TypeScript SDK, the dashboard type and the schedule UI. Changing it needs a migration for schedules already saved and a naming decision that is not mine to make. Keeping the two meanings apart by `run_kind` fixes the bug without touching the wire API. Happy to raise the split as a separate issue.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #2093


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development task activity now correctly refreshes idle tracking for structured events.
  * Deployment tasks and generic output or debugger events retain their existing idle-time behavior.
  * Clean task exits are now recorded with the correct exit status.
  * Idle task monitoring more reliably identifies abandoned tasks while preserving active tasks.

* **Tests**
  * Added coverage for idle timers, task expiration, active and silent tasks, zero-timeout tasks, and exit-status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

