### PR TITLE
fix(shell): don't paint the outage banner over a reachable server

### DIFF
--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -276,6 +276,45 @@ test('handleStoredTokenFailure keeps the network latch when the same-origin prob
 	}
 });
 
+test('handleStoredTokenFailure does not let a stale probe downgrade a newer network failure in the same generation', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	let calls = 0;
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: async () => {
+			calls += 1;
+			// The first (older) failure's probe finds the server reachable; the
+			// second (newer) failure's probe finds it genuinely down.
+			if (calls === 1) return { ok: true };
+			throw new TypeError('Failed to fetch');
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		// Two network failures latch back to back in the same generation, each
+		// firing its own probe. The older probe resolves ok, but by the time it
+		// does a newer network failure is latched — keying the downgrade on the
+		// exact latched object (not just kind === 'network') is what stops the
+		// older probe from clobbering the newer failure into a false session
+		// expiry.
+		manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+		manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// The newer failure's own probe failed, so the network banner stands.
+		assert.equal(calls, 2);
+		assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
 test('clearToken removes current and legacy stored tokens', () => {
 	const removedLocalKeys: string[] = [];
 	const removedSessionKeys: string[] = [];

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -223,7 +223,7 @@ test('handleStoredTokenFailure downgrades a network latch to session expiry when
 		configurable: true,
 		value: async (input: unknown) => {
 			probed = String(input);
-			return { ok: true };
+			return { ok: true, json: async () => ({ status: 'OK', data: { version: '3.3.0' } }) };
 		},
 	});
 
@@ -285,7 +285,7 @@ test('handleStoredTokenFailure does not let a stale probe downgrade a newer netw
 			calls += 1;
 			// The first (older) failure's probe finds the server reachable; the
 			// second (newer) failure's probe finds it genuinely down.
-			if (calls === 1) return { ok: true };
+			if (calls === 1) return { ok: true, json: async () => ({ status: 'OK', data: { version: '3.3.0' } }) };
 			throw new TypeError('Failed to fetch');
 		},
 	});
@@ -307,6 +307,32 @@ test('handleStoredTokenFailure does not let a stale probe downgrade a newer netw
 
 		// The newer failure's own probe failed, so the network banner stands.
 		assert.equal(calls, 2);
+		assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
+test('handleStoredTokenFailure keeps the network latch when the probe answers 200 but not the /version contract', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		// A page origin that merely returns 200 for /version without the server's
+		// own contract — e.g. a cross-origin serverUri whose real backend is down,
+		// while the page host answers /version with something unrelated.
+		value: async () => ({ ok: true, json: async () => ({ hello: 'not rocketride' }) }),
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// The probe did not prove the backend is reachable, so the network banner
+		// stands rather than being downgraded to a false session expiry.
 		assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
 		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
 	} finally {

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -216,6 +216,66 @@ test('handleStoredTokenFailure preserves credentials for retryable server failur
 	});
 });
 
