### PR TITLE
fix(ci): stop lock-node-deps failing develop when the PR cannot be opened

### DIFF
--- a/.github/workflows/lock-node-deps.yml
+++ b/.github/workflows/lock-node-deps.yml
@@ -146,7 +146,13 @@ jobs:
       # the lockfile silently stopped tracking its inputs while CI stayed green
       # on pull requests. Same action and pin already used by sync-models.yml.
       - name: Open a PR with the regenerated lockfile (develop / weekly / manual)
+        id: pr
         if: ${{ steps.check.outputs.changed == 'true' && github.event_name != 'pull_request' }}
+        # Opening the PR needs a permission the token may not carry, and that is
+        # not a reason to fail the run: the branch push above already succeeded,
+        # so the regenerated lockfile is preserved either way. The step below
+        # turns a refused creation into a warning that says how to finish it.
+        continue-on-error: true
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
@@ -167,6 +173,32 @@ jobs:
           labels: |
             automated
             dependencies
+
+      # A refused PR creation leaves the work done and unreachable, which is worse
+      # than either succeeding or failing loudly: the branch carries the lockfile
+      # and nobody knows. Say so, and say what unblocks it.
+      - name: Report a refused PR creation
+        if: ${{ steps.pr.outcome == 'failure' }}
+        env:
+          BRANCH: chore/refresh-node-constraints-lock
+          SERVER: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.ref_name }}
+        run: |
+          echo "::warning::the regenerated lockfile was pushed to ${BRANCH} but the pull request could not be opened - the token lacks pull-requests: write. Open it by hand, or grant the RELEASE_BOT app that permission."
+          {
+            echo "### Lockfile refreshed, PR not opened"
+            echo ""
+            echo "The compile succeeded and \`${BRANCH}\` holds the regenerated lockfile."
+            echo "Creating the pull request was refused with \`Resource not accessible by integration\`,"
+            echo "which means the token used here has no \`pull-requests: write\`."
+            echo ""
+            echo "To finish it now: [open the PR](${SERVER}/${REPO}/compare/${BASE}...${BRANCH}?expand=1)"
+            echo ""
+            echo "To stop it recurring: grant the \`RELEASE_BOT\` GitHub App **Pull requests: read and write**"
+            echo "(and **Issues: read and write**, which \`create-pull-request\` uses for labels), then accept"
+            echo "the permission request on the installation."
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Note drift on PRs (non-blocking)
         if: ${{ steps.check.outputs.changed == 'true' && github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

- `Lock node deps (universal constraints)` has failed on every push to `develop` since 24 August — 12 consecutive runs — and each merge adds another red run to the branch.
- The failure is in the last step only. The compile succeeds, the branch push succeeds, and `chore/refresh-node-constraints-lock` currently holds a fully regenerated lockfile that nobody can see.
- Let that step report instead of failing, and say what unblocks it.

## Type

fix (CI)

## What is actually broken

The job does three things: compile the universal lockfile, push it to a branch, open a PR from that branch. The first two work. The third returns:

```
Attempting creation of pull request
##[error]Resource not accessible by integration
```

The App token is minted (step 2 green) and carries `contents: write` — that is why the branch push lands. It does not carry `pull-requests: write`, so creating the PR is refused.

The workflow already asks for it:

```yaml
permission-contents: write
permission-pull-requests: write
permission-issues: write
```

but `permission-*` can only narrow what an installation already grants. If the `RELEASE_BOT` App has no pull-requests permission, requesting it in YAML does not create it.

This matches the comment already in the file — the refresh was changed from a direct push to a pull request, because `develop` is protected and the unattended push was rejected (`protected branch hook declined`). The YAML was updated for the new mechanism; the App's permissions were not.

## Why this is worth fixing rather than ignoring

The current shape is the least useful one available. The lockfile **is** regenerated and **is** pushed, then the run goes red and the work sits on a branch unreferenced by anything. Two weeks of dependency drift accumulated that way, including `rank-bm25` from #899 and the removal of `docopt`.

Red on a step that produced its output is noise, and noise on `develop` is what stops anyone reading the next real failure.

## The change

- `continue-on-error: true` and an `id` on the PR step, so a refused creation does not take the run down. A genuine compile failure still fails, untouched.
- A new step that fires only on that refusal and writes a warning plus a job summary containing a compare link to open the PR by hand, and the permission to grant so it stops recurring.

## What this does not fix

The permission itself. That needs an org admin to grant the `RELEASE_BOT` App **Pull requests: read and write** (and **Issues: read and write**, which `create-pull-request` uses for labels) and accept the request on the installation. Until then the lockfile PR is opened manually — the summary now links straight to it.

## Verification

- YAML parses; both steps wired as intended (`continue-on-error` on the PR step, `if: steps.pr.outcome == 'failure'` on the report).
- No change to the compile, the enforce step, or the pull-request path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency lockfile updates now retain the regenerated branch if automatic pull-request creation fails.
  * Added clearer job warnings and remediation details, including the branch name, required permissions, and a direct pull-request link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->