### PR TITLE
fix(shell): don't paint the outage banner over a reachable server

### DIFF
--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -216,6 +216,66 @@ test('handleStoredTokenFailure preserves credentials for retryable server failur
 	});
 });
 
+test('handleStoredTokenFailure downgrades a network latch to session expiry when a same-origin probe answers', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	let probed: string | undefined;
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: async (input: unknown) => {
+			probed = String(input);
+			return { ok: true };
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		const shouldClearToken = manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+
+		// The network failure latches synchronously so recovery UI can render it.
+		assert.equal(shouldClearToken, false);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+
+		// The same-origin probe answering proves the server is reachable, so the
+		// latched failure downgrades to session expiry instead of a false outage.
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(probed, '/version');
+		assert.equal(manager.connectionStatus.state, ConnectionState.AUTH_FAILED);
+		assert.deepEqual(manager.connectionStatus.lastFailure, {
+			kind: 'auth',
+			lastError: 'Your session has expired — please sign in again.',
+			errorKind: 'session',
+		});
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
+test('handleStoredTokenFailure keeps the network latch when the same-origin probe fails too', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: async () => {
+			throw new TypeError('Failed to fetch');
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// Both requests dead: genuinely unreachable, the network banner stands.
+		assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
 test('clearToken removes current and legacy stored tokens', () => {
 	const removedLocalKeys: string[] = [];
 	const removedSessionKeys: string[] = [];

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -1093,6 +1093,34 @@ export class ConnectionManager implements IConnectionManager {
 				errorKind: isAuthFailure ? 'session' : undefined,
 			},
 		});
+		// A CORS-blocked or proxy-dropped request and a dead server both surface
+		// as the same opaque network TypeError, but only one means the server is
+		// down. Disambiguate with a same-origin probe, which every topology
+		// serves: single-host deployments answer /version on the page origin and
+		// CDN-split ones proxy it through the edge. When the probe answers, the
+		// server is reachable and the stored token simply couldn't be validated,
+		// so recovery is sign-in, not retry; re-latch as a session failure so the
+		// signed-out landing gets the sign-in banner instead of a false outage.
+		if (isNetworkFailure) {
+			const generation = this.connectionGeneration;
+			void fetch('/version', { cache: 'no-store' }).then((res) => {
+				if (!res.ok) return;
+				if (this.connectionGeneration !== generation) return;
+				// Only downgrade the failure this call latched; a newer failure
+				// or a successful reconnect must not be overwritten.
+				if (this.connectionStatus.lastFailure?.kind !== 'network') return;
+				const message = 'Your session has expired — please sign in again.';
+				this.updateConnectionStatus({
+					state: ConnectionState.AUTH_FAILED,
+					lastError: message,
+					progressMessage: undefined,
+					errorKind: 'session',
+					lastFailure: { kind: 'auth', lastError: message, errorKind: 'session' },
+				});
+			}).catch(() => {
+				// Probe failed too: genuinely unreachable, keep the network banner.
+			});
+		}
 		return isAuthFailure;
 	}
 


### PR DESCRIPTION
## What

When a stored-token bootstrap fails with a network-class error, probe `/version` same-origin before leaving the "Can't reach the server" banner up. If the probe answers, the server is reachable and the latched failure downgrades to the session-expired banner with a Sign in action. If the probe fails too, the network banner stands unchanged.

## Why

A CORS-blocked request and a dead server both surface as the same opaque `TypeError: Failed to fetch`. On staging, an expired session plus the missing `RR_CORS_ORIGINS` (being fixed in rocketride-saas#616) latched `kind:'network'` and painted the outage banner over the signed-out landing. That converted a routine session expiry into two false "staging is down" reports in two days (PD #126 and today's #engineering thread), with everyone signed-out seeing it from every browser.

The same-origin probe is topology-safe: single-host deployments serve `/version` on the page origin directly, and the CDN-split production proxies it through the edge. Verified live on both staging.rocketride.ai and cloud.rocketride.ai.

## Safety

The async downgrade is generation-guarded and only replaces a failure that is still latched as `network`, so a newer failure or a successful reconnect is never overwritten. The sync contract of `handleStoredTokenFailure` (return value drives token clearing) is unchanged.

## Tests

Two new cases in `connection.test.ts`: probe answers → downgrade to auth/session with the expired-session message; probe fails → network latch and FAILED state stand. Full suite: 26/26 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rmuLKEUUMCxcV5p5T6xwr