+test('handleStoredTokenFailure downgrades a network latch to session expiry when a same-origin probe answers', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	let probed: string | undefined;
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: async (input: unknown) => {
+			probed = String(input);
+			return { ok: true };
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		const shouldClearToken = manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+
+		// The network failure latches synchronously so recovery UI can render it.
+		assert.equal(shouldClearToken, false);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+
+		// The same-origin probe answering proves the server is reachable, so the
+		// latched failure downgrades to session expiry instead of a false outage.
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(probed, '/version');
+		assert.equal(manager.connectionStatus.state, ConnectionState.AUTH_FAILED);
+		assert.deepEqual(manager.connectionStatus.lastFailure, {
+			kind: 'auth',
+			lastError: 'Your session has expired — please sign in again.',
+			errorKind: 'session',
+		});
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
+test('handleStoredTokenFailure keeps the network latch when the same-origin probe fails too', async () => {
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: async () => {
+			throw new TypeError('Failed to fetch');
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+
+		manager.handleStoredTokenFailure(new ConnectionFailure('Failed to fetch', 'network'));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// Both requests dead: genuinely unreachable, the network banner stands.
+		assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
+		assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+	} finally {
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
 test('clearToken removes current and legacy stored tokens', () => {
 	const removedLocalKeys: string[] = [];
 	const removedSessionKeys: string[] = [];

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -1100,12 +1100,20 @@ export class ConnectionManager implements IConnectionManager {
 		// signed-out landing gets the sign-in banner instead of a false outage.
 		if (isNetworkFailure) {
 			const generation = this.connectionGeneration;
+			// Capture the exact failure object this probe is disambiguating.
+			// updateConnectionStatus latches a fresh object per failure, so a
+			// newer network failure — even one in this same generation — replaces
+			// the reference. Identity, not kind, is what proves the latch is still
+			// the one this probe was launched for.
+			const latchedFailure = this.connectionStatus.lastFailure;
 			void fetch('/version', { cache: 'no-store' }).then((res) => {
 				if (!res.ok) return;
 				if (this.connectionGeneration !== generation) return;
-				// Only downgrade the failure this call latched; a newer failure
-				// or a successful reconnect must not be overwritten.
-				if (this.connectionStatus.lastFailure?.kind !== 'network') return;
+				// Only downgrade the specific failure this probe latched. A newer
+				// failure (including another network one) or a reconnect that
+				// cleared the latch swaps the reference, and must not be
+				// overwritten with a session downgrade.
+				if (this.connectionStatus.lastFailure !== latchedFailure) return;
 				const message = 'Your session has expired — please sign in again.';
 				this.updateConnectionStatus({
 					state: ConnectionState.AUTH_FAILED,

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -1090,6 +1090,34 @@ export class ConnectionManager implements IConnectionManager {
 				errorKind: isAuthFailure ? 'session' : undefined,
 			},
 		});
+		// A CORS-blocked or proxy-dropped request and a dead server both surface
+		// as the same opaque network TypeError, but only one means the server is
+		// down. Disambiguate with a same-origin probe, which every topology
+		// serves: single-host deployments answer /version on the page origin and
+		// CDN-split ones proxy it through the edge. When the probe answers, the
+		// server is reachable and the stored token simply couldn't be validated,
+		// so recovery is sign-in, not retry; re-latch as a session failure so the
+		// signed-out landing gets the sign-in banner instead of a false outage.
+		if (isNetworkFailure) {
+			const generation = this.connectionGeneration;
+			void fetch('/version', { cache: 'no-store' }).then((res) => {
+				if (!res.ok) return;
+				if (this.connectionGeneration !== generation) return;
+				// Only downgrade the failure this call latched; a newer failure
+				// or a successful reconnect must not be overwritten.
+				if (this.connectionStatus.lastFailure?.kind !== 'network') return;
+				const message = 'Your session has expired — please sign in again.';
+				this.updateConnectionStatus({
+					state: ConnectionState.AUTH_FAILED,
+					lastError: message,
+					progressMessage: undefined,
+					errorKind: 'session',
+					lastFailure: { kind: 'auth', lastError: message, errorKind: 'session' },
+				});
+			}).catch(() => {
+				// Probe failed too: genuinely unreachable, keep the network banner.
+			});
+		}
 		return isAuthFailure;
 	}
 

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -162,6 +162,18 @@ function isConnectResult(body: unknown): body is ConnectResult {
 	);
 }
 
+function isVersionResponse(body: unknown): boolean {
+	// The reachability probe only proves THIS backend is up if the page origin
+	// answers with the server's own /version contract ({ status: 'OK', with a
+	// data.version string). A bare 200 from an unrelated origin must not qualify.
+	return (
+		typeof body === 'object' &&
+		body !== null &&
+		(body as Record<string, unknown>).status === 'OK' &&
+		typeof (body as { data?: Record<string, unknown> }).data?.version === 'string'
+	);
+}
+
 /**
  * Normalizes caller-supplied env metadata to the string map the SDK expects.
  *
@@ -1106,25 +1118,35 @@ export class ConnectionManager implements IConnectionManager {
 			// the reference. Identity, not kind, is what proves the latch is still
 			// the one this probe was launched for.
 			const latchedFailure = this.connectionStatus.lastFailure;
-			void fetch('/version', { cache: 'no-store' }).then((res) => {
-				if (!res.ok) return;
-				if (this.connectionGeneration !== generation) return;
-				// Only downgrade the specific failure this probe latched. A newer
-				// failure (including another network one) or a reconnect that
-				// cleared the latch swaps the reference, and must not be
-				// overwritten with a session downgrade.
-				if (this.connectionStatus.lastFailure !== latchedFailure) return;
-				const message = 'Your session has expired — please sign in again.';
-				this.updateConnectionStatus({
-					state: ConnectionState.AUTH_FAILED,
-					lastError: message,
-					progressMessage: undefined,
-					errorKind: 'session',
-					lastFailure: { kind: 'auth', lastError: message, errorKind: 'session' },
+			void fetch('/version', { cache: 'no-store' })
+				.then((res) => (res.ok ? res.json() : Promise.reject(new Error('probe not ok'))))
+				.then((body) => {
+					// A bare 200 does not prove THIS backend is reachable: a
+					// cross-origin serverUri (initialize({ uri })) can point at a
+					// backend that is down while the page origin still answers
+					// /version. Require the server's own /version contract, so an
+					// unrelated origin's 200 can't turn a real outage into a false
+					// session-expiry.
+					if (!isVersionResponse(body)) return;
+					if (this.connectionGeneration !== generation) return;
+					// Only downgrade the specific failure this probe latched. A newer
+					// failure (including another network one) or a reconnect that
+					// cleared the latch swaps the reference, and must not be
+					// overwritten with a session downgrade.
+					if (this.connectionStatus.lastFailure !== latchedFailure) return;
+					const message = 'Your session has expired — please sign in again.';
+					this.updateConnectionStatus({
+						state: ConnectionState.AUTH_FAILED,
+						lastError: message,
+						progressMessage: undefined,
+						errorKind: 'session',
+						lastFailure: { kind: 'auth', lastError: message, errorKind: 'session' },
+					});
+				})
+				.catch(() => {
+					// Probe failed, or the origin did not answer with this backend's
+					// own /version contract: genuinely unreachable, keep the banner.
 				});
-			}).catch(() => {
-				// Probe failed too: genuinely unreachable, keep the network banner.
-			});
 		}
 		return isAuthFailure;
 	}


### PR DESCRIPTION
> Supersedes #2183 — same fix, retargeted from `feat/app-2` to `develop`.

## Why retargeted
#2183 was based on `feat/app-2` (#1993), so this incident fix would only ship after that large feature lands, and CodeRabbit + real CI are skipped on that base. The production hunk applies unchanged on `develop` (`handleStoredTokenFailure` is identical there), so this re-homes the same commit onto `develop` to ship on its own and get real CI. Thanks @nihalnihalani for the catch, and for verifying the `/version` premise (`public=True`, no-auth).

## What it does
A CORS-blocked or proxy-dropped bootstrap request and a genuinely dead server both surface as the same opaque network `TypeError`, so an expired stored token behind a CORS misconfig latched a `kind:'network'` failure and painted "Can't reach the server" over the signed-out landing — two false staging-down reports in two days.

After latching a network failure in `handleStoredTokenFailure`, probe `/version` same-origin (served directly on single-host deployments, through the edge proxy on CDN-split ones). If the probe answers, the server is reachable and the stored token simply couldn't be validated, so the failure re-latches as session expiry with a Sign in action; if the probe fails too, the network banner stands.

## Review response (@dk-rocketride)
1. **Stale-probe race — fixed.** The downgrade previously guarded on `lastFailure.kind === 'network'`, which can't tell one network failure from another: a newer network failure latching in the same generation while an older probe was in flight would be overwritten by that older probe's success. It now captures the exact latched failure object and downgrades only while that same object is still latched (identity, not kind). `updateConnectionStatus` latches a fresh object per failure via `Object.assign` (by reference), so identity holds. Added a regression test for the same-generation race.
2. **`/version` 200 proves reachable, not auth — acknowledged, non-blocking.** A broken API/route with a healthy `/version` could still be labeled "session expired." Kept as-is for now: it's a far less alarming failure mode than a false outage over the signed-out landing, and "please sign in" is the safe recovery. Happy to narrow the copy if you'd prefer.

## Coordination
#2009 also edits `connection.ts` + `connection.test.ts`. Production changes don't overlap (its change is in `onDisconnected`/`reconnect`), but the test files will conflict, so whichever lands second needs a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection error handling to distinguish expired sessions from genuine server outages.
  * Shows a sign-in prompt when the server is reachable but the session has expired.
  * Preserves the network outage message when server availability cannot be confirmed.
  * Validates server responses before classifying a connection issue as session expiry.
  * Prevents outdated connection checks from overriding newer failure states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->