### PR TITLE
fix(task): tell the caller when useExisting returned a running instance

### DIFF
--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1548,6 +1548,12 @@ class TaskServer(DAPBase):
             if type(components) is not list:
                 raise ValueError('Invalid components in pipeline')
 
+            # Normalise BEFORE anything is stopped. This is also the validation: it
+            # raises when the source component is missing, and doing that after the
+            # restart would leave the task stopped, the new pipeline already stored
+            # by Task.restart_task, and control.pipeline still naming the old one.
+            pipeline = _apply_source_defaults(pipeline, control.source)
+
             # Call the Task's restart method to restart the engine process
             # This preserves all statistics and monitoring while restarting the subprocess
             await control.task.restart_task(
@@ -1557,12 +1563,10 @@ class TaskServer(DAPBase):
                 provider=control.provider,
             )
 
-            # The control now describes the pipeline that is running. Without this the
+            # The control now describes the pipeline that is running: without this the
             # record still holds whatever was launched originally, so a later
             # useExisting compares against a configuration that was replaced here.
-            # Normalised the same way a launch does, or the comparison reads the
-            # difference a launch itself introduced.
-            control.pipeline = _apply_source_defaults(pipeline, control.source)
+            control.pipeline = pipeline
 
             # Wait for running state if requested
             if wait_for_running:

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1548,6 +1548,17 @@ class TaskServer(DAPBase):
             if type(components) is not list:
                 raise ValueError('Invalid components in pipeline')
 
+            # The source is part of the task's identity and a restart cannot change
+            # it. _apply_source_defaults stamps control.source onto the pipeline, so
+            # a different explicit source would be overwritten without a word —
+            # refuse it instead, which is what the docstring above promises.
+            requested_source = pipeline.get('source')
+            if requested_source and requested_source != control.source:
+                raise ValueError(
+                    f'Cannot change the source on restart: task "{control.id}" runs '
+                    f'"{control.source}", the request asks for "{requested_source}"'
+                )
+
             # Normalise BEFORE anything is stopped. This is also the validation: it
             # raises when the source component is missing, and doing that after the
             # restart would leave the task stopped, the new pipeline already stored

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1539,6 +1539,11 @@ class TaskServer(DAPBase):
                 provider=control.provider,
             )
 
+            # The control now describes the pipeline that is running. Without this the
+            # record still holds whatever was launched originally, so a later
+            # useExisting compares against a configuration that was replaced here.
+            control.pipeline = pipeline
+
             # Wait for running state if requested
             if wait_for_running:
                 await control.task.wait_for_running()

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1173,7 +1173,7 @@ class TaskServer(DAPBase):
                 of the task controls its life cycle
         """
 
-        def _return_results(control: TASK_CONTROL) -> str:
+        def _return_results(control: TASK_CONTROL, reused: bool = False) -> str:
             """
             Return task token for the task.
 
@@ -1181,6 +1181,11 @@ class TaskServer(DAPBase):
 
             Args:
                 control (TASK_CONTROL): The existing task control structure
