### PR TITLE
fix(sync_models): stop shipping a max_tokens the provider rejects

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -94,6 +94,10 @@ jobs:
       # Strict sync: only providers whose API key is configured. Native API
       # discovers and smoke-tests new models. No OpenRouter pollution.
       - name: Sync providers WITH key (strict, native API)
+        id: sync_with_key
+        # The catalogue gate exits non-zero on findings. Keep going so the sync PR is
+        # still opened with those findings in its body; the job is failed at the end.
+        continue-on-error: true
         if: steps.partition.outputs.with_key != ''
         shell: bash
         run: |
@@ -116,6 +120,8 @@ jobs:
       # (no client). Output may include OpenRouter routing aliases — review
       # the PR body before merging.
       - name: Sync providers WITHOUT key (fallback discovery)
+        id: sync_without_key
+        continue-on-error: true
         if: steps.partition.outputs.without_key != ''
         shell: bash
         run: |
@@ -124,6 +130,7 @@ jobs:
       # Combine the two PR bodies and write a single SYNC_OUTPUT to GITHUB_ENV.
       # This overrides whatever each --pr-body step appended individually.
       - name: Compose combined PR body
+        if: always()
         shell: bash
         run: |
           {
@@ -145,6 +152,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Create Pull Request
+        if: always()
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           title: 'chore(models): sync LLM model lists'
@@ -156,3 +164,12 @@ jobs:
           labels: |
             automated
             models
+
+      # The PR is opened first (above) so findings reach a human even on a bad run;
+      # the job is failed here so the run is visibly red rather than silently green.
+      - name: Fail if a sync step reported findings
+        if: always() && (steps.sync_with_key.outcome == 'failure' || steps.sync_without_key.outcome == 'failure')
+        shell: bash
+        run: |
+          echo "::error::A sync step exited non-zero — a provider failed to sync, or the catalogue gate found a profile sending its context window as max_tokens. See the step logs and the PR body."
+          exit 1

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -259,7 +259,7 @@
 				"title": "GPT-5.1 Chat Latest",
 				"model": "gpt-5.1-chat-latest",
 				"modelSource": "provider",
-				"modelTotalTokens": 16384, // manual
+				"modelTotalTokens": 128000, // manual
 				"modelOutputTokens": 16384, // manual
 				"apikey": ""
 			},
@@ -267,7 +267,7 @@
 				"title": "GPT-5.2 Chat Latest",
 				"model": "gpt-5.2-chat-latest",
 				"modelSource": "provider",
-				"modelTotalTokens": 16384, // manual
+				"modelTotalTokens": 128000, // manual
 				"modelOutputTokens": 16384, // manual
 				"apikey": ""
 			},
@@ -275,7 +275,7 @@
 				"title": "GPT-5.3 Chat Latest",
 				"model": "gpt-5.3-chat-latest",
 				"modelSource": "provider",
-				"modelTotalTokens": 16384, // manual
+				"modelTotalTokens": 128000, // manual
 				"modelOutputTokens": 16384, // manual
 				"apikey": ""
 			},
@@ -283,7 +283,7 @@
 				"title": "GPT-5 Chat Latest",
 				"model": "gpt-5-chat-latest",
 				"modelSource": "provider",
-				"modelTotalTokens": 16384, // manual
+				"modelTotalTokens": 128000, // manual
 				"modelOutputTokens": 16384, // manual
 				"apikey": ""
 			},

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -23,6 +23,7 @@ from ai.common.validation import (
     validate_max_tokens,
     validate_prompt,
     check_output_token_config,
+    hand_supplied_token_fields,
 )
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR, dispatch_native_chat_stream
 from ai.common.llm_adapter import LangChainAdapter, NativeOpenAIResponsesAdapter, drive_adapter
@@ -104,14 +105,12 @@ class ChatBase:
         self._modelTotalTokens = config.get('modelTotalTokens', 16384)  # Default to 16K if not specified
         self._modelOutputTokens = config.get('modelOutputTokens', 4096)  # Default to 4K if not specified
 
-        # Validate and clamp output tokens against known safe maximums
-        self._modelOutputTokens = validate_max_tokens(self._modelOutputTokens, self._modelTotalTokens)
-
-        # A custom profile carries whatever the author typed and the model sync never sees
-        # it, so check the resolved limits here. Most custom profiles name a model that is
-        # also in the catalogue ("gpt-4.1-mini"), which gives a real completion limit to
-        # compare against; without one, fall back to spotting the whole window being sent.
-        if connConfig.get('profile') == 'custom':
+        # Check what the author wrote, before the clamp below rewrites it — a value the
+        # provider would reject can be clamped into a plausible-looking one, and then
+        # there is nothing left to report. Only when a token field was hand-supplied:
+        # catalogue profiles are checked by the model sync, and warning about those on
+        # every run would be noise. Hand-written config is what the sync never sees.
+        if hand_supplied_token_fields(connConfig):
             problem = check_output_token_config(
                 self._model,
                 self._modelOutputTokens,
@@ -120,6 +119,9 @@ class ChatBase:
             )
             if problem:
                 warning(f'{provider}: {problem}')
+
+        # Validate and clamp output tokens against known safe maximums
+        self._modelOutputTokens = validate_max_tokens(self._modelOutputTokens, self._modelTotalTokens)
 
         # We really can't work with a model that has a very small output window
         if self._modelOutputTokens < 1024:

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -18,7 +18,12 @@ from rocketlib import debug, warning
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
 from ai.common.util import parseJson
-from ai.common.validation import validate_model_name, validate_max_tokens, validate_prompt
+from ai.common.validation import (
+    validate_model_name,
+    validate_max_tokens,
+    validate_prompt,
+    check_output_token_config,
+)
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR, dispatch_native_chat_stream
 from ai.common.llm_adapter import LangChainAdapter, NativeOpenAIResponsesAdapter, drive_adapter
 
@@ -101,6 +106,20 @@ class ChatBase:
 
         # Validate and clamp output tokens against known safe maximums
         self._modelOutputTokens = validate_max_tokens(self._modelOutputTokens, self._modelTotalTokens)
+
+        # A custom profile carries whatever the author typed and the model sync never sees
+        # it, so check the resolved limits here. Most custom profiles name a model that is
+        # also in the catalogue ("gpt-4.1-mini"), which gives a real completion limit to
+        # compare against; without one, fall back to spotting the whole window being sent.
+        if connConfig.get('profile') == 'custom':
+            problem = check_output_token_config(
+                self._model,
+                self._modelOutputTokens,
+                self._modelTotalTokens,
+                Config.getNodeProfiles(provider),
+            )
+            if problem:
+                warning(f'{provider}: {problem}')
 
         # We really can't work with a model that has a very small output window
         if self._modelOutputTokens < 1024:

--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -68,6 +68,19 @@ class Config:
         return Config._config
 
     @staticmethod
+    def getNodeProfiles(logicalType: str) -> Dict:
+        """
+        Get the preconfig.profiles mapping for a node, or {} if it has none.
+
+        Lets callers look a model name up in the catalogue without going through
+        profile resolution.
+        """
+        service = getServiceDefinition(logicalType)
+        if service is None or 'preconfig' not in service:
+            return {}
+        return service['preconfig'].get('profiles') or {}
+
+    @staticmethod
     def getNodeConfig(logicalType: str, connConfig: Dict):
         """
         Get the configuration for a connector.

--- a/packages/ai/src/ai/common/validation.py
+++ b/packages/ai/src/ai/common/validation.py
@@ -12,7 +12,7 @@ it is sent to LLM provider APIs. It guards against:
 """
 
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from rocketlib import debug
 
@@ -122,6 +122,64 @@ def validate_model_name(model: Optional[str]) -> Optional[str]:
         )
 
     return model
