### PR TITLE
feat(canvas,vscode): starter templates hierarchy and canvas auto-launch on welcome completion (#2184)

### DIFF
--- a/apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx
+++ b/apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx
@@ -150,7 +150,6 @@ const styles = {
 		fontWeight: 500,
 		color: 'var(--rr-text-secondary)',
 		cursor: 'pointer',
-		outline: 'none',
 		userSelect: 'none' as const,
 		padding: '4px 0',
 	},
@@ -172,6 +171,13 @@ interface IEmptyCanvasPromptProps {
 	onNodeAdded: (nodeId: string, formDataValid: boolean) => void;
 }
 
+/**
+ * EmptyCanvasPrompt renders the starting point overlay when the pipeline canvas has no nodes.
+ * Prioritizes curated starter templates and nests raw source components in an advanced collapsible section.
+ *
+ * @param props - Component properties including template instantiation and node addition callbacks.
+ * @returns The rendered empty canvas prompt overlay or null if no sources/templates are available.
+ */
 export default function EmptyCanvasPrompt({ instantiateTemplate, onNodeAdded }: IEmptyCanvasPromptProps): ReactElement | null {
 	const { servicesJson } = useFlowProject();
 	const { addNode } = useFlowGraph();

--- a/apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx
+++ b/apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx
@@ -142,6 +142,24 @@ const styles = {
 		color: 'var(--rr-text-secondary)',
 		lineHeight: '1.3',
 	},
+	details: {
+		width: '100%',
+	},
+	summary: {
+		fontSize: '12px',
+		fontWeight: 500,
+		color: 'var(--rr-text-secondary)',
+		cursor: 'pointer',
+		outline: 'none',
+		userSelect: 'none' as const,
+		padding: '4px 0',
+	},
+	note: {
+		margin: '8px 0 10px 0',
+		fontSize: '11.5px',
+		color: 'var(--rr-text-secondary)',
+		lineHeight: '1.4',
+	},
 };
 
 // =============================================================================
@@ -231,39 +249,11 @@ export default function EmptyCanvasPrompt({ instantiateTemplate, onNodeAdded }: 
 		<>
 			<div style={styles.overlay}>
 				<div style={styles.card}>
-					{/* Sources section */}
-					<h3 style={styles.heading}>Select your starting point</h3>
-					<p style={styles.subheading}>Choose a source to begin building your pipeline</p>
-					<div style={styles.grid}>
-						{sources.map(({ key, service }) => (
-							<button
-								key={key}
-								style={{
-									...styles.item,
-									...(hoveredKey === key
-										? {
-												backgroundColor: 'var(--rr-bg-widget-hover)',
-												borderColor: 'var(--rr-accent)',
-											}
-										: {}),
-								}}
-								onClick={() => onClickSource(key)}
-								onMouseEnter={() => setHoveredKey(key)}
-								onMouseLeave={() => setHoveredKey(null)}
-							>
-								<Icon name={service.icon} width="18px" height="18px" style={styles.itemIcon} />
-
-								<span style={styles.itemTitle}>{service.title ?? key}</span>
-							</button>
-						))}
-					</div>
-
 					{/* Templates section */}
 					{templateList.length > 0 && (
 						<>
-							<div style={styles.divider} />
-							<h3 style={styles.heading}>Or start from a template</h3>
-							<p style={styles.subheading}>Pre-built pipeline skeletons you can customize</p>
+							<h3 style={styles.heading}>Choose a Starter Pipeline</h3>
+							<p style={styles.subheading}>Select a working template to customize</p>
 							<div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
 								{templateList.map(({ slug, template }) => (
 									<button
@@ -293,6 +283,40 @@ export default function EmptyCanvasPrompt({ instantiateTemplate, onNodeAdded }: 
 									</button>
 								))}
 							</div>
+						</>
+					)}
+
+					{/* Raw sources section (wrapped in <details>) */}
+					{sources.length > 0 && (
+						<>
+							{templateList.length > 0 && <div style={styles.divider} />}
+							<details style={styles.details}>
+								<summary style={styles.summary}>Advanced: Start with a raw source component</summary>
+								<p style={styles.note}>Every pipeline must begin with a single source component.</p>
+								<div style={styles.grid}>
+									{sources.map(({ key, service }) => (
+										<button
+											key={key}
+											style={{
+												...styles.item,
+												...(hoveredKey === key
+													? {
+															backgroundColor: 'var(--rr-bg-widget-hover)',
+															borderColor: 'var(--rr-accent)',
+														}
+													: {}),
+											}}
+											onClick={() => onClickSource(key)}
+											onMouseEnter={() => setHoveredKey(key)}
+											onMouseLeave={() => setHoveredKey(null)}
+										>
+											<Icon name={service.icon} width="18px" height="18px" style={styles.itemIcon} />
+
+											<span style={styles.itemTitle}>{service.title ?? key}</span>
+										</button>
+									))}
+								</div>
+							</details>
 						</>
 					)}
 				</div>

--- a/apps/vscode/src/providers/WelcomeProvider.ts
+++ b/apps/vscode/src/providers/WelcomeProvider.ts
@@ -243,6 +243,9 @@ export class WelcomeProvider {
 
 			// Step 6: Close panel — engines are starting, CMs will auto-connect
 			this.panel?.dispose();
+
+			// Auto-launch blank canvas after welcome completes so user lands in the builder
+			void vscode.commands.executeCommand('rocketride.pipeline.new');
 		} catch (error) {
 			console.error('[WelcomeProvider] Failed to save settings:', error);
 			this.panel?.webview.postMessage({ type: 'showMessage', level: 'error', message: `Failed to save settings: ${error}` });


### PR DESCRIPTION
## Summary

Closes #2184

The first-time user experience in the visual pipeline editor suffered from two onboarding drop-offs: (1) completing the Welcome setup panel closed the webview and left the user on a blank workspace with no document open, and (2) opening an empty `.pipe` file presented a raw, alphabetical grid of 10+ backend source nodes (`aparavi_aql`, `db_mysql`, `webhook`, etc.) while burying working pipeline templates at the bottom.

This PR addresses both issues:
- **`EmptyCanvasPrompt.tsx`**: Reorders the prompt card so starter templates are the primary hero section (**"Choose a Starter Pipeline"**), styled as clickable cards with theme hover borders. Raw source components are tucked into a collapsible `<details>` element (**"Advanced: Start with a raw source component"**) accompanied by an architectural rule note explaining that every pipeline starts with a single source node.
- **`WelcomeProvider.ts`**: Immediately dispatches `rocketride.pipeline.new` upon closing the Welcome panel in `saveAndConnect()`, guiding the user directly into an untitled pipeline editor.

---

## Changes

### 1. `apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx`
```diff
+	details: {
+		width: '100%',
+	},
+	summary: {
+		fontSize: '12px',
+		fontWeight: 500,
+		color: 'var(--rr-text-secondary)',
+		cursor: 'pointer',
+		outline: 'none',
+		userSelect: 'none' as const,
+		padding: '4px 0',
+	},
+	note: {
+		margin: '8px 0 10px 0',
+		fontSize: '11.5px',
+		color: 'var(--rr-text-secondary)',
+		lineHeight: '1.4',
+	},
...
-					{/* Sources section */}
-					<h3 style={styles.heading}>Select your starting point</h3>
-					<p style={styles.subheading}>Choose a source to begin building your pipeline</p>
-					<div style={styles.grid}>
...
-					{/* Templates section */}
-					{templateList.length > 0 && (
-						<>
-							<div style={styles.divider} />
-							<h3 style={styles.heading}>Or start from a template</h3>
-							<p style={styles.subheading}>Pre-built pipeline skeletons you can customize</p>
+					{/* Templates section */}
+					{templateList.length > 0 && (
+						<>
+							<h3 style={styles.heading}>Choose a Starter Pipeline</h3>
+							<p style={styles.subheading}>Select a working template to customize</p>
...
+					{/* Raw sources section (wrapped in <details>) */}
+					{sources.length > 0 && (
+						<>
+							{templateList.length > 0 && <div style={styles.divider} />}
+							<details style={styles.details}>
+								<summary style={styles.summary}>Advanced: Start with a raw source component</summary>
+								<p style={styles.note}>Every pipeline must begin with a single source component.</p>
+								<div style={styles.grid}>
+									{sources.map(({ key, service }) => (
...
+							</details>
+						</>
+					)}
```

### 2. `apps/vscode/src/providers/WelcomeProvider.ts`
```diff
 			// Step 6: Close panel — engines are starting, CMs will auto-connect
 			this.panel?.dispose();
+
+			// Auto-launch blank canvas after welcome completes so user lands in the builder
+			void vscode.commands.executeCommand('rocketride.pipeline.new');
 		} catch (error) {
```

---

## Root Cause

1. **Dead-End Setup**: `WelcomeProvider.saveAndConnect()` ran through connection initialization and called `this.panel?.dispose()`, but never triggered an open document action. Users finished setup with no obvious next step.
2. **Component Catalog Overload**: `EmptyCanvasPrompt` iterated over all services matching `classType.includes('source')` and rendered them above templates. Clicking a source dropped a lone node on the canvas, leaving users who don't yet know RocketRide's lane wiring rules stranded. Pre-built templates from `templates.json` were hidden below a divider as plain text buttons.

---

## Testing

- **Component Contract Audit**: Confirmed `EmptyCanvasPrompt.tsx` preserves its public interface (`IEmptyCanvasPromptProps`) with unchanged callbacks (`instantiateTemplate`, `onNodeAdded`).
- **Visual & Interaction Verification**:
  - Starter templates (`rag-chat`, `document-parser`, `rocketride-wave-agent`) render as the top section with title, description, and hover border accents (`var(--rr-accent)`).
  - Clicking a template launches `TemplatePickerDialog` or instantiates the graph as expected.
  - Raw sources grid is collapsed by default under `<details>` and expands upon click with the architectural note displayed.
- **Welcome Flow Verification**:
  - `saveAndConnect()` invokes `rocketride.pipeline.new` asynchronously after panel disposal, verified against `extension.ts` command registry.

---

## Notes

- Changes are strictly limited to `apps/shared/src/components/canvas/components/EmptyCanvasPrompt.tsx` and `apps/vscode/src/providers/WelcomeProvider.ts`.
- Uses existing design tokens (`var(--rr-*)`) without adding external dependencies or changing backend schemas.
- Preserves all template resolution, auto-fit, and config-toast behaviors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Starter pipelines are now the primary option when creating a new canvas.
  - Advanced users can expand a section to start with a raw source component.
  - Added explanatory guidance for the advanced source-based workflow.
  - After connecting through the welcome experience for the first time, a blank pipeline canvas now opens automatically in the builder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->