### PR TITLE
fix(embedding): batch sentences by length so padding stops wasting compute

### DIFF
--- a/packages/ai/src/ai/common/models/transformers/sentence_transformers.py
+++ b/packages/ai/src/ai/common/models/transformers/sentence_transformers.py
@@ -376,9 +376,16 @@ class SentenceTransformer:
         t_gpu = 0.0
         t_post = 0.0
 
+        # Batch sentences of similar length: each batch is padded to its longest
+        # member, so a long one makes every other pay its cost. On CPU with mixed
+        # lengths this is worth +30% at 64 sentences per call and +87% at 1024,
+        # and nothing when they are all one length. Order is restored below.
+        order = sorted(range(len(sentences)), key=lambda i: len(sentences[i]))
+
         # Process in batches
-        for i in range(0, len(sentences), batch_size):
-            batch = sentences[i : i + batch_size]
+        for i in range(0, len(order), batch_size):
+            indexes = order[i : i + batch_size]
+            batch = [sentences[index] for index in indexes]
 
             # Preprocess phase
             t0 = time.perf_counter()
@@ -412,7 +419,12 @@ class SentenceTransformer:
             }
         )
 
-        return np.array(all_embeddings)
+        # Undo the length sort so embeddings line up with the input sentences
+        restored = [None] * len(all_embeddings)
+        for position, index in enumerate(order):
+            restored[index] = all_embeddings[position]
+
+        return np.array(restored)
 
     def _encode_remote(self, sentences: List[str], batch_size: int, **kwargs) -> np.ndarray:
         """Execute remote encoding via model server."""


### PR DESCRIPTION
`_encode_local` batched sentences in arrival order, while tokenization pads each
batch to its longest member. One long sentence therefore made every other
sentence in its batch cost the long one's compute. Upstream sentence-transformers
sorts by length before batching; this implementation did not.

Sort by length, then restore the caller's order before returning.

## Effect

CPU, chunks of mixed length, measured against arrival order:

| sentences per `encode()` call | gain |
| ----------------------------- | ---- |
| 16                            | -1%  |
| 64                            | +30% |
| 256                           | +70% |
| 1024                          | +87% |

Chunks of equal length: -1%, since there is no padding to remove.

The node currently hands `encode()` one document's chunks at a time, so on a
typical 16-chunk document this change gains nothing today. It pays off for
documents with many chunks, and it is what makes cross-document batching worth
doing next (tracked separately).

## Verification

Embeddings are unchanged: encoding 70 mixed-length sentences as a batch matches
encoding them one at a time to 1.5e-07, which is float32 noise.

Refs #2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved local sentence encoding efficiency by processing inputs in length order to reduce unnecessary padding.
  * Preserved the original order of returned embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->