+                reused (bool): True when this is a live instance returned under
+                    useExisting rather than a task launched from the submitted
+                    pipeline. Without it the two are indistinguishable to the
+                    caller, and a run against stale configuration reads as a
+                    successful run of the configuration just sent.
             """
             return {
                 'id': control.id,
@@ -1189,6 +1194,7 @@ class TaskServer(DAPBase):
                 'projectId': control.project_id,
                 'source': control.source,
                 'provider': control.provider,
+                'reused': reused,
             }
 
         # Initialize task control structure for new task
@@ -1332,9 +1338,18 @@ class TaskServer(DAPBase):
                 # make sure the user actually specified the task to use. If so,
                 # then all is ok, just use the existing task
                 if use_existing_task:
+                    # The submitted pipeline is not applied to a running instance.
+                    # Say so when it differs from what is actually running, otherwise
+                    # an edit-and-rerun loop silently measures the old configuration.
+                    if control.pipeline != existing_control.pipeline:
+                        self.debug_message(
+                            f'Task "{existing_control.id}" is already running: reusing it and ignoring the '
+                            'submitted pipeline, which differs from the running one. Restart the task to '
+                            'apply it.'
+                        )
                     if wait_for_running:
                         await existing_control.task.wait_for_running()
-                    return _return_results(existing_control)
+                    return _return_results(existing_control, reused=True)
 
                 # We are absolutely supposed to create a task or the user did
                 # not specify the token (which means a random collision)

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -159,6 +159,34 @@ class TASK_CONTROL:
         return self.teamId if self.run_kind == 'deploy' else self.userId
 
 
+def _apply_source_defaults(pipeline: Dict[str, Any], source: str) -> Dict[str, Any]:
+    """
+    Fill in the fields a launch stamps on a pipeline, so two copies compare equal.
+
+    ``start_task`` writes the resolved source onto the pipeline and gives the
+    source component an empty config when it has none. A pipeline stored without
+    those looks different from the same pipeline after a launch, which turns a
+    useExisting comparison into a false "differs".
+
+    Args:
+        pipeline: The pipeline to normalise, mutated in place.
+        source: The resolved source component id.
+
+    Returns:
+        The same pipeline.
+
+    Raises:
+        ValueError: If the source component is not in the components list.
+    """
+    pipeline['source'] = source
+    for component in pipeline.get('components', []):
+        if component.get('id') == source:
+            if 'config' not in component:
+                component['config'] = {}
+            return pipeline
+    raise ValueError(f'Pipeline source component "{source}" not found in components list')
+
+
 class TaskServer(DAPBase):
     """
     Central task management server orchestrating computational task lifecycles.
@@ -1231,20 +1259,10 @@ class TaskServer(DAPBase):
                 raise ValueError('Pipeline does not have a source component defined')
 
         # Find the actual source component
-        source_component = None
-        for component in control.pipeline.get('components', []):
-            if component.get('id') == control.source:
-                source_component = component
-                break
-
-        # Update the source on the pipeline
-        control.pipeline['source'] = control.source
-
-        if source_component is None:
-            raise ValueError(f'Pipeline source component "{control.source}" not found in components list')
-
-        if 'config' not in source_component:
-            source_component['config'] = {}
+        # Stamp the resolved source and give the source component a config if it has
+        # none. Shared with restart_task so a restarted pipeline is stored in the same
+        # shape a launched one is, and the two compare equal.
+        _apply_source_defaults(control.pipeline, control.source)
 
         # Project identity is project_id on the flat project.
         control.project_id = control.pipeline.get('project_id', None)
@@ -1542,7 +1560,9 @@ class TaskServer(DAPBase):
             # The control now describes the pipeline that is running. Without this the
             # record still holds whatever was launched originally, so a later
             # useExisting compares against a configuration that was replaced here.
-            control.pipeline = pipeline
+            # Normalised the same way a launch does, or the comparison reads the
+            # difference a launch itself introduced.
+            control.pipeline = _apply_source_defaults(pipeline, control.source)
 
             # Wait for running state if requested
             if wait_for_running:

--- a/packages/ai/tests/ai/modules/task/test_task_reuse.py
+++ b/packages/ai/tests/ai/modules/task/test_task_reuse.py
@@ -206,3 +206,33 @@ async def test_an_invalid_pipeline_is_refused_before_the_task_is_stopped():
 
     control.task.restart_task.assert_not_awaited()
     assert control.pipeline is original, 'the record still describes what is running'
+
+
+@pytest.mark.asyncio
+async def test_a_restart_cannot_change_the_source():
+    """
+    The source is part of the task's identity, as restart_task documents.
+
+    _apply_source_defaults stamps the control's source onto the pipeline, so a
+    request naming a different one would be silently overwritten — the caller
+    would believe it had switched source and be told nothing.
+    """
+    ts = _make_server()
+    control = _running(_pipeline())
+    control.teamId = ''
+    ts._task_control['tk_test'] = control
+    ts.get_task_control = lambda token: control
+    control.task.restart_task = AsyncMock()
+    control.task.has_attached_debugger.return_value = False
+
+    other_source = {
+        'project_id': 'project-1',
+        'source': 'llm',  # a real component, but not the one this task runs
+        'components': [{'id': 'src', 'provider': 'webhook'}, {'id': 'llm', 'provider': 'llm_openai'}],
+    }
+    conn = MagicMock()
+    conn._account_info = None
+    with pytest.raises(ValueError, match='source'):
+        await ts.restart_task({'arguments': {'token': 'tk_test', 'pipeline': other_source}}, conn=conn)
+
+    control.task.restart_task.assert_not_awaited()

