### PR TITLE
fix(docs): replace docker create with docker run in README (#2191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ ROCKETRIDE_URI=ws://localhost:5565
 
      ```bash
      docker pull ghcr.io/rocketride-org/rocketride-engine:latest
-     docker create --name rocketride-engine -p 5565:5565 ghcr.io/rocketride-org/rocketride-engine:latest
+     docker run -d --name rocketride-engine -p 5565:5565 ghcr.io/rocketride-org/rocketride-engine:latest
      ```
 
    - **Local Deployment** - Download your preferred runtime as a standalone process from the **Deploy** page in the `Connection Manager`.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ ROCKETRIDE_URI=ws://localhost:5565
 
 5. Deploy your pipelines - pick the path that fits:
 
-   - **Docker** - Download the RocketRide server image and create a container. Requires [Docker](https://docs.docker.com/get-docker/) to be installed.
+   - **Docker** - Download the RocketRide server image and run the container. Requires [Docker](https://docs.docker.com/get-docker/) to be installed.
 
      ```bash
      docker pull ghcr.io/rocketride-org/rocketride-engine:latest


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker deployment instructions for the RocketRide engine.
  * The documented command now starts the container immediately in detached mode, making the deployment workflow clearer and more direct.
  * Revised the surrounding wording to describe running the container rather than only creating it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->