### PR TITLE
fix(config): name a config key that is almost, but not quite, a real one

### DIFF
--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -110,15 +110,20 @@ class Config:
         nodes read config keys their services.json never declares, and warning
         about those on every run would train people to ignore the message.
 
-        Two signals qualify:
+        Three signals qualify:
+          - a key that matches except for casing. merge() keys off the exact
+            spelling, so "MODELOUTPUTTOKENS" overrides nothing at all.
           - a known key that ENDS with the unknown one ("outputTokens" ->
             "modelOutputTokens"), the dropped-prefix mistake this exists for.
             Not the reverse, which fires on unrelated names sharing a suffix.
           - a very close spelling (difflib at 0.9), for a plain typo.
         """
         lowered = unknown.lower()
-        if any(key.lower() == lowered for key in knownKeys):
+        if unknown in knownKeys:
             return None
+        for key in sorted(knownKeys):
+            if key.lower() == lowered:
+                return key
         for key in sorted(knownKeys):
             candidate = key.lower()
             if len(candidate) > len(lowered) and candidate.endswith(lowered):

--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -6,6 +6,11 @@ from typing import Dict, Any
 from rocketlib import getServiceDefinition, IJson, warning
 
 
+# Fields the catalogue keeps about a profile, which a pipeline never sets. Kept out
+# of the known-key set so a near-miss cannot be answered with one of them.
+_CATALOGUE_METADATA = frozenset({'title', 'modelSource', 'deprecated', 'deprecatedBy', 'deprecatedSince', 'migration'})
+
+
 class Config:
     """
     Loads and parses the aiconfig.json file (deprecated).
@@ -95,7 +100,7 @@ class Config:
         preconfig = service.get('preconfig') or {}
         for profile in (preconfig.get('profiles') or {}).values():
             if isinstance(profile, (dict, IJson)):
-                keys.update(profile.keys())
+                keys.update(key for key in profile.keys() if key not in _CATALOGUE_METADATA)
         for field in service.get('fields') or {}:
             keys.add(field.split('.')[-1] if '.' in field else field)
         return keys

--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -1,6 +1,7 @@
 import json5
 import sys
 import os
+import difflib
 from typing import Dict, Any
 from rocketlib import getServiceDefinition, IJson, warning
 
@@ -79,6 +80,71 @@ class Config:
         if service is None or 'preconfig' not in service:
             return {}
         return service['preconfig'].get('profiles') or {}
+
+    @staticmethod
+    def _knownConfigKeys(service: Dict) -> set:
+        """
+        Collect every config key this node legitimately accepts.
+
+        Two sources, unioned: the keys declared across all of the node's profiles
+        (so a key present on any profile counts, e.g. modelOutputTokens, which the
+        "custom" placeholder omits), and the names in the node's "fields" block,
+        with any "<prefix>." stripped.
+        """
+        keys: set = set()
+        preconfig = service.get('preconfig') or {}
+        for profile in (preconfig.get('profiles') or {}).values():
+            if isinstance(profile, (dict, IJson)):
+                keys.update(profile.keys())
+        for field in service.get('fields') or {}:
+            keys.add(field.split('.')[-1] if '.' in field else field)
+        return keys
+
+    @staticmethod
+    def _suggestKey(unknown: str, knownKeys: set) -> str | None:
+        """
+        Return the key ``unknown`` was probably meant to be, or None.
+
+        Deliberately narrow. A near-miss is reported only when it is nearly
+        certain, because an unrecognised key is not proof of a mistake: several
+        nodes read config keys their services.json never declares, and warning
+        about those on every run would train people to ignore the message.
+
+        Two signals qualify:
+          - a known key that ENDS with the unknown one ("outputTokens" ->
+            "modelOutputTokens"), the dropped-prefix mistake this exists for.
+            Not the reverse, which fires on unrelated names sharing a suffix.
+          - a very close spelling (difflib at 0.9), for a plain typo.
+        """
+        lowered = unknown.lower()
+        if any(key.lower() == lowered for key in knownKeys):
+            return None
+        for key in sorted(knownKeys):
+            candidate = key.lower()
+            if len(candidate) > len(lowered) and candidate.endswith(lowered):
+                return key
+        matches = difflib.get_close_matches(unknown, [k for k in knownKeys if k.lower() != lowered], n=1, cutoff=0.9)
+        return matches[0] if matches else None
+
+    @staticmethod
+    def _warnMisnamedKeys(logicalType: str, service: Dict, userConfig: Dict) -> None:
+        """
+        Warn about a config key that is almost, but not quite, a real one.
+
+        Such a key is copied into the merged config and then never read, so the
+        node runs with a default the author believes they overrode. Nothing else
+        reports it: the pipeline publishes, runs, and produces output.
+        """
+        knownKeys = Config._knownConfigKeys(service)
+        if not knownKeys:
+            return
+        for key in userConfig:
+            suggestion = Config._suggestKey(key, knownKeys)
+            if suggestion:
+                warning(
+                    f'{logicalType}: unknown config key "{key}" - did you mean "{suggestion}"? '
+                    f'"{key}" is ignored, so the node runs with the default.'
+                )
 
     @staticmethod
     def getNodeConfig(logicalType: str, connConfig: Dict):