+
+
+def check_output_token_config(
+    model: str,
+    output_tokens: int,
+    total_tokens: int,
+    profiles: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Report a max_tokens value the provider is likely to reject.
+
+    A hand-written profile carries whatever the author typed, and nothing checks
+    it before the request goes out. Providers that cap completions below their
+    context window answer with a 400 naming a limit the author never saw.
+
+    Two checks, in order of usefulness:
+
+    1. If the model name matches a catalogue profile that states a completion
+       limit, anything above that limit is reported with both numbers. Catalogue
+       entries whose own output equals their window are skipped — that value is
+       the window, not a limit, and cannot be compared against.
+    2. Otherwise, an output limit equal to the context window is reported: it
+       sends the whole window as max_tokens. Legitimate where the provider has
+       no separate completion limit, hence a warning rather than an error.
+
+    Args:
+        model: Configured model name.
+        output_tokens: Resolved max output tokens.
+        total_tokens: Resolved context window.
+        profiles: The node's "preconfig.profiles" mapping, used to look the
+            model up. Any mapping of profile-key to a ``.get``-able profile.
+
+    Returns:
+        The message to warn with, or None when nothing looks wrong.
+    """
+    catalogue_limit: Optional[int] = None
+    for profile in (profiles or {}).values():
+        if not hasattr(profile, 'get') or profile.get('model') != model:
+            continue
+        limit = profile.get('modelOutputTokens')
+        if isinstance(limit, int) and not isinstance(limit, bool) and limit != profile.get('modelTotalTokens'):
+            catalogue_limit = limit
+            break
+
+    if catalogue_limit is not None:
+        if output_tokens > catalogue_limit:
+            return (
+                f'modelOutputTokens ({output_tokens:,}) exceeds the {catalogue_limit:,} that {model} accepts. '
+                'The provider will reject the request.'
+            )
+        return None
+
+    if output_tokens == total_tokens:
+        return (
+            f'modelOutputTokens ({output_tokens:,}) equals modelTotalTokens, so the whole context window is sent '
+            f'as max_tokens. Set the real completion limit for {model} unless this provider accepts max_tokens '
+            'up to its context window.'
+        )
+    return None
 
 
 def validate_max_tokens(output_tokens: int, total_tokens: int) -> int:

--- a/packages/ai/src/ai/common/validation.py
+++ b/packages/ai/src/ai/common/validation.py
@@ -124,6 +124,36 @@ def validate_model_name(model: Optional[str]) -> Optional[str]:
     return model
 
 
+_TOKEN_FIELDS = ('modelTotalTokens', 'modelOutputTokens')
+
+
+def hand_supplied_token_fields(connConfig: Optional[Dict[str, Any]]) -> bool:
+    """True if the pipeline author wrote a token limit into this node's config.
+
+    A node's config arrives in several shapes — keyed under a named profile, nested
+    under the default profile's name, or as direct top-level fields — and a profile
+    named "custom" is only one of them (``llm_openai_api`` has "custom" as its
+    default, so an omitted key resolves there too). Rather than matching on the
+    profile string, look for the token fields themselves at either level: their
+    presence is what makes a value the author's rather than the catalogue's.
+
+    Args:
+        connConfig: The node's raw connection config, before profile resolution.
+
+    Returns:
+        True when a token field appears at the top level or in a nested block.
+    """
+    if not hasattr(connConfig, 'get'):
+        return False
+
+    def _has(block: Any) -> bool:
+        return hasattr(block, 'get') and any(block.get(field) is not None for field in _TOKEN_FIELDS)
+
+    if _has(connConfig):
+        return True
+    return any(_has(value) for value in connConfig.values())
+
+
 def check_output_token_config(
     model: str,
     output_tokens: int,
@@ -165,12 +195,21 @@ def check_output_token_config(
             catalogue_limit = limit
             break
 
+    if catalogue_limit is not None and output_tokens > catalogue_limit:
+        return (
+            f'modelOutputTokens ({output_tokens:,}) exceeds the {catalogue_limit:,} that {model} accepts. '
+            'The provider will reject the request.'
+        )
+
+    if output_tokens > total_tokens:
+        # About to be clamped down to the window. Silent otherwise, and it reads at
+        # run time as the model simply refusing to write more.
+        return (
+            f'modelOutputTokens ({output_tokens:,}) is above modelTotalTokens ({total_tokens:,}) '
+            f'and will be capped at the smaller value.'
+        )
+
     if catalogue_limit is not None:
-        if output_tokens > catalogue_limit:
-            return (
-                f'modelOutputTokens ({output_tokens:,}) exceeds the {catalogue_limit:,} that {model} accepts. '
-                'The provider will reject the request.'
-            )
         return None
 
     if output_tokens == total_tokens:

--- a/packages/ai/src/ai/common/validation.py
+++ b/packages/ai/src/ai/common/validation.py
@@ -195,18 +195,24 @@ def check_output_token_config(
             catalogue_limit = limit
             break
 
-    if catalogue_limit is not None and output_tokens > catalogue_limit:
+    # What validate_max_tokens will actually send. The rejection warning has to be
+    # decided on this, not on the configured value: a 128,000 output under a 16,384
+    # window goes out as 16,384, which the provider accepts, so claiming it will be
+    # rejected would be wrong. The cap itself is still worth reporting, below.
+    effective_tokens = min(output_tokens, total_tokens, MAX_OUTPUT_TOKENS)
+
+    if catalogue_limit is not None and effective_tokens > catalogue_limit:
         return (
-            f'modelOutputTokens ({output_tokens:,}) exceeds the {catalogue_limit:,} that {model} accepts. '
+            f'modelOutputTokens ({effective_tokens:,}) exceeds the {catalogue_limit:,} that {model} accepts. '
             'The provider will reject the request.'
         )
 
-    if output_tokens > total_tokens:
-        # About to be clamped down to the window. Silent otherwise, and it reads at
-        # run time as the model simply refusing to write more.
+    if effective_tokens < output_tokens:
+        # Capped before the request. Silent otherwise, and it reads at run time as
+        # the model simply refusing to write more.
         return (
-            f'modelOutputTokens ({output_tokens:,}) is above modelTotalTokens ({total_tokens:,}) '
-            f'and will be capped at the smaller value.'
+            f'modelOutputTokens ({output_tokens:,}) is above the {effective_tokens:,} that can be sent '
+            f'and will be capped at that value.'
         )
 
     if catalogue_limit is not None:

--- a/packages/ai/tests/ai/common/test_output_token_config.py
+++ b/packages/ai/tests/ai/common/test_output_token_config.py
@@ -1,0 +1,59 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit: the custom-profile check for a max_tokens the provider would reject."""
+
+from ai.common.validation import check_output_token_config
+
+
+PROFILES = {
+    'gpt-4-1-mini': {'model': 'gpt-4.1-mini', 'modelTotalTokens': 1047576, 'modelOutputTokens': 32768},
+    'gpt-4-turbo': {'model': 'gpt-4-turbo', 'modelTotalTokens': 128000, 'modelOutputTokens': 4096},
+    # Its own output equals its window — no limit to compare against.
+    'grok-3': {'model': 'grok-3', 'modelTotalTokens': 131072, 'modelOutputTokens': 131072},
+    'custom': {'model': '', 'modelTotalTokens': 16384},
+}
+
+
+def test_flags_output_above_the_catalogue_limit():
+    problem = check_output_token_config('gpt-4.1-mini', 128000, 128000, PROFILES)
+    assert problem is not None
+    assert '128,000' in problem
+    assert '32,768' in problem
+    assert 'gpt-4.1-mini' in problem
+
+
+def test_silent_when_within_the_catalogue_limit():
+    assert check_output_token_config('gpt-4.1-mini', 32768, 1047576, PROFILES) is None
+    assert check_output_token_config('gpt-4.1-mini', 4096, 128000, PROFILES) is None
+
+
+def test_catalogue_limit_wins_over_the_equality_check():
+    # Equal to the configured window, but under what the model accepts: not a problem.
+    assert check_output_token_config('gpt-4-turbo', 4096, 4096, PROFILES) is None
+
+
+def test_falls_back_to_equality_for_an_unknown_model():
+    problem = check_output_token_config('some-local-model', 128000, 128000, PROFILES)
+    assert problem is not None
+    assert 'equals modelTotalTokens' in problem
+
+
+def test_unknown_model_below_the_window_is_silent():
+    assert check_output_token_config('some-local-model', 8192, 128000, PROFILES) is None
+
+
+def test_catalogue_entry_with_its_own_swapped_value_is_not_used():
+    # grok-3 states output == window, which is not a limit; fall back to equality.
+    assert check_output_token_config('grok-3', 65536, 131072, PROFILES) is None
+    problem = check_output_token_config('grok-3', 131072, 131072, PROFILES)
+    assert problem is not None
+    assert 'equals modelTotalTokens' in problem
+
+
+def test_no_profiles_available():
+    assert check_output_token_config('gpt-4.1-mini', 8192, 128000, None) is None
+    problem = check_output_token_config('gpt-4.1-mini', 128000, 128000, {})
+    assert problem is not None

--- a/packages/ai/tests/ai/common/test_output_token_config.py
+++ b/packages/ai/tests/ai/common/test_output_token_config.py
@@ -5,7 +5,7 @@
 
 """Unit: the custom-profile check for a max_tokens the provider would reject."""
 
-from ai.common.validation import check_output_token_config
+from ai.common.validation import check_output_token_config, hand_supplied_token_fields
 
 
 PROFILES = {
@@ -57,3 +57,36 @@ def test_no_profiles_available():
     assert check_output_token_config('gpt-4.1-mini', 8192, 128000, None) is None
     problem = check_output_token_config('gpt-4.1-mini', 128000, 128000, {})
     assert problem is not None
+
+
+def test_flags_output_above_the_configured_window():
+    # Would be clamped down to 32,768 with nothing said.
+    problem = check_output_token_config('some-local-model', 131072, 32768, PROFILES)
+    assert problem is not None
+    assert 'capped at the smaller value' in problem
+
+
+def test_catalogue_breach_outranks_the_clamp_notice():
+    problem = check_output_token_config('gpt-4.1-mini', 128000, 64000, PROFILES)
+    assert 'exceeds the 32,768' in problem
+
+
+class TestHandSuppliedTokenFields:
+    def test_top_level_fields(self):
+        assert hand_supplied_token_fields({'model': 'x', 'modelTotalTokens': 128000}) is True
+
+    def test_nested_under_a_named_profile(self):
+        assert hand_supplied_token_fields({'profile': 'custom', 'custom': {'modelOutputTokens': 32768}}) is True
+
+    def test_nested_under_the_default_profile_name(self):
+        # llm_openai_api's default profile is 'custom', so 'profile' is often omitted.
+        assert hand_supplied_token_fields({'custom': {'modelTotalTokens': 128000}}) is True
+
+    def test_no_token_fields(self):
+        assert hand_supplied_token_fields({'profile': 'gpt-4-1-mini', 'gpt-4-1-mini': {'apikey': ''}}) is False
+
+    def test_none_values_do_not_count(self):
+        assert hand_supplied_token_fields({'modelTotalTokens': None}) is False
+
+    def test_non_mapping(self):
+        assert hand_supplied_token_fields(None) is False

--- a/packages/ai/tests/ai/common/test_output_token_config.py
+++ b/packages/ai/tests/ai/common/test_output_token_config.py
@@ -60,14 +60,22 @@ def test_no_profiles_available():
 
 
 def test_flags_output_above_the_configured_window():
-    # Would be clamped down to 32,768 with nothing said.
+    # Would be capped down to 32,768 with nothing said.
     problem = check_output_token_config('some-local-model', 131072, 32768, PROFILES)
     assert problem is not None
-    assert 'capped at the smaller value' in problem
+    assert 'capped at that value' in problem
 
 
-def test_catalogue_breach_outranks_the_clamp_notice():
-    problem = check_output_token_config('gpt-4.1-mini', 128000, 64000, PROFILES)
+def test_a_capped_value_the_model_accepts_is_not_called_a_rejection():
+    # 128,000 configured under a 16,384 window goes out as 16,384, which
+    # gpt-4.1-mini accepts. Reporting a rejection here would be wrong.
+    problem = check_output_token_config('gpt-4.1-mini', 128000, 16384, PROFILES)
+    assert 'reject' not in problem
+    assert 'capped at that value' in problem
+
+
+def test_catalogue_breach_is_reported_when_the_value_really_goes_out():
+    problem = check_output_token_config('gpt-4.1-mini', 128000, 128000, PROFILES)
     assert 'exceeds the 32,768' in problem
 
 

--- a/tools/sync_models/README.md
+++ b/tools/sync_models/README.md
@@ -121,6 +121,8 @@ Pick primary source  →  fetch model list  →  discovery gate  →  smoke test
 
 The same priority applies to output tokens: `model_output_tokens.overrides` → first source in `--model-source` order with data → `model_output_tokens.defaults.chat` (or `defaults.embedding` for embedding providers).
 
+**Swapped-value guard**: LiteLLM and OpenRouter report max output tokens as the context window for some models. A candidate whose value equals its own source's context window is discarded and the next source is tried; if none has a usable value, the default applies to new profiles only and never overwrites a limit already in `services.json`. After the run, the sync fails with exit code 1 if any profile still has `modelOutputTokens == modelTotalTokens` — such a profile sends the whole window as `max_tokens` and the provider rejects the call. Fix those with `model_output_tokens.overrides`.
+
 ### Discovery vs enrichment
 
 The sync has two distinct modes:

--- a/tools/sync_models/README.md
+++ b/tools/sync_models/README.md
@@ -121,7 +121,11 @@ Pick primary source  →  fetch model list  →  discovery gate  →  smoke test
 
 The same priority applies to output tokens: `model_output_tokens.overrides` → first source in `--model-source` order with data → `model_output_tokens.defaults.chat` (or `defaults.embedding` for embedding providers).
 
-**Swapped-value guard**: LiteLLM and OpenRouter report max output tokens as the context window for some models. A candidate whose value equals its own source's context window is discarded and the next source is tried; if none has a usable value, the default applies to new profiles only and never overwrites a limit already in `services.json`. After the run, the sync fails with exit code 1 if any profile still has `modelOutputTokens == modelTotalTokens` — such a profile sends the whole window as `max_tokens` and the provider rejects the call. Fix those with `model_output_tokens.overrides`.
+**Swapped-value guard** (providers with `output_limit_below_context` only): LiteLLM and OpenRouter report max output tokens as the context window for some models. On a provider that caps completions below its window, a candidate equal to its own source's context window is discarded and the next source is tried. If no source has a usable value, the default applies to new profiles only — it never overwrites a limit already in `services.json`.
+
+The equality is only a defect where the provider enforces a separate completion limit. OpenAI rejects an oversized `max_tokens` with _"This model supports at most N completion tokens"_, and litellm swaps the fields for Anthropic; both set `output_limit_below_context`. Mistral and xAI accept `max_tokens` up to the context window and publish no separate limit, so **every** source reports the two values as equal there and it is correct data — do not set the flag for them.
+
+After the run the sync reports every profile with `modelOutputTokens == modelTotalTokens`, and exits 1 for those that are also (a) on a provider with `output_limit_below_context`, (b) `modelSource: provider` — a routed OpenRouter or LiteLLM alias is served elsewhere and is not bound by this provider's limit — and (c) not `deprecated`. Fix a failing profile with `model_output_tokens.overrides`; adding a model there also marks the value as confirmed and silences the warning.
 
 ### Discovery vs enrichment
 
@@ -180,6 +184,7 @@ The sync has two distinct modes:
     "default_context_window": 128000,  // fallback for new models when API + litellm have no data
     "protected_profiles": ["custom"],  // these keys are never deprecated (merged with default_protected_profiles)
     "exclude_dated_snapshots": true,   // drop -2024-04-09 and -0613 date suffixes
+    "output_limit_below_context": true, // provider caps completions below its window (see above)
     "model_filter": {
         "include_prefixes": ["gpt-", "o1"],  // only these prefixes; empty = allow all
         "exclude_prefixes": [],

--- a/tools/sync_models/src/core/merger.py
+++ b/tools/sync_models/src/core/merger.py
@@ -115,6 +115,50 @@ def _is_reasoning_model(bare_id: str) -> bool:
     return any(fam in low for fam in _REASONING_FAMILIES)
 
 
+def _is_swapped_output(out: Optional[int], ctx: Optional[int]) -> bool:
+    """
+    True when a source reports its max output tokens as the context window.
+
+    Both LiteLLM and OpenRouter do this for some models: the two fields come
+    back identical, which is never a real completion limit — modern models cap
+    output well below their window. Sending that value as ``max_tokens`` gets
+    the call rejected by the provider, so the candidate must be discarded and
+    the next source tried.
+
+    Args:
+        out: Candidate max output tokens from a source.
+        ctx: Context window reported by that same source.
+
+    Returns:
+        True if the pair carries the swap signature.
+    """
+    return out is not None and ctx is not None and out == ctx
+
+
+def find_swapped_output_profiles(profiles: Dict[str, Any]) -> List[Tuple[str, int]]:
+    """
+    Return profiles whose ``modelOutputTokens`` equals their ``modelTotalTokens``.
+
+    Used as a catalogue gate: such a profile sends the whole context window as
+    ``max_tokens`` and the provider rejects the call with a 400.
+
+    Args:
+        profiles: The "preconfig.profiles" mapping from a services.json.
+
+    Returns:
+        List of (profile_key, shared_token_value), sorted by key.
+    """
+    found: List[Tuple[str, int]] = []
+    for key, profile in profiles.items():
+        if not isinstance(profile, dict):
+            continue
+        total = profile.get('modelTotalTokens')
+        output = profile.get('modelOutputTokens')
+        if isinstance(total, int) and total == output:
+            found.append((key, total))
+    return sorted(found)
+
+
 def _source_is_authoritative(source: str, model_source: str) -> bool:
     """
     Return True if the given sync source has authority to deprecate or
@@ -591,26 +635,32 @@ def merge(
         else:
             api_output_tokens = -1  # sentinel — replaced below
             output_tokens_src = 'default'
+            # A candidate whose value equals its own source's context window is the
+            # swap signature (_is_swapped_output) — skip it and try the next source
+            # rather than break, so a good value further down the list still wins.
             for _src in model_sources:
                 if _src == 'provider' and _api_entry_source == 'provider API' and _api_entry_out is not None:
-                    api_output_tokens = _api_entry_out
-                    output_tokens_src = 'provider API'
-                    break
+                    if not _is_swapped_output(_api_entry_out, _api_ctx):
+                        api_output_tokens = _api_entry_out
+                        output_tokens_src = 'provider API'
+                        break
                 if _src == 'openrouter':
                     if _api_entry_source == 'openrouter' and _api_entry_out is not None:
-                        api_output_tokens = _api_entry_out
-                        output_tokens_src = 'openrouter'
-                        break
-                    if _or_out is not None:
+                        if not _is_swapped_output(_api_entry_out, _api_ctx):
+                            api_output_tokens = _api_entry_out
+                            output_tokens_src = 'openrouter'
+                            break
+                    if _or_out is not None and not _is_swapped_output(_or_out, _or_ctx):
                         api_output_tokens = _or_out
                         output_tokens_src = 'openrouter'
                         break
                 if _src == 'litellm':
                     if _api_entry_source == 'litellm' and _api_entry_out is not None:
-                        api_output_tokens = _api_entry_out
-                        output_tokens_src = 'litellm'
-                        break
-                    if _litellm_out is not None:
+                        if not _is_swapped_output(_api_entry_out, _api_ctx):
+                            api_output_tokens = _api_entry_out
+                            output_tokens_src = 'litellm'
+                            break
+                    if _litellm_out is not None and not _is_swapped_output(_litellm_out, _litellm_ctx):
                         api_output_tokens = _litellm_out
                         output_tokens_src = 'litellm'
                         break
@@ -682,7 +732,12 @@ def merge(
                 # any patcher rewrite, even when the value itself hasn't changed.
                 updated_profiles[profile_key]['_src_modelTotalTokens'] = total_tokens_src
 
-            if api_output_tokens > 0:
+            # 'default' means no source produced a usable value (none had one, or the
+            # only candidates carried the swap signature). That is a fallback for new
+            # profiles, not evidence about this model — never let it overwrite a value
+            # already in the catalogue.
+            _output_is_fallback = output_tokens_src == 'default' and existing.get('modelOutputTokens') is not None
+            if api_output_tokens > 0 and not _output_is_fallback:
                 if existing.get('modelOutputTokens') != api_output_tokens:
                     old_val = existing.get('modelOutputTokens')
                     updated_profiles[profile_key]['modelOutputTokens'] = api_output_tokens

--- a/tools/sync_models/src/core/merger.py
+++ b/tools/sync_models/src/core/merger.py
@@ -119,11 +119,12 @@ def _is_swapped_output(out: Optional[int], ctx: Optional[int]) -> bool:
     """
     True when a source reports its max output tokens as the context window.
 
-    Both LiteLLM and OpenRouter do this for some models: the two fields come
-    back identical, which is never a real completion limit — modern models cap
-    output well below their window. Sending that value as ``max_tokens`` gets
-    the call rejected by the provider, so the candidate must be discarded and
-    the next source tried.
+    Only meaningful for providers that actually cap completions below their
+    window — see ``output_limit_below_context`` in sync_models.config.json.
+    Where a provider has no separate completion limit (its API accepts
+    ``max_tokens`` up to the context window), the two values are legitimately
+    equal and every source reports them that way, so callers must gate this
+    check on the provider rather than applying it everywhere.
 
     Args:
         out: Candidate max output tokens from a source.
@@ -135,22 +136,42 @@ def _is_swapped_output(out: Optional[int], ctx: Optional[int]) -> bool:
     return out is not None and ctx is not None and out == ctx
 
 
-def find_swapped_output_profiles(profiles: Dict[str, Any]) -> List[Tuple[str, int]]:
+def find_swapped_output_profiles(
+    profiles: Dict[str, Any],
+    confirmed_models: Optional[set] = None,
+    native_only: bool = False,
+) -> List[Tuple[str, int]]:
     """
-    Return profiles whose ``modelOutputTokens`` equals their ``modelTotalTokens``.
+    Return active profiles whose ``modelOutputTokens`` equals ``modelTotalTokens``.
 
-    Used as a catalogue gate: such a profile sends the whole context window as
-    ``max_tokens`` and the provider rejects the call with a 400.
+    On a provider that caps completions below its window, such a profile sends
+    the whole window as ``max_tokens`` and the call is rejected with a 400.
+
+    Deprecated profiles and placeholder profiles (no model ID, e.g. "custom")
+    are never reported: the first are unreachable, the second carry no limits.
 
     Args:
         profiles: The "preconfig.profiles" mapping from a services.json.
+        confirmed_models: Model IDs with an explicit entry in
+            ``model_output_tokens.overrides``. A human has stated the value, so
+            equality there is a confirmed limit rather than a suspect one.
+        native_only: Restrict to profiles discovered through the provider's own
+            API (``modelSource: provider``). OpenRouter and LiteLLM aliases are
+            served elsewhere and are not bound by this provider's limit.
 
     Returns:
         List of (profile_key, shared_token_value), sorted by key.
     """
+    confirmed = confirmed_models or set()
     found: List[Tuple[str, int]] = []
     for key, profile in profiles.items():
         if not isinstance(profile, dict):
+            continue
+        if profile.get('deprecated') or not profile.get('model'):
+            continue
+        if profile.get('model') in confirmed:
+            continue
+        if native_only and profile.get('modelSource') != 'provider':
             continue
         total = profile.get('modelTotalTokens')
         output = profile.get('modelOutputTokens')
@@ -429,6 +450,7 @@ def merge(
     normalize_profile_model_id=None,
     deprecation_source: str = 'provider API',
     derive_title_fn=None,
+    output_limit_below_context: bool = False,
 ) -> tuple[Dict[str, Any], MergeResult]:
     """
     Perform a smart merge of current profiles against the provider API model list.
@@ -635,32 +657,37 @@ def merge(
         else:
             api_output_tokens = -1  # sentinel — replaced below
             output_tokens_src = 'default'
-            # A candidate whose value equals its own source's context window is the
-            # swap signature (_is_swapped_output) — skip it and try the next source
-            # rather than break, so a good value further down the list still wins.
+
+            # On a provider that caps completions below its window, a candidate equal
+            # to its own source's context window is the swap signature — skip it and
+            # try the next source rather than break, so a good value further down the
+            # list still wins. Elsewhere the equality is legitimate and must be kept.
+            def _usable(out: Optional[int], ctx: Optional[int]) -> bool:
+                return not (output_limit_below_context and _is_swapped_output(out, ctx))
+
             for _src in model_sources:
                 if _src == 'provider' and _api_entry_source == 'provider API' and _api_entry_out is not None:
-                    if not _is_swapped_output(_api_entry_out, _api_ctx):
+                    if _usable(_api_entry_out, _api_ctx):
                         api_output_tokens = _api_entry_out
                         output_tokens_src = 'provider API'
                         break
                 if _src == 'openrouter':
                     if _api_entry_source == 'openrouter' and _api_entry_out is not None:
-                        if not _is_swapped_output(_api_entry_out, _api_ctx):
+                        if _usable(_api_entry_out, _api_ctx):
                             api_output_tokens = _api_entry_out
                             output_tokens_src = 'openrouter'
                             break
-                    if _or_out is not None and not _is_swapped_output(_or_out, _or_ctx):
+                    if _or_out is not None and _usable(_or_out, _or_ctx):
                         api_output_tokens = _or_out
                         output_tokens_src = 'openrouter'
                         break
                 if _src == 'litellm':
                     if _api_entry_source == 'litellm' and _api_entry_out is not None:
-                        if not _is_swapped_output(_api_entry_out, _api_ctx):
+                        if _usable(_api_entry_out, _api_ctx):
                             api_output_tokens = _api_entry_out
                             output_tokens_src = 'litellm'
                             break
-                    if _litellm_out is not None and not _is_swapped_output(_litellm_out, _litellm_ctx):
+                    if _litellm_out is not None and _usable(_litellm_out, _litellm_ctx):
                         api_output_tokens = _litellm_out
                         output_tokens_src = 'litellm'
                         break

--- a/tools/sync_models/src/providers/base.py
+++ b/tools/sync_models/src/providers/base.py
@@ -601,6 +601,7 @@ class CloudProvider(ABC):
             normalize_profile_model_id=self.normalize_profile_model_id,
             deprecation_source=deprecation_source,
             derive_title_fn=self.derive_title,
+            output_limit_below_context=bool(self._config.get('output_limit_below_context', False)),
         )
 
         report.added = merge_result.added

--- a/tools/sync_models/src/sync_models.config.json
+++ b/tools/sync_models/src/sync_models.config.json
@@ -25,6 +25,13 @@
 			"auth_header": "Authorization",
 			"auth_prefix": "Bearer",
 			"smoke_test": "chat",
+			// This provider caps completions well below the context window and rejects a
+			// larger max_tokens with "This model supports at most N completion tokens".
+			// So modelOutputTokens equal to modelTotalTokens is a broken value here: token
+			// candidates carrying it are discarded, and native profiles still holding it
+			// fail the sync. Leave unset for providers with no separate completion limit
+			// (Mistral, xAI) — there the two values are legitimately equal.
+			"output_limit_below_context": true,
 			// model_filter controls which models from the API are considered.
 			// include_prefixes: if non-empty, model must start with one of these.
 			// exclude_patterns: substring match anywhere in model ID.
@@ -122,6 +129,9 @@
 				"anthropic-version": "2023-06-01"
 			},
 			"smoke_test": "chat",
+			// Anthropic caps completions below the window, and litellm reports the window
+			// as max_output_tokens here (see the WARNING further down). See llm_openai.
+			"output_limit_below_context": true,
 			"model_filter": {
 				"include_prefixes": ["claude-"],
 				"exclude_prefixes": [],

--- a/tools/sync_models/src/sync_models.config.json
+++ b/tools/sync_models/src/sync_models.config.json
@@ -54,6 +54,14 @@
 			// Override token limits when the provider API and litellm are unreliable.
 			// Comment out to let litellm drive — restore when litellm has wrong values.
 			"token_limit_overrides": {
+				// The chat-latest family had its window hand-filled with its output limit
+				// (16384 in both fields). 16384 is the correct output; the window is
+				// 128000 per models.dev and litellm. Pinned so a source that reports no
+				// context window for these cannot let the wrong value back in.
+				"gpt-5-chat-latest": 128000,
+				"gpt-5.1-chat-latest": 128000,
+				"gpt-5.2-chat-latest": 128000,
+				"gpt-5.3-chat-latest": 128000,
 				// "gpt-3.5-turbo": 16385,
 				// "gpt-3.5-turbo-16k": 16385,
 				// "gpt-3.5-turbo-1106": 16385,

--- a/tools/sync_models/src/sync_models.py
+++ b/tools/sync_models/src/sync_models.py
@@ -246,7 +246,7 @@ def sync_provider(
 
 
 def check_swapped_outputs(
-    repo_root: Path, provider_names: List[str], config: Dict[str, Any]
+    repo_root: Path, provider_names: List[str], config: Dict[str, Any], use_config_overrides: bool = True
 ) -> tuple[List[tuple], List[tuple]]:
     """
     Find catalogue profiles whose ``modelOutputTokens`` equals ``modelTotalTokens``.
@@ -261,12 +261,17 @@ def check_swapped_outputs(
         repo_root: Repository root.
         provider_names: Providers whose services.json should be checked.
         config: Parsed sync_models.config.json.
+        use_config_overrides: False under --no-config-overrides, where the configured
+            overrides are not applied to the catalogue either — a value that is not in
+            play must not count as a confirmed limit and silence the check.
 
     Returns:
         (errors, warnings), each a list of (provider_name, profile_key, value).
     """
     providers_config = config.get('providers', {})
-    confirmed = set((config.get('model_output_tokens', {}) or {}).get('overrides', {}) or {})
+    confirmed = (
+        set((config.get('model_output_tokens', {}) or {}).get('overrides', {}) or {}) if use_config_overrides else set()
+    )
     errors: List[tuple] = []
     warnings: List[tuple] = []
     for provider_name in provider_names:
@@ -285,6 +290,46 @@ def check_swapped_outputs(
             target = errors if profile_key in failing else warnings
             target.append((provider_name, profile_key, value))
     return errors, warnings
+
+
+def _format_gate_markdown(errors: List[tuple], warnings: List[tuple]) -> str:
+    """
+    Render the catalogue gate findings as a markdown section for the PR body.
+
+    A scheduled run exits non-zero on errors, and the workflow opens the PR anyway,
+    so the findings have to travel in the body or nobody sees them.
+
+    Args:
+        errors: (provider, profile_key, value) tuples that fail the run.
+        warnings: (provider, profile_key, value) tuples reported only.
+
+    Returns:
+        Markdown to append to the PR body, or '' when there is nothing to report.
+    """
+    if not errors and not warnings:
+        return ''
+    lines = ['', '---', '']
+    if errors:
+        lines.append('### Blocking: profiles sending the context window as `max_tokens`')
+        lines.append('')
+        lines.append('Their provider caps completions below its window and rejects the call. ')
+        lines.append("Set the model's real limit in `model_output_tokens.overrides`.")
+        lines.append('')
+        for provider_name, profile_key, value in errors:
+            lines.append(f'- `{provider_name}` — `{profile_key}` ({value:,} / {value:,})')
+        lines.append('')
+    if warnings:
+        lines.append('### Profiles with `modelOutputTokens` equal to `modelTotalTokens`')
+        lines.append('')
+        lines.append(
+            'Legitimate where the provider has no separate completion limit. '
+            'Confirm one by adding it to `model_output_tokens.overrides`.'
+        )
+        lines.append('')
+        for provider_name, profile_key, value in warnings:
+            lines.append(f'- `{provider_name}` — `{profile_key}` ({value:,})')
+        lines.append('')
+    return '\n'.join(lines)
 
 
 def main() -> int:
@@ -437,31 +482,35 @@ def main() -> int:
         )
         report.add(pr)
 
+    # Catalogue gate — on a provider that caps completions, a native profile sending
+    # its whole context window as max_tokens is rejected at run time. Fail on those;
+    # report the rest, where the equality may well be legitimate. Rendered into the PR
+    # body too, so a scheduled run puts the findings in front of whoever reviews it.
+    errors, warnings = check_swapped_outputs(
+        repo_root, providers_to_sync, config, use_config_overrides=not args.no_config_overrides
+    )
+
     if args.pr_body:
-        print(format_pr_body(report))
+        body = format_pr_body(report) + _format_gate_markdown(errors, warnings)
+        print(body)
         # Also write to GITHUB_ENV for the CI workflow
         github_env = os.environ.get('GITHUB_ENV')
         if github_env:
             with open(github_env, 'a', encoding='utf-8') as fh:
-                body = format_pr_body(report)
                 fh.write(f'SYNC_OUTPUT<<EOF\n{body}\nEOF\n')
     else:
         print(format_console(report))
+        if warnings:
+            print(f'\nNote: {len(warnings)} profile(s) have modelOutputTokens equal to modelTotalTokens.')
+            print('      Legitimate where the provider has no separate completion limit; confirm a')
+            print('      value by adding it to model_output_tokens.overrides to silence this.')
+            for provider_name, profile_key, value in warnings:
+                print(f'      {provider_name}: {profile_key} ({value:,})')
 
     # Exit 1 if any provider had an error
     if any(p.error for p in report.providers):
         return 1
 
-    # Catalogue gate — on a provider that caps completions, a native profile sending
-    # its whole context window as max_tokens is rejected at run time. Fail on those;
-    # report the rest, where the equality may well be legitimate.
-    errors, warnings = check_swapped_outputs(repo_root, providers_to_sync, config)
-    if warnings:
-        print(f'\nNote: {len(warnings)} profile(s) have modelOutputTokens equal to modelTotalTokens.')
-        print('      Legitimate where the provider has no separate completion limit; confirm a')
-        print('      value by adding it to model_output_tokens.overrides to silence this.')
-        for provider_name, profile_key, value in warnings:
-            print(f'      {provider_name}: {profile_key} ({value:,})')
     if errors:
         print(
             f'\nERROR: {len(errors)} profile(s) send the whole context window as max_tokens.\n'

--- a/tools/sync_models/src/sync_models.py
+++ b/tools/sync_models/src/sync_models.py
@@ -245,22 +245,30 @@ def sync_provider(
     )
 
 
-def check_swapped_outputs(repo_root: Path, provider_names: List[str]) -> List[tuple]:
+def check_swapped_outputs(
+    repo_root: Path, provider_names: List[str], config: Dict[str, Any]
+) -> tuple[List[tuple], List[tuple]]:
     """
-    Find catalogue profiles that send their whole context window as ``max_tokens``.
+    Find catalogue profiles whose ``modelOutputTokens`` equals ``modelTotalTokens``.
 
-    A profile whose ``modelOutputTokens`` equals its ``modelTotalTokens`` is the
-    signature of an upstream source swapping the two fields. The provider rejects
-    such a call with a 400, so this is checked against what is on disk.
+    Equality only proves a broken value on a provider that caps completions below
+    its context window (``output_limit_below_context``), and only for profiles that
+    came from that provider's own API — an OpenRouter or LiteLLM alias is served
+    elsewhere. Everything else is reported but does not fail the run: on providers
+    with no separate completion limit the two values are legitimately equal.
 
     Args:
         repo_root: Repository root.
         provider_names: Providers whose services.json should be checked.
+        config: Parsed sync_models.config.json.
 
     Returns:
-        List of (provider_name, profile_key, shared_token_value).
+        (errors, warnings), each a list of (provider_name, profile_key, value).
     """
-    offenders: List[tuple] = []
+    providers_config = config.get('providers', {})
+    confirmed = set((config.get('model_output_tokens', {}) or {}).get('overrides', {}) or {})
+    errors: List[tuple] = []
+    warnings: List[tuple] = []
     for provider_name in provider_names:
         rel_path = _SERVICES_JSON_PATHS.get(provider_name)
         if not rel_path:
@@ -268,9 +276,15 @@ def check_swapped_outputs(repo_root: Path, provider_names: List[str]) -> List[tu
         services_path = repo_root / rel_path
         if not services_path.exists():
             continue
-        for profile_key, value in find_swapped_output_profiles(get_profiles(str(services_path))):
-            offenders.append((provider_name, profile_key, value))
-    return offenders
+        profiles = get_profiles(str(services_path))
+        capped = bool(providers_config.get(provider_name, {}).get('output_limit_below_context', False))
+        failing = (
+            {key for key, _ in find_swapped_output_profiles(profiles, confirmed, native_only=True)} if capped else set()
+        )
+        for profile_key, value in find_swapped_output_profiles(profiles, confirmed):
+            target = errors if profile_key in failing else warnings
+            target.append((provider_name, profile_key, value))
+    return errors, warnings
 
 
 def main() -> int:
@@ -438,18 +452,25 @@ def main() -> int:
     if any(p.error for p in report.providers):
         return 1
 
-    # Catalogue gate — a profile sending its context window as max_tokens is
-    # rejected by the provider at run time, so fail the sync rather than ship it.
-    offenders = check_swapped_outputs(repo_root, providers_to_sync)
-    if offenders:
+    # Catalogue gate — on a provider that caps completions, a native profile sending
+    # its whole context window as max_tokens is rejected at run time. Fail on those;
+    # report the rest, where the equality may well be legitimate.
+    errors, warnings = check_swapped_outputs(repo_root, providers_to_sync, config)
+    if warnings:
+        print(f'\nNote: {len(warnings)} profile(s) have modelOutputTokens equal to modelTotalTokens.')
+        print('      Legitimate where the provider has no separate completion limit; confirm a')
+        print('      value by adding it to model_output_tokens.overrides to silence this.')
+        for provider_name, profile_key, value in warnings:
+            print(f'      {provider_name}: {profile_key} ({value:,})')
+    if errors:
         print(
-            f'\nERROR: {len(offenders)} profile(s) have modelOutputTokens equal to modelTotalTokens.\n'
-            '       These send the whole context window as max_tokens and the provider rejects\n'
-            "       the call. Set the model's real completion limit in sync_models.config.json\n"
-            '       under model_output_tokens.overrides.',
+            f'\nERROR: {len(errors)} profile(s) send the whole context window as max_tokens.\n'
+            '       Their provider caps completions below the window and rejects the call.\n'
+            "       Set the model's real completion limit in sync_models.config.json under\n"
+            '       model_output_tokens.overrides.',
             file=sys.stderr,
         )
-        for provider_name, profile_key, value in offenders:
+        for provider_name, profile_key, value in errors:
             print(f'       {provider_name}: {profile_key} ({value:,} / {value:,})', file=sys.stderr)
         return 1
 

--- a/tools/sync_models/src/sync_models.py
+++ b/tools/sync_models/src/sync_models.py
@@ -38,7 +38,12 @@ _TOOLS_SRC = Path(__file__).parent
 if str(_TOOLS_SRC) not in sys.path:
     sys.path.insert(0, str(_TOOLS_SRC))
 
-from core.merger import _LITELLM_AVAILABLE, get_openrouter_cache, is_openrouter_available
+from core.merger import (
+    _LITELLM_AVAILABLE,
+    find_swapped_output_profiles,
+    get_openrouter_cache,
+    is_openrouter_available,
+)
 from core.patcher import get_profiles
 from core.reporter import SyncReport, format_console, format_pr_body
 from providers.base import _active_protected_profiles
@@ -240,6 +245,34 @@ def sync_provider(
     )
 
 
+def check_swapped_outputs(repo_root: Path, provider_names: List[str]) -> List[tuple]:
+    """
+    Find catalogue profiles that send their whole context window as ``max_tokens``.
+
+    A profile whose ``modelOutputTokens`` equals its ``modelTotalTokens`` is the
+    signature of an upstream source swapping the two fields. The provider rejects
+    such a call with a 400, so this is checked against what is on disk.
+
+    Args:
+        repo_root: Repository root.
+        provider_names: Providers whose services.json should be checked.
+
+    Returns:
+        List of (provider_name, profile_key, shared_token_value).
+    """
+    offenders: List[tuple] = []
+    for provider_name in provider_names:
+        rel_path = _SERVICES_JSON_PATHS.get(provider_name)
+        if not rel_path:
+            continue
+        services_path = repo_root / rel_path
+        if not services_path.exists():
+            continue
+        for profile_key, value in find_swapped_output_profiles(get_profiles(str(services_path))):
+            offenders.append((provider_name, profile_key, value))
+    return offenders
+
+
 def main() -> int:
     """
     CLI entry point.
@@ -404,6 +437,22 @@ def main() -> int:
     # Exit 1 if any provider had an error
     if any(p.error for p in report.providers):
         return 1
+
+    # Catalogue gate — a profile sending its context window as max_tokens is
+    # rejected by the provider at run time, so fail the sync rather than ship it.
+    offenders = check_swapped_outputs(repo_root, providers_to_sync)
+    if offenders:
+        print(
+            f'\nERROR: {len(offenders)} profile(s) have modelOutputTokens equal to modelTotalTokens.\n'
+            '       These send the whole context window as max_tokens and the provider rejects\n'
+            "       the call. Set the model's real completion limit in sync_models.config.json\n"
+            '       under model_output_tokens.overrides.',
+            file=sys.stderr,
+        )
+        for provider_name, profile_key, value in offenders:
+            print(f'       {provider_name}: {profile_key} ({value:,} / {value:,})', file=sys.stderr)
+        return 1
+
     return 0
 
 

--- a/tools/sync_models/test/test_sync_logic.py
+++ b/tools/sync_models/test/test_sync_logic.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # tools/sync_models/src is added to sys.path by conftest.py
-from core.merger import merge, _make_profile_key, _derive_title
+from core.merger import merge, _make_profile_key, _derive_title, find_swapped_output_profiles
 from core.smoke import run
 from core.patcher import load as patcher_load, patch as patcher_patch, get_profiles
 from core.reporter import SyncReport, ProviderReport, format_console, format_pr_body
@@ -527,3 +527,103 @@ class TestCliValidation:
         )
         assert rc != 0
         assert 'must not be repeated' in stderr.lower() or 'duplicate' in stderr.lower() or '--model-source' in stderr
+
+
+# ---------------------------------------------------------------------------
+# Swapped output tokens (context window reported as the completion limit)
+# ---------------------------------------------------------------------------
+
+
+class TestSwappedOutputTokens:
+    def test_swapped_candidate_is_not_used_for_new_profile(self, current_profiles, title_mappings):
+        # Source reports the same number for both fields — the swap signature.
+        api_models = [
+            {'id': 'test-model-a'},
+            {'id': 'test-model-b'},
+            {'id': 'test-model-c', 'context_window': 128000, 'max_output_tokens': 128000},
+        ]
+        updated, result = merge(
+            current_profiles=current_profiles,
+            api_models=api_models,
+            title_mappings=title_mappings,
+            token_overrides={},
+            output_token_overrides={},
+            default_output_tokens=4096,
+        )
+        profile = updated['test-model-c']
+        assert profile['modelTotalTokens'] == 128000
+        assert profile['modelOutputTokens'] == 4096
+
+    def test_genuine_output_limit_is_kept(self, current_profiles, title_mappings):
+        api_models = [
+            {'id': 'test-model-a'},
+            {'id': 'test-model-b'},
+            {'id': 'test-model-c', 'context_window': 128000, 'max_output_tokens': 32768},
+        ]
+        updated, _ = merge(
+            current_profiles=current_profiles,
+            api_models=api_models,
+            title_mappings=title_mappings,
+            token_overrides={},
+            output_token_overrides={},
+            default_output_tokens=4096,
+        )
+        assert updated['test-model-c']['modelOutputTokens'] == 32768
+
+    def test_override_still_wins_over_source(self, current_profiles, title_mappings):
+        api_models = [
+            {'id': 'test-model-a'},
+            {'id': 'test-model-b'},
+            {'id': 'test-model-c', 'context_window': 128000, 'max_output_tokens': 128000},
+        ]
+        updated, _ = merge(
+            current_profiles=current_profiles,
+            api_models=api_models,
+            title_mappings=title_mappings,
+            token_overrides={},
+            output_token_overrides={'test-model-c': 16384},
+            default_output_tokens=4096,
+        )
+        assert updated['test-model-c']['modelOutputTokens'] == 16384
+
+    def test_fallback_default_does_not_overwrite_existing_value(self, title_mappings):
+        # A profile that already carries a real limit must survive a source that
+        # only offers a swapped value — the 4096 default is for new profiles.
+        profiles = {
+            'test-model-a': {
+                'title': 'Test Model A',
+                'model': 'test-model-a',
+                'modelSource': 'provider',
+                'modelTotalTokens': 128000,
+                'modelOutputTokens': 32768,
+                'apikey': '',
+            },
+        }
+        api_models = [{'id': 'test-model-a', 'context_window': 128000, 'max_output_tokens': 128000}]
+        updated, _ = merge(
+            current_profiles=profiles,
+            api_models=api_models,
+            title_mappings=title_mappings,
+            token_overrides={},
+            output_token_overrides={},
+            default_output_tokens=4096,
+        )
+        assert updated['test-model-a']['modelOutputTokens'] == 32768
+
+    def test_find_swapped_output_profiles(self):
+        profiles = {
+            'bad': {'model': 'm1', 'modelTotalTokens': 131072, 'modelOutputTokens': 131072},
+            'good': {'model': 'm2', 'modelTotalTokens': 131072, 'modelOutputTokens': 32768},
+            'no-output-key': {'model': 'm3', 'modelTotalTokens': 131072},
+            'custom': {'model': ''},
+        }
+        assert find_swapped_output_profiles(profiles) == [('bad', 131072)]
+
+    def test_catalogue_has_no_swapped_profiles(self):
+        # Guards every llm_* node, including the ones sync_models does not cover.
+        repo_root = Path(__file__).resolve().parents[3]
+        offenders = []
+        for services_path in sorted(repo_root.glob('nodes/src/nodes/llm_*/services.json')):
+            for key, value in find_swapped_output_profiles(get_profiles(str(services_path))):
+                offenders.append(f'{services_path.parent.name}: {key} ({value:,})')
+        assert not offenders, 'Profiles sending the context window as max_tokens:\n' + '\n'.join(offenders)

--- a/tools/sync_models/test/test_sync_logic.py
+++ b/tools/sync_models/test/test_sync_logic.py
@@ -20,6 +20,7 @@ from core.merger import merge, _make_profile_key, _derive_title, find_swapped_ou
 from core.smoke import run
 from core.patcher import load as patcher_load, patch as patcher_patch, get_profiles
 from core.reporter import SyncReport, ProviderReport, format_console, format_pr_body
+import sync_models
 
 
 # ---------------------------------------------------------------------------
@@ -549,10 +550,28 @@ class TestSwappedOutputTokens:
             token_overrides={},
             output_token_overrides={},
             default_output_tokens=4096,
+            output_limit_below_context=True,
         )
         profile = updated['test-model-c']
         assert profile['modelTotalTokens'] == 128000
         assert profile['modelOutputTokens'] == 4096
+
+    def test_equal_values_kept_when_provider_has_no_separate_limit(self, current_profiles, title_mappings):
+        # Mistral and xAI accept max_tokens up to the window, so equality is real data.
+        api_models = [
+            {'id': 'test-model-a'},
+            {'id': 'test-model-b'},
+            {'id': 'test-model-c', 'context_window': 128000, 'max_output_tokens': 128000},
+        ]
+        updated, _ = merge(
+            current_profiles=current_profiles,
+            api_models=api_models,
+            title_mappings=title_mappings,
+            token_overrides={},
+            output_token_overrides={},
+            default_output_tokens=4096,
+        )
+        assert updated['test-model-c']['modelOutputTokens'] == 128000
 
     def test_genuine_output_limit_is_kept(self, current_profiles, title_mappings):
         api_models = [
@@ -583,6 +602,7 @@ class TestSwappedOutputTokens:
             token_overrides={},
             output_token_overrides={'test-model-c': 16384},
             default_output_tokens=4096,
+            output_limit_below_context=True,
         )
         assert updated['test-model-c']['modelOutputTokens'] == 16384
 
@@ -607,23 +627,57 @@ class TestSwappedOutputTokens:
             token_overrides={},
             output_token_overrides={},
             default_output_tokens=4096,
+            output_limit_below_context=True,
         )
         assert updated['test-model-a']['modelOutputTokens'] == 32768
 
     def test_find_swapped_output_profiles(self):
         profiles = {
-            'bad': {'model': 'm1', 'modelTotalTokens': 131072, 'modelOutputTokens': 131072},
-            'good': {'model': 'm2', 'modelTotalTokens': 131072, 'modelOutputTokens': 32768},
+            'bad': {'model': 'm1', 'modelSource': 'provider', 'modelTotalTokens': 131072, 'modelOutputTokens': 131072},
+            'good': {'model': 'm2', 'modelSource': 'provider', 'modelTotalTokens': 131072, 'modelOutputTokens': 32768},
             'no-output-key': {'model': 'm3', 'modelTotalTokens': 131072},
             'custom': {'model': ''},
         }
         assert find_swapped_output_profiles(profiles) == [('bad', 131072)]
 
-    def test_catalogue_has_no_swapped_profiles(self):
-        # Guards every llm_* node, including the ones sync_models does not cover.
+    def test_deprecated_and_confirmed_profiles_are_not_reported(self):
+        profiles = {
+            'dead': {
+                'model': 'm1',
+                'deprecated': True,
+                'modelTotalTokens': 131072,
+                'modelOutputTokens': 131072,
+            },
+            'confirmed': {'model': 'm2', 'modelTotalTokens': 16384, 'modelOutputTokens': 16384},
+            'suspect': {'model': 'm3', 'modelTotalTokens': 131072, 'modelOutputTokens': 131072},
+        }
+        assert find_swapped_output_profiles(profiles, confirmed_models={'m2'}) == [('suspect', 131072)]
+
+    def test_native_only_skips_routed_aliases(self):
+        profiles = {
+            'native': {
+                'model': 'm1',
+                'modelSource': 'provider',
+                'modelTotalTokens': 131072,
+                'modelOutputTokens': 131072,
+            },
+            'routed': {
+                'model': 'm2',
+                'modelSource': 'openrouter',
+                'modelTotalTokens': 131072,
+                'modelOutputTokens': 131072,
+            },
+        }
+        assert find_swapped_output_profiles(profiles, native_only=True) == [('native', 131072)]
+        assert len(find_swapped_output_profiles(profiles)) == 2
+
+    def test_catalogue_gate_is_clean(self):
+        # The real gate: fails only where the provider caps completions below its
+        # window and the profile came from that provider's own API.
         repo_root = Path(__file__).resolve().parents[3]
-        offenders = []
-        for services_path in sorted(repo_root.glob('nodes/src/nodes/llm_*/services.json')):
-            for key, value in find_swapped_output_profiles(get_profiles(str(services_path))):
-                offenders.append(f'{services_path.parent.name}: {key} ({value:,})')
-        assert not offenders, 'Profiles sending the context window as max_tokens:\n' + '\n'.join(offenders)
+        config = sync_models._load_config()
+        providers = sorted(sync_models._PROVIDER_REGISTRY)
+        errors, _ = sync_models.check_swapped_outputs(repo_root, providers, config)
+        assert not errors, 'Profiles sending the context window as max_tokens:\n' + '\n'.join(
+            f'{p}: {k} ({v:,})' for p, k, v in errors
+        )


### PR DESCRIPTION
## Summary

- **Stop the swap from entering the catalogue.** LiteLLM and OpenRouter report max output tokens as the context window for some models. On a provider that caps completions below its window, such a candidate is discarded and the next source is tried; the 4096 fallback no longer overwrites a limit already in `services.json`.
- **Gate the catalogue, scoped to where the equality actually proves a defect.** The sync fails when a profile still sends its whole window as `max_tokens`, but only for native profiles on a provider that caps completions, skipping deprecated ones and models confirmed in `model_output_tokens.overrides`. Everything else is reported as a note (26 today, 0 errors).
- **Warn at runtime for custom profiles**, which the sync never sees. `ChatBase` resolves the configured model name against the node's own catalogue and names the real limit: `modelOutputTokens (128,000) exceeds the 32,768 that gpt-4.1-mini accepts`.
- **Fix the four `gpt-5-*-chat-latest` profiles**, whose context window was set to their output value (16,384 instead of 128,000) and were truncating prompts at 16k.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./builder test` not run — see Verification below for what was.

### Verification

- `pytest tools/sync_models/test/test_sync_logic.py` — 50 passed (41 existing, 9 new).
- `./dist/server/engine -m pytest packages/ai/tests/ai/common/` — 919 passed, including 7 new for `check_output_token_config`.
- `sync_models.py --all --model-source provider` end to end: exit 0, 0 errors, 26 notes.
- `ruff check` and `ruff format --check` clean on every file touched.

Not covered: no run against live provider keys. The guard's effect on real API responses is exercised through unit tests with mocked entries only.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; `output_limit_below_context` defaults to off, so an unlisted provider behaves exactly as before.

## Notes for the reviewer

**The rule is per provider on purpose.** The first version applied the equality check everywhere and that would have been a regression. Mistral and xAI publish no separate completion limit — their API accepts `max_tokens` up to the context window — which is why *every* source reports the two values as equal for them. A global rule would have thrown that correct data away and replaced it with the 4096 default, truncating output on 26 profiles to fix a problem they do not have. `output_limit_below_context` is set only for OpenAI (whose 400 names the limit outright) and Anthropic (the LiteLLM swap already documented in the config file).

**Why `modelOutputTokens` is worth getting right beyond `max_tokens`.** It also sizes document chunking — `preprocessor_llm/IInstance.py:197` uses it as the ceiling on chunk size. An inflated value merely stops the ceiling binding; a value that is too low splits a document into far more pieces, and every piece is a call.

That is the shape of a **second, larger defect this PR does not touch**: ~70 profiles across `llm_bedrock`, `llm_ollama`, `llm_gmi_cloud` and the four `llm_vision_*` nodes have no `modelOutputTokens` at all and fall back to 4096. They do not error, they just cap generation and multiply chunk count. Those nodes are not in the sync's `providers` list at all, so fixing them starts by adding them. Filed separately rather than widened into this PR.

**On the numbers.** No value here was guessed. The only data change is the four `gpt-5-*-chat-latest` windows, corrected to the 128,000 that models.dev and LiteLLM both report; their 16,384 output is correct and stays. The remaining suspect profiles are reported as notes rather than "fixed" with an invented number — no public source publishes reliable completion limits (native APIs do not expose the field at all, OpenRouter returns 0.8–0.9 × the window, LiteLLM and models.dev return the window itself), so anything else would have been a guess wearing a citation. Detail in the issue.

## Linked Issue

Fixes #2151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased supported context limits for several latest chat models to 128,000 tokens.
  * Added validation and warnings for custom model profiles with incompatible token settings.
  * Improved model synchronization for providers with separate context and completion limits.

* **Bug Fixes**
  * Prevented incorrect token-limit values from overwriting existing model configurations.
  * Added safeguards and error reporting for invalid provider model profiles.

* **Documentation**
  * Documented provider configurations where completion limits are lower than context windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->