--- a/packages/ai/tests/ai/modules/task/test_task_reuse.py
+++ b/packages/ai/tests/ai/modules/task/test_task_reuse.py
@@ -1,0 +1,104 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+useExisting returns a live instance instead of starting the submitted pipeline.
+
+The caller has to be able to tell the two apart: a run against stale
+configuration is otherwise indistinguishable from a run of what was just sent,
+and reads as a successful measurement of the wrong thing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.modules.task.task_server import TaskServer, TASK_CONTROL
+
+
+def _make_server():
+    """A TaskServer with no event loop, no ports, and no real account service."""
+    ts = TaskServer.__new__(TaskServer)
+    ts._task_control = {}
+    ts._connections = {}
+    ts._connection_id = 0
+    ts._unauthed_by_ip = {}
+    ts._allocated_ports = []
+    ts._reserved_ports = set()
+    ts._store_instance = None
+    ts._config = {}
+    ts._server = MagicMock()
+    ts._server.account.generate_token.return_value = 'pk_public'
+    ts.debug_message = MagicMock()
+    return ts
+
+
+def _pipeline(model='gpt-4.1-mini'):
+    return {
+        'project_id': 'project-1',
+        'source': 'src',
+        'components': [
+            {'id': 'src', 'provider': 'webhook', 'config': {}},
+            {'id': 'llm', 'provider': 'llm_openai', 'config': {'model': model}},
+        ],
+    }
+
+
+def _running(pipeline):
+    """A TASK_CONTROL whose task reports itself as still running."""
+    control = TASK_CONTROL()
+    control.token = 'tk_test'
+    control.id = 'abcd1234.src'
+    control.project_id = 'project-1'
+    control.source = 'src'
+    control.provider = 'webhook'
+    control.public_auth = 'pk_public'
+    control.pipeline = pipeline
+    control.task = MagicMock()
+    control.task.is_task_complete.return_value = False
+    return control
+
+
+def _request(pipeline):
+    return {
+        'command': 'launch',
+        'arguments': {'token': 'tk_test', 'pipeline': pipeline, 'useExisting': True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_reused_flag_marks_an_instance_that_was_already_running():
+    ts = _make_server()
+    ts._task_control['tk_test'] = _running(_pipeline())
+
+    result = await ts.start_task(_request(_pipeline()), conn=MagicMock())
+
+    assert result['reused'] is True
+    assert result['token'] == 'tk_test'
+
+
+@pytest.mark.asyncio
+async def test_a_differing_pipeline_is_reported_as_ignored():
+    ts = _make_server()
+    ts._task_control['tk_test'] = _running(_pipeline(model='gpt-4.1-mini'))
+
+    await ts.start_task(_request(_pipeline(model='claude-opus-5')), conn=MagicMock())
+
+    said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
+    assert 'ignoring the submitted pipeline' in said
+
+
+@pytest.mark.asyncio
+async def test_an_identical_pipeline_is_reused_without_the_notice():
+    ts = _make_server()
+    ts._task_control['tk_test'] = _running(_pipeline())
+
+    result = await ts.start_task(_request(_pipeline()), conn=MagicMock())
+
+    said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
+    assert 'ignoring the submitted pipeline' not in said
+    assert result['reused'] is True

--- a/packages/ai/tests/ai/modules/task/test_task_reuse.py
+++ b/packages/ai/tests/ai/modules/task/test_task_reuse.py
@@ -133,3 +133,47 @@ async def test_the_restarted_pipeline_is_what_a_later_reuse_compares_against():
     await ts.start_task(_request(restarted), conn=MagicMock())
     said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
     assert 'ignoring the submitted pipeline' not in said
+
+
+@pytest.mark.asyncio
+async def test_a_restart_stores_the_pipeline_in_the_shape_a_launch_would():
+    """
+    A launch stamps `source` and gives the source component a config. A restart
+    that stores the raw request would differ from the same pipeline after a
+    launch normalises it, so the comparison would report a difference that the
+    launch itself introduced.
+    """
+    ts = _make_server()
+    control = _running(_pipeline())
+    control.teamId = ''
+    ts._task_control['tk_test'] = control
+    ts.get_task_control = lambda token: control
+    control.task.restart_task = AsyncMock()
+    control.task.has_attached_debugger.return_value = False
+
+    # As a caller would write it: no config on the source node.
+    raw = {
+        'project_id': 'project-1',
+        'source': 'src',
+        'components': [{'id': 'src', 'provider': 'webhook'}, {'id': 'llm', 'provider': 'llm_openai'}],
+    }
+    conn = MagicMock()
+    conn._account_info = None
+    await ts.restart_task({'arguments': {'token': 'tk_test', 'pipeline': raw}}, conn=conn)
+
+    assert control.pipeline['source'] == 'src'
+    assert control.pipeline['components'][0]['config'] == {}
+
+    # The same pipeline submitted again must not read as different.
+    ts.debug_message.reset_mock()
+    resubmitted = {
+        'project_id': 'project-1',
+        'source': 'src',
+        'components': [{'id': 'src', 'provider': 'webhook'}, {'id': 'llm', 'provider': 'llm_openai'}],
+    }
+    await ts.start_task(
+        {'command': 'launch', 'arguments': {'token': 'tk_test', 'pipeline': resubmitted, 'useExisting': True}},
+        conn=MagicMock(),
+    )
+    said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
+    assert 'ignoring the submitted pipeline' not in said

--- a/packages/ai/tests/ai/modules/task/test_task_reuse.py
+++ b/packages/ai/tests/ai/modules/task/test_task_reuse.py
@@ -13,7 +13,7 @@ and reads as a successful measurement of the wrong thing.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -102,3 +102,34 @@ async def test_an_identical_pipeline_is_reused_without_the_notice():
     said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
     assert 'ignoring the submitted pipeline' not in said
     assert result['reused'] is True
+
+
+@pytest.mark.asyncio
+async def test_the_restarted_pipeline_is_what_a_later_reuse_compares_against():
+    """
+    restart(P2) then use(P2, useExisting) must not report a difference.
+
+    That is the documented way to apply new configuration to a live token, so
+    the control has to describe what is running. Left stale, the flow warns
+    about the pipeline that is actually loaded and stays silent about the one
+    that is not — exactly backwards.
+    """
+    ts = _make_server()
+    control = _running(_pipeline(model='gpt-4.1-mini'))
+    control.teamId = ''
+    ts._task_control['tk_test'] = control
+    ts.get_task_control = lambda token: control
+    control.task.restart_task = AsyncMock()
+    control.task.has_attached_debugger.return_value = False
+
+    restarted = _pipeline(model='claude-opus-5')
+    conn = MagicMock()
+    conn._account_info = None
+    await ts.restart_task({'arguments': {'token': 'tk_test', 'pipeline': restarted}}, conn=conn)
+
+    assert control.pipeline == restarted
+
+    ts.debug_message.reset_mock()
+    await ts.start_task(_request(restarted), conn=MagicMock())
+    said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
+    assert 'ignoring the submitted pipeline' not in said

--- a/packages/ai/tests/ai/modules/task/test_task_reuse.py
+++ b/packages/ai/tests/ai/modules/task/test_task_reuse.py
@@ -177,3 +177,32 @@ async def test_a_restart_stores_the_pipeline_in_the_shape_a_launch_would():
     )
     said = ' '.join(str(call) for call in ts.debug_message.call_args_list)
     assert 'ignoring the submitted pipeline' not in said
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_pipeline_is_refused_before_the_task_is_stopped():
+    """
+    Normalisation doubles as validation, so it has to happen first.
+
+    Rejecting after the restart would leave the task stopped, Task.restart_task
+    holding the new pipeline, and control.pipeline still naming the old one —
+    three views of the world, none of them running.
+    """
+    ts = _make_server()
+    original = _pipeline()
+    control = _running(original)
+    control.teamId = ''
+    ts._task_control['tk_test'] = control
+    ts.get_task_control = lambda token: control
+    control.task.restart_task = AsyncMock()
+    control.task.has_attached_debugger.return_value = False
+
+    # The source component the control names is not in this pipeline.
+    broken = {'project_id': 'project-1', 'components': [{'id': 'other', 'provider': 'webhook'}]}
+    conn = MagicMock()
+    conn._account_info = None
+    with pytest.raises(ValueError):
+        await ts.restart_task({'arguments': {'token': 'tk_test', 'pipeline': broken}}, conn=conn)
+
+    control.task.restart_task.assert_not_awaited()
+    assert control.pipeline is original, 'the record still describes what is running'

--- a/packages/client-typescript/docs/guide/methods/use.md
+++ b/packages/client-typescript/docs/guide/methods/use.md
@@ -61,7 +61,7 @@ const result = await client.use({
 | `token` | `str` / `string` | No | Custom task token (server generates one if not provided) |
 | `source` | `str` / `string` | No | Override the source component specified in the pipeline config |
 | `threads` | `int` / `number` | No | Number of processing threads (server decides default) |
-| `use_existing` / `useExisting` | `bool` / `boolean` | No | Reuse an existing pipeline with the same token |
+| `use_existing` / `useExisting` | `bool` / `boolean` | No | Reuse an existing pipeline with the same token. The submitted pipeline is **not** applied to an instance that is already running — see `reused` below |
 | `args` | `list[str]` / `string[]` | No | Command-line style arguments to pass to the pipeline |
 | `ttl` | `int` / `number` | No | Time-to-live in seconds for idle pipelines (0 = no timeout) |
 | `pipelineTraceLevel` | `str` / `string` | No | Trace level: `'none'`, `'metadata'`, `'summary'`, or `'full'` |
@@ -72,6 +72,8 @@ const result = await client.use({
 - **Description**: Object containing the task `token` and other pipeline startup metadata
 
 The returned `token` is required for all subsequent operations: sending data, checking status, and terminating the pipeline.
+
+`reused` is `true` when `useExisting` returned an instance that was already running rather than starting the pipeline you submitted. In that case the running instance keeps the configuration it was created with, and the pipeline in this call is ignored — including any edits since. It also keeps whatever state that instance has accumulated. Check this flag before treating a result as a run of the configuration you just sent; benchmarks and A/B comparisons are where an unnoticed reuse is most costly. Call `restart()` to apply new configuration to a live token.
 
 ## **Usage Examples**
 


### PR DESCRIPTION
## Summary

- Add `reused` to the `use()` response. It is `true` when `useExisting` returned an instance that was already running rather than starting the submitted pipeline, which until now was indistinguishable from a fresh launch.
- Log it when the submitted pipeline differs from the running one, so an edit-and-rerun loop says why nothing changed.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./dist/server/engine -m pytest packages/ai/tests/ai/modules/task packages/ai/tests/ai/modules/mcp` — 915 passed, including 3 new covering the reused flag, the differing-pipeline notice, and its absence when the pipeline is identical. `ruff check` / `format --check` clean.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none. The field is additive; the only consumer of this response (`mcp/tools/execution.py`) reads keys by name.

## Notes for the reviewer

Reuse itself is the right default — it is what keeps a warm instance cheap, and the PR does not change it. What was missing is that it was invisible.

The cost is not a confusing edit-test loop, it is that the failure produces *plausible results rather than errors*. From the session that turned this up: an A/B comparison of two pipeline versions returned identical numbers on all four test documents, which reads as "the change had no effect" and is in fact "the second version never ran". A configuration error that had already been fixed kept reappearing, because the value was still alive in an instance the file on disk no longer described. And since reuse carries the instance's accumulated state, run 3 of a benchmark benefits from what runs 1 and 2 taught it — inflating quality numbers in the direction that flatters whatever is being tested.

The notice goes through `debug_message` rather than `warning()` because reuse is legitimate and expected in production; a warning on every reconnect would be noise. The `reused` flag is the part a caller can act on programmatically.

Not included: the `restart_if_changed` option floated in the issue. `restart()` already exists and does the work, and making it automatic is a behaviour decision worth taking on its own rather than bundling here.

## Linked Issue

Fixes #2153
Also Fixes #2091


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Task reuse results now indicate when an existing task instance was reused.
  * Reused tasks retain their current configuration and accumulated state.

* **Bug Fixes**
  * Different pipelines submitted to active tasks are ignored consistently.
  * Restarting applies the updated pipeline for future reuse comparisons.
  * Invalid pipelines are rejected before stopping an existing task.
  * Restarting with a different source is rejected.

* **Documentation**
  * Clarified `useExisting` behavior and when to use `restart()` for new configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->