@@ -186,6 +252,8 @@ class Config:
                         combined[key] = value
                 userConfig = combined
 
+            Config._warnMisnamedKeys(logicalType, service, userConfig)
+
             # Merge it
             config = merge(userConfig, defaultConfig)
 
@@ -211,6 +279,8 @@ class Config:
             # If it is none, then set to empty
             if not userConfig:
                 userConfig = {}
+
+            Config._warnMisnamedKeys(logicalType, service, userConfig)
 
             # Merge defaultConfig into userConfig
             config = merge(userConfig, defaultConfig)

--- a/packages/ai/tests/ai/common/test_config_key_warnings.py
+++ b/packages/ai/tests/ai/common/test_config_key_warnings.py
@@ -1,0 +1,140 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+A config key that is nearly a real one is reported instead of silently dropped.
+
+`merge()` copies unknown keys into the merged config, where nothing reads them,
+so the node runs with a default the author believes they overrode. The check is
+deliberately narrow: several nodes read keys their services.json never declares,
+and warning about every unrecognised key would make the message worthless.
+"""
+
+from ai.common.config import Config
+
+
+SERVICE = {
+    'preconfig': {
+        'default': 'gpt-4-1-mini',
+        'profiles': {
+            'custom': {'model': '', 'modelTotalTokens': 16384, 'apikey': ''},
+            'gpt-4-1-mini': {
+                'title': 'GPT-4.1 mini',
+                'model': 'gpt-4.1-mini',
+                'modelTotalTokens': 1047576,
+                'modelOutputTokens': 32768,
+                'apikey': '',
+            },
+        },
+    },
+    'fields': {
+        'model': {'type': 'string'},
+        'modelTotalTokens': {'type': 'number'},
+        'openai.profile': {'type': 'string'},
+    },
+}
+
+
+class TestKnownConfigKeys:
+    def test_unions_every_profile_not_just_the_selected_one(self):
+        keys = Config._knownConfigKeys(SERVICE)
+        # 'custom' omits modelOutputTokens, but it is a real key of this node.
+        assert 'modelOutputTokens' in keys
+        assert 'apikey' in keys
+
+    def test_strips_the_node_prefix_from_field_names(self):
+        assert 'profile' in Config._knownConfigKeys(SERVICE)
+
+    def test_empty_service(self):
+        assert Config._knownConfigKeys({}) == set()
+
+
+class TestSuggestKey:
+    def test_dropped_prefix_is_the_case_this_exists_for(self):
+        keys = Config._knownConfigKeys(SERVICE)
+        assert Config._suggestKey('outputTokens', keys) == 'modelOutputTokens'
+        assert Config._suggestKey('totalTokens', keys) == 'modelTotalTokens'
+
+    def test_a_real_key_is_not_flagged(self):
+        keys = Config._knownConfigKeys(SERVICE)
+        for key in ('model', 'modelTotalTokens', 'modelOutputTokens', 'apikey'):
+            assert Config._suggestKey(key, keys) is None
+
+    def test_case_differences_are_not_a_mistake(self):
+        assert Config._suggestKey('MODELOUTPUTTOKENS', Config._knownConfigKeys(SERVICE)) is None
+
+    def test_an_unrelated_key_is_left_alone(self):
+        keys = Config._knownConfigKeys(SERVICE)
+        # Nodes legitimately read keys their services.json does not declare
+        # (score, similarity, renderChunkSize...). Those must stay silent.
+        for key in ('thisKeyDoesNotExist', 'score', 'similarity', 'renderChunkSize'):
+            assert Config._suggestKey(key, keys) is None
+
+    def test_a_shared_suffix_alone_does_not_qualify(self):
+        # 'max_model_tokens' ends with 'tokens' but is not a misspelling of it.
+        assert Config._suggestKey('max_model_tokens', {'tokens', 'model'}) is None
+
+    def test_a_longer_known_key_starting_with_the_unknown_one_is_not_a_match(self):
+        # 'anonymize' vs 'anonymizeChar' — a real pair in the catalogue, both valid.
+        assert Config._suggestKey('anonymize', {'anonymizeChar', 'anonymizeAll'}) is None
+
+    def test_a_plain_typo_is_caught(self):
+        assert Config._suggestKey('modelOutputTokns', Config._knownConfigKeys(SERVICE)) == 'modelOutputTokens'
+
+
+class TestWarnMisnamedKeys:
+    def test_warns_naming_both_keys(self, monkeypatch):
+        said = []
+        monkeypatch.setattr('ai.common.config.warning', said.append)
+        Config._warnMisnamedKeys('llm_openai', SERVICE, {'apikey': '', 'outputTokens': 32768})
+        assert len(said) == 1
+        assert 'outputTokens' in said[0]
+        assert 'modelOutputTokens' in said[0]
+
+    def test_silent_on_a_correct_config(self, monkeypatch):
+        said = []
+        monkeypatch.setattr('ai.common.config.warning', said.append)
+        Config._warnMisnamedKeys('llm_openai', SERVICE, {'model': 'gpt-4.1-mini', 'modelOutputTokens': 32768})
+        assert said == []
+
+    def test_a_service_declaring_nothing_is_not_second_guessed(self, monkeypatch):
+        said = []
+        monkeypatch.setattr('ai.common.config.warning', said.append)
+        Config._warnMisnamedKeys('some_node', {}, {'outputTokens': 1})
+        assert said == []
+
+
+class TestAgainstTheRealCatalogue:
+    """Guards the heuristic: no node may flag a key it declares itself."""
+
+    def _services(self):
+        import glob
+        import json5
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[5]
+        for path in sorted(glob.glob(str(repo_root / 'nodes/src/nodes/*/services.json'))):
+            try:
+                with open(path, encoding='utf-8') as fh:
+                    yield Path(path).parent.name, json5.load(fh)
+            except Exception:
+                continue
+
+    def test_no_declared_key_is_reported_as_a_mistake(self):
+        offenders = []
+        for node, service in self._services():
+            keys = Config._knownConfigKeys(service)
+            for key in keys:
+                suggestion = Config._suggestKey(key, keys)
+                if suggestion:
+                    offenders.append(f'{node}: {key} -> {suggestion}')
+        assert not offenders, 'Valid keys flagged as mistakes:\n' + '\n'.join(offenders)
+
+    def test_the_motivating_typo_is_still_caught(self):
+        for node, service in self._services():
+            if node == 'llm_openai':
+                assert Config._suggestKey('outputTokens', Config._knownConfigKeys(service)) == 'modelOutputTokens'
+                return
+        raise AssertionError('llm_openai/services.json not found')

--- a/packages/ai/tests/ai/common/test_config_key_warnings.py
+++ b/packages/ai/tests/ai/common/test_config_key_warnings.py
@@ -62,8 +62,10 @@ class TestSuggestKey:
         for key in ('model', 'modelTotalTokens', 'modelOutputTokens', 'apikey'):
             assert Config._suggestKey(key, keys) is None
 
-    def test_case_differences_are_not_a_mistake(self):
-        assert Config._suggestKey('MODELOUTPUTTOKENS', Config._knownConfigKeys(SERVICE)) is None
+    def test_a_casing_difference_is_a_mistake(self):
+        # merge() keys off the exact spelling, so this overrides nothing.
+        assert Config._suggestKey('MODELOUTPUTTOKENS', Config._knownConfigKeys(SERVICE)) == 'modelOutputTokens'
+        assert Config._suggestKey('modeloutputtokens', Config._knownConfigKeys(SERVICE)) == 'modelOutputTokens'
 
     def test_an_unrelated_key_is_left_alone(self):
         keys = Config._knownConfigKeys(SERVICE)
@@ -116,20 +118,22 @@ class TestAgainstTheRealCatalogue:
 
         repo_root = Path(__file__).resolve().parents[5]
         for path in sorted(glob.glob(str(repo_root / 'nodes/src/nodes/*/services.json'))):
-            try:
-                with open(path, encoding='utf-8') as fh:
-                    yield Path(path).parent.name, json5.load(fh)
-            except Exception:
-                continue
+            # Never swallowed: a service that fails to load would silently drop out
+            # of the sweep below and leave it passing on nothing.
+            with open(path, encoding='utf-8') as fh:
+                yield Path(path).parent.name, json5.load(fh)
 
     def test_no_declared_key_is_reported_as_a_mistake(self):
         offenders = []
+        checked = 0
         for node, service in self._services():
+            checked += 1
             keys = Config._knownConfigKeys(service)
             for key in keys:
                 suggestion = Config._suggestKey(key, keys)
                 if suggestion:
                     offenders.append(f'{node}: {key} -> {suggestion}')
+        assert checked > 50, f'only {checked} services.json files found — the sweep is not running'
         assert not offenders, 'Valid keys flagged as mistakes:\n' + '\n'.join(offenders)
 
     def test_the_motivating_typo_is_still_caught(self):

--- a/packages/ai/tests/ai/common/test_config_key_warnings.py
+++ b/packages/ai/tests/ai/common/test_config_key_warnings.py
@@ -50,6 +50,14 @@ class TestKnownConfigKeys:
     def test_empty_service(self):
         assert Config._knownConfigKeys({}) == set()
 
+    def test_catalogue_metadata_is_not_a_configuration_key(self):
+        # A pipeline never sets these, so they must not be offered as a suggestion.
+        keys = Config._knownConfigKeys(
+            {'preconfig': {'profiles': {'p': {'title': 'X', 'deprecated': True, 'migration': 'use y', 'model': 'm'}}}}
+        )
+        assert keys == {'model'}
+        assert Config._suggestKey('deprecatd', keys) is None
+
 
 class TestSuggestKey:
     def test_dropped_prefix_is_the_case_this_exists_for(self):


### PR DESCRIPTION
## Summary

- Warn when a node's config carries a key that is almost, but not quite, a real one — `outputTokens` where the engine reads `modelOutputTokens`. The message names both keys and says the value is being ignored.
- Known keys are the union of every profile the node declares (so `modelOutputTokens` counts even though the `custom` placeholder omits it) plus the names in its `fields` block.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./dist/server/engine -m pytest packages/ai/tests` — 2490 passed, 120 skipped. 15 new, including a guard that runs the heuristic over all 120 real `services.json` files and fails if any node flags a key it declares itself. `ruff check` / `format --check` clean.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none. A warning, not an error, so existing pipelines carrying harmless leftovers keep running.

## Notes for the reviewer

**The check is narrower than the issue asks for, on purpose.** "Warn about every unrecognised key" is not viable today: **15 nodes read config keys their `services.json` never declares** — `store_atlas` alone reads eight (`score`, `similarity`, `renderChunkSize`, `payloadLimit`, `collection`, `apikey`, `textIndexName`, `vectorIndexName`), and `store_chroma`, `store_milvus`, `store_qdrant`, `store_weaviate`, `store_postgres`, `store_pinecone`, `rocketride_vector`, `preprocessor_langchain`, `ocr`, `detect`, `anonymize`, `llm_ollama` and `llm_vision_gemini` each read one or more. Every pipeline using those would warn on every run, which is how a message gets tuned out.

So this reports only a near-certain miss:

- a known key that **ends with** the unknown one (`outputTokens` → `modelOutputTokens`) — the dropped-prefix mistake this issue is about. Deliberately not the reverse: `max_model_tokens` ends with `tokens` and is not a misspelling of it.
- a difflib match at 0.9, for a plain typo. 0.85 was too loose — it paired `anonymize` with `anonymizeAll`, two valid keys of the same node.

Measured against the whole catalogue, both signals together flag **zero** valid keys, and the two from the issue (`outputTokens`, `totalTokens`) resolve correctly. The catalogue test keeps that true.

What this does not catch is an unknown key resembling nothing, like the issue's `thisKeyDoesNotExist`. Catching those needs the 15 nodes above to declare what they read, which is a data change across those `services.json` files and worth doing separately — it would also make the UI schema honest, not just this warning.

The other half of the issue — surfacing this in `client.validate()` before publishing — is not here either. This lands on the path every node already goes through, so it covers publish-and-run today; the validate-time version can reuse `Config._suggestKey` when someone wires it up.

## Linked Issue

Fixes #2152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings for likely misspelled AI configuration keys.
  * Improved typo detection across profiles, including case variations, missing prefixes, and common naming mismatches.
  * Added suggestions for likely corrections to configuration keys.
  * Prevented warnings for valid configuration keys in both default and explicitly selected profiles.

* **Tests**
  * Added coverage for key validation, typo suggestions, profile handling, and real-world node configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->