### PR TITLE
fix(nodes): map the SMB password text_output added

### DIFF
--- a/packages/ai/src/ai/modules/mcp/credentials.json
+++ b/packages/ai/src/ai/modules/mcp/credentials.json
@@ -698,6 +698,18 @@
       }
     ]
   },
+  "text-output": {
+    "title": "Text Output",
+    "fields": [
+      {
+        "path": "text_output.password",
+        "title": "SMB password",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_TEXT_OUTPUT_PASSWORD"
+      }
+    ]
+  },
   "tool_apify": {
     "title": "tool_apify",
     "fields": [


### PR DESCRIPTION
## Summary

- Map `text_output.password` in the credentials catalog, so `nodes:credentials-check` passes again on `develop`.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`node nodes/scripts/gen-credentials.mjs --check` — was failing on `develop` with the unmapped path, now reports *"catalog matches detected credential-shaped fields"*. Re-running the generator appends nothing, so the entry is what the generator would produce and the check stays green.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; one catalog entry.

## Notes for the reviewer

**`develop` is currently red, not just one PR.** #1178 gave `text_output` a `password` field for SMB shares and did not regenerate the catalog, so the *Shell API contract* job fails for every PR that rebases onto `develop`:

```
Unmapped credential path(s) - run nodes:credentials-generate to add stubs:
  text-output: text_output.password
```

I hit it on #2165 and confirmed it reproduces on `develop` with nothing of mine applied, which is why this is its own PR rather than a fix buried in an unrelated one.

**Curated, not left as the stub.** The generator emits `required: true` and repeats the path as the title; the field is `optional: true` in `services.json`, so `required` is false here, and the title says what it is (*SMB password*). That also keeps it out of the 74 entries the check already warns are waiting for a curated name — no reason to make it the 75th.

## Linked Issue

Fixes #2193

Cause: #1178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional text-output credential configuration with support for an SMB password.
  * Included the `ROCKETRIDE_TEXT_OUTPUT_PASSWORD` environment variable as a suggested configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->