### PR TITLE
nodes: add tool_datetime (and name the zone on every CRM time field)

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -82,11 +82,36 @@ class Chat(ChatBase):
         if self._extended_thinking:
             self._native_stream_provider = 'anthropic'
 
+        # The workspace an identity-linked key acts in.
+        #
+        # Anthropic binds a key either to a workspace or to a user identity. An
+        # identity-linked key does not carry a workspace of its own, so the API
+        # refuses the request outright: "anthropic-workspace-id is required when
+        # authenticating with an identity-linked API key". Nothing about such a
+        # key looks unusual — same `sk-ant-api03` prefix, same length — so the
+        # first sign of it is a 400 on the first turn.
+        #
+        # OPTIONAL, and silent when unset. A workspace-scoped key needs no
+        # header and is rejected if sent a wrong one, so this must stay absent
+        # unless a real value was configured — which is why an unresolved
+        # `${...}` is treated as unset rather than passed along. An engine that
+        # leaves the reference in place when nothing is set would otherwise send
+        # the literal text as the workspace id, and the resulting error names a
+        # workspace nobody has.
+        workspace = str(config.get('workspaceId') or '').strip()
+        if workspace.startswith('${'):
+            workspace = ''
+
+        client_kwargs: Dict[str, Any] = {}
+        if workspace:
+            client_kwargs['default_headers'] = {'anthropic-workspace-id': workspace}
+
         self._llm = ChatAnthropic(
             model=model,
             api_key=apikey,
             max_tokens=self._modelOutputTokens,
             custom_get_token_ids=_estimate_token_ids,
+            **client_kwargs,
         )
 
         # Save our chat class into the bag

--- a/nodes/src/nodes/llm_anthropic/services.json
+++ b/nodes/src/nodes/llm_anthropic/services.json
@@ -360,6 +360,12 @@
 			"default": false,
 			"description": "Enable Anthropic extended thinking (reasoning) for this node. Off by default. Applies to reasoning-capable models on the interactive chat path."
 		},
+		"workspaceId": {
+			"type": "string",
+			"title": "Workspace ID",
+			"default": "",
+			"description": "Anthropic workspace this key acts in. Required only for an identity-linked API key, which carries no workspace of its own and is refused with \"anthropic-workspace-id is required\". Leave empty for a workspace-scoped key: sending a workspace id it does not expect is itself an error."
+		},
 		"anthropic.custom": {
 			"object": "custom",
 			"properties": [

--- a/nodes/src/nodes/tool_datetime/IGlobal.py
+++ b/nodes/src/nodes/tool_datetime/IGlobal.py
@@ -1,0 +1,57 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Date and time tool node — global (shared) state.
+
+Holds the default timezone, and nothing else. The arithmetic is in
+``datetime_math`` and the tool surface is on ``IInstance``; there is no client
+to build, no connection to hold and no credential to carry, because the answer
+to every question this node is asked is already on the machine.
+"""
+
+from __future__ import annotations
+
+from rocketlib import IGlobalBase
+
+from .datetime_math import DEFAULT_ZONE
+
+
+class IGlobal(IGlobalBase):
+    """Global state for tool_datetime."""
+
+    #: The zone used when a caller names none.
+    #:
+    #: A DEPLOYMENT-WIDE DEFAULT, not the caller's zone, and the difference is
+    #: worth keeping in view. Whoever is actually asking may be anywhere; the
+    #: only honest thing a shared default can do is be a zone the answer names
+    #: out loud, so a caller reading `timezone: UTC` on a reply can see it was
+    #: not their own and pass one next time.
+    default_zone: str = DEFAULT_ZONE
+
+    def beginGlobal(self) -> None:
+        """Read the configured default zone, if the pipeline set one."""
+        config = self.glb.connConfig or {}
+        configured = str(config.get('defaultTimezone') or '').strip()
+        if configured:
+            self.default_zone = configured

--- a/nodes/src/nodes/tool_datetime/IInstance.py
+++ b/nodes/src/nodes/tool_datetime/IInstance.py
@@ -1,0 +1,368 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Date and time tool node instance.
+
+WHY THIS EXISTS. A model has no clock, and telling it the date does not fix
+arithmetic. It can be told today is Thursday 3 September and still book a
+follow-up for "next Tuesday" on the wrong Tuesday, or add a month to 31 January
+and produce the 31st of February. Those are the errors this node removes, by
+doing the counting somewhere that counts correctly.
+
+UNIX SECONDS ARE THE WIRE FORMAT. Every instant in and out is an integer epoch.
+A timestamp carries no timezone to be wrong about, so nothing is lost passing one
+between the model, this tool and a CRM. Dates, weekdays and "start of the month"
+are a RENDERING of an instant, and `timezone` is the argument that resolves them.
+
+THE DESCRIPTIONS CARRY THE CURRENT TIME. `@tool_function` evaluates a callable
+`description` at tool.query time, so an agent reading its tool list learns what
+"now" is without anything else having injected it. That matters where the agent
+doing the work is a sub-agent several delegations deep, which is exactly where
+an injected anchor tends not to reach.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rocketlib import IInstanceBase, tool_function
+
+from . import datetime_math as dtm
+from .IGlobal import IGlobal
+
+#: Reused by every schema. The one argument that decides what a date means.
+_ZONE_ARG = {
+    'type': 'string',
+    'description': (
+        'IANA timezone name, e.g. "America/Los_Angeles". Pass the caller\'s own '
+        'zone whenever it is known — it decides what date an instant falls on. '
+        'Omitted, the deployment default is used and the answer says which.'
+    ),
+}
+
+_EPOCH_ARG = {
+    'type': 'integer',
+    'description': 'Unix timestamp in seconds. Use the epoch from an earlier call rather than re-deriving it.',
+}
+
+#: What every instant-returning tool answers with.
+#:
+#: TWO RENDERINGS, AND THE CALLER PICKS BY FIELD, NOT BY PREFERENCE. An instant
+#: has a different date and time in every zone; which one a CRM field wants is a
+#: fact about that field. Pipedrive reads an activity's `due_time` as UTC, while
+#: GoHighLevel wants an offset-bearing local string. Both forms travel on every
+#: answer so that writing the right one is reading a different key — never
+#: subtracting an offset by hand, which is what put a 12:30 meeting into the CRM
+#: at 05:30.
+_INSTANT_RESULT = {
+    'type': 'object',
+    'description': (
+        'epoch (unix seconds), iso, date (YYYY-MM-DD), time (HH:MM), weekday, '
+        'the timezone actually used, and utc_iso/utc_date/utc_time — the SAME '
+        'instant written in UTC. Write one of these pairs straight into a CRM '
+        'rather than formatting or converting an instant yourself: use date/time '
+        'for a field stored in local time, and utc_date/utc_time for a field '
+        'the CRM reads as UTC. Check which the field wants; getting it wrong '
+        'stores a real-looking time that is hours out.'
+    ),
+}
+
+
+def _dated(text: str):
+    """
+    A description that states the current instant, refreshed on every read.
+
+    The engine re-evaluates a callable description at tool.query time, so this
+    never goes stale on a long-running task. Same device as `tool_oura`, for the
+    same reason: without it a model dates from whenever its weights were frozen.
+
+    AND IT SAYS WHOSE CLOCK IT IS. The zone here is the deployment's, which is
+    not necessarily the zone of whoever is asking. Left unqualified, this line
+    said "Right now it is … in UTC" beside a prompt anchor naming the caller's
+    real zone — two statements that disagree about what day it is for anyone
+    west of Greenwich in the evening, with nothing to say which to believe. A
+    reader that resolves that by picking one has picked at random.
+    """
+
+    def _describe(self) -> str:
+        moment = dtm.now(self.IGlobal.default_zone)
+        return (
+            f'{text} Right now it is {moment["date"]} {moment["time"]} '
+            f'({moment["weekday"]}) in {moment["timezone"]}, '
+            f'which is unix timestamp {moment["epoch"]}. That zone is this '
+            f'deployment default, not necessarily the zone of the person you are '
+            f'working for - pass theirs to get the date they are having.'
+        )
+
+    return _describe
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def _zone(self, args: dict, key: str = 'timezone') -> str:
+        """The caller's zone, or the deployment's."""
+        return str(args.get(key) or '').strip() or self.IGlobal.default_zone
+
+    @staticmethod
+    def _args(args: Any) -> dict:
+        if not isinstance(args, dict):
+            raise ValueError('Tool input must be a JSON object')
+        return args
+
+    @staticmethod
+    def _epoch(args: dict, key: str = 'epoch') -> float:
+        value = args.get(key)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f'"{key}" is required and must be a unix timestamp in seconds')
+        return float(value)
+
+    @tool_function(
+        input_schema={'type': 'object', 'properties': {'timezone': _ZONE_ARG}},
+        output_schema=_INSTANT_RESULT,
+        description=_dated(
+            'The current date and time. Call this before working out any date '
+            'from words like "today", "tomorrow" or "next week" — never date '
+            'those from your own sense of now.'
+        ),
+    )
+    def now(self, args):
+        """The current instant."""
+        args = self._args(args or {})
+        return dtm.now(self._zone(args))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['date', 'time'],
+            'properties': {
+                'date': {
+                    'type': 'string',
+                    'description': 'Calendar date, YYYY-MM-DD. Resolve a relative one with the other tools first.',
+                },
+                'time': {
+                    'type': 'string',
+                    'description': 'Wall-clock time as the person said it, 24-hour HH:MM. "12:30pm" is "12:30"; "8pm" is "20:00".',
+                },
+                'timezone': _ZONE_ARG,
+            },
+        },
+        output_schema={
+            'type': 'object',
+            'description': (
+                'The instant, in the shape every tool here returns — plus requested '
+                '(the wall time asked for), adjusted (true when that hour does not '
+                'exist, on the morning clocks go forward) and ambiguous (true when it '
+                'happens twice, on the morning they go back). Say so in your report '
+                'when either is true.'
+            ),
+        },
+        description=_dated(
+            'Turn a date and a clock time into an instant. Use this whenever a '
+            'person names a time of day — "next Wednesday at 12:30pm" — and pass '
+            'their timezone: a time of day means nothing without one. The answer '
+            'carries both the local and the UTC form, so write whichever the CRM '
+            'field asks for instead of converting it yourself.'
+        ),
+    )
+    def at(self, args):
+        """The instant a wall-clock date and time name in one zone."""
+        args = self._args(args)
+        return dtm.at(str(args.get('date') or ''), str(args.get('time') or ''), self._zone(args))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['epoch', 'amount', 'unit'],
+            'properties': {
+                'epoch': _EPOCH_ARG,
+                'amount': {
+                    'type': 'integer',
+                    'description': 'How many units to move. Negative goes backwards.',
+                },
+                'unit': {
+                    'type': 'string',
+                    'enum': list(dtm.UNITS),
+                    'description': (
+                        'second/minute/hour move the instant by that duration. '
+                        'day/week/month/year move the calendar and keep the time '
+                        'of day, which is what "same time next week" means. '
+                        'Month arithmetic clamps: 31 January plus one month is '
+                        'the last day of February.'
+                    ),
+                },
+                'timezone': _ZONE_ARG,
+            },
+        },
+        output_schema=_INSTANT_RESULT,
+        description=_dated(
+            'Add or subtract time. Use this for "in 90 days", "three weeks '
+            'from now", "a month before the close date" — do not do the '
+            'arithmetic yourself.'
+        ),
+    )
+    def shift(self, args):
+        """An instant moved by a whole number of units."""
+        args = self._args(args)
+        amount = args.get('amount')
+        if isinstance(amount, bool) or not isinstance(amount, int):
+            raise ValueError('"amount" is required and must be a whole number')
+        return dtm.shift(self._epoch(args), amount, str(args.get('unit') or ''), self._zone(args))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['epoch', 'weekday'],
+            'properties': {
+                'epoch': _EPOCH_ARG,
+                'weekday': {
+                    'type': 'string',
+                    'enum': list(dtm.WEEKDAYS),
+                    'description': 'The day wanted, e.g. "tuesday".',
+                },
+                'allow_today': {
+                    'type': 'boolean',
+                    'description': (
+                        'False by default, so "next Tuesday" asked on a Tuesday '
+                        'means the one coming, not today. Pass true only when '
+                        'today should count.'
+                    ),
+                },
+                'timezone': _ZONE_ARG,
+            },
+        },
+        output_schema=_INSTANT_RESULT,
+        description=_dated(
+            'The next occurrence of a weekday. Use this for "next Tuesday", '
+            '"on Friday", "a week on Monday" — counting weekdays by hand is '
+            'where dates most often go wrong.'
+        ),
+    )
+    def next_weekday(self, args):
+        """The next occurrence of a named weekday."""
+        args = self._args(args)
+        return dtm.next_weekday(
+            self._epoch(args),
+            str(args.get('weekday') or ''),
+            self._zone(args),
+            bool(args.get('allow_today')),
+        )
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['epoch', 'unit', 'edge'],
+            'properties': {
+                'epoch': _EPOCH_ARG,
+                'unit': {
+                    'type': 'string',
+                    'enum': list(dtm.BOUNDARY_UNITS),
+                    'description': 'The period the instant falls in.',
+                },
+                'edge': {
+                    'type': 'string',
+                    'enum': ['start', 'end'],
+                    'description': (
+                        'end is the last second of the period, so end-of-month '
+                        'is the 31st rather than the 1st of the next.'
+                    ),
+                },
+                'timezone': _ZONE_ARG,
+            },
+        },
+        output_schema=_INSTANT_RESULT,
+        description=_dated(
+            'The first or last instant of a day, week, month, quarter or year. '
+            'Use this for "end of the month", "this quarter", "start of next '
+            'week" — month lengths and quarter boundaries are not worth '
+            'recalling from memory.'
+        ),
+    )
+    def boundary(self, args):
+        """The first or last instant of a period."""
+        args = self._args(args)
+        return dtm.boundary(
+            self._epoch(args),
+            str(args.get('unit') or ''),
+            str(args.get('edge') or ''),
+            self._zone(args),
+        )
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['start', 'end', 'unit'],
+            'properties': {
+                'start': dict(_EPOCH_ARG, description='The earlier instant, unix seconds.'),
+                'end': dict(_EPOCH_ARG, description='The later instant, unix seconds.'),
+                'unit': {
+                    'type': 'string',
+                    'enum': ['second', 'minute', 'hour', 'day', 'week'],
+                    'description': 'The unit `elapsed` is measured in.',
+                },
+                'timezone': _ZONE_ARG,
+            },
+        },
+        output_schema={
+            'type': 'object',
+            'description': (
+                'elapsed (real duration in the unit), calendar_days (how many '
+                'dates apart they are on a wall calendar), and the timezone '
+                'used. For "how many days until", calendar_days is the answer '
+                'a person means.'
+            ),
+        },
+        description=_dated(
+            'How far apart two instants are. Returns both the real duration '
+            'and the number of calendar days, because at 23:00 on Thursday '
+            '"tomorrow" is one day away and 60 minutes away at the same time.'
+        ),
+    )
+    def difference(self, args):
+        """How far apart two instants are."""
+        args = self._args(args)
+        return dtm.difference(
+            self._epoch(args, 'start'),
+            self._epoch(args, 'end'),
+            str(args.get('unit') or ''),
+            self._zone(args),
+        )
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['epoch'],
+            'properties': {'epoch': _EPOCH_ARG, 'timezone': _ZONE_ARG},
+        },
+        output_schema=_INSTANT_RESULT,
+        description=_dated(
+            'Render a timestamp as a date and time in a given zone. Use the '
+            'date (YYYY-MM-DD) and time (HH:MM) fields verbatim when writing '
+            'to a CRM rather than formatting the instant yourself.'
+        ),
+    )
+    def render(self, args):
+        """One instant, in every shape a caller might need."""
+        args = self._args(args)
+        return dtm.render(self._epoch(args), self._zone(args))

--- a/nodes/src/nodes/tool_datetime/__init__.py
+++ b/nodes/src/nodes/tool_datetime/__init__.py
@@ -1,0 +1,27 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/tool_datetime/datetime_math.py
+++ b/nodes/src/nodes/tool_datetime/datetime_math.py
@@ -1,0 +1,405 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+The arithmetic, with no engine around it.
+
+Separated from ``IInstance`` so it can be tested as plain functions: this node
+exists because a model gets date arithmetic wrong, and a node whose arithmetic
+is only reachable through a running pipeline would be asking to be trusted on
+exactly the thing it was built to be doubted about.
+
+TWO KINDS OF SHIFT, AND THE DIFFERENCE MATTERS.
+
+``minute`` and ``hour`` are durations: add them to the instant. ``day``, ``week``,
+``month`` and ``year`` are calendar steps: convert to local time, move the
+calendar, convert back. Across a daylight-saving boundary those disagree by an
+hour, and the calendar answer is the one a person means. "Same time tomorrow"
+is 09:00 tomorrow, not 08:00 because the clocks moved.
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+try:  # pragma: no cover - exercised by whichever branch the platform takes
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover
+    ZoneInfo = None  # type: ignore[assignment]
+
+#: Where an unusable zone lands. Never an exception: a mistyped zone should
+#: cost the caller a UTC answer it can see and correct, not a failed turn.
+DEFAULT_ZONE = 'UTC'
+
+#: Calendar steps, which move the local date. See the module docstring.
+CALENDAR_UNITS = ('day', 'week', 'month', 'year')
+
+#: Durations, which move the instant.
+DURATION_UNITS = ('second', 'minute', 'hour')
+
+UNITS = DURATION_UNITS + CALENDAR_UNITS
+
+#: Monday-first, matching ISO and `datetime.weekday()`.
+WEEKDAYS = ('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday')
+
+BOUNDARY_UNITS = ('day', 'week', 'month', 'quarter', 'year')
+
+
+def resolve_zone(name: Optional[str]) -> tuple[Any, str]:
+    """
+    A timezone object and the name it actually resolved to.
+
+    Args:
+        name: An IANA name, or None/'' for the default.
+
+    Returns:
+        The tzinfo and the name to report, which is ``UTC`` whenever the
+        requested one could not be used.
+    """
+    wanted = (name or '').strip()
+    if not wanted or wanted.upper() == 'UTC' or ZoneInfo is None:
+        return timezone.utc, DEFAULT_ZONE
+    try:
+        return ZoneInfo(wanted), wanted
+    except Exception:  # noqa: BLE001 — a bad zone is an answer, not a failure
+        return timezone.utc, DEFAULT_ZONE
+
+
+def render(epoch: float, zone: Optional[str] = None) -> dict[str, Any]:
+    """
+    One instant, in every shape a caller might need.
+
+    The `date` and `time` fields are the CRMs' formats — Pipedrive documents
+    `due_date` as YYYY-MM-DD and `due_time` as HH:MM — so a caller never has to
+    format an instant by hand, which is one more place to get it wrong.
+
+    BOTH RENDERINGS, ALWAYS, and that is the point of the `utc_` fields.
+
+    An instant has no single date and time: it has one per zone. A CRM field
+    wants a particular one, and which is a fact about the field, not about the
+    caller — Pipedrive reads `due_time` as UTC while GoHighLevel wants an
+    offset-bearing local string. A booking asked for at 12:30 Pacific was
+    written as `12:30`, stored as UTC, and shown back to the person who asked
+    for it as 05:30.
+
+    Nothing here can know which field it is feeding. What it can do is refuse to
+    make the caller choose blind: every answer carries the local rendering and
+    the UTC one side by side, so writing the right one is reading a different
+    key rather than doing arithmetic. Subtracting an offset by hand is exactly
+    the class of mistake this node exists to take away.
+
+    `render` is the single funnel — `shift`, `next_weekday`, `boundary`, `at`
+    and `now` all return through it — so these fields reach every tool answer.
+
+    Args:
+        epoch: Unix seconds.
+        zone: IANA name, or None for UTC.
+
+    Returns:
+        The rendering, including the zone actually used and the UTC form.
+    """
+    tz, name = resolve_zone(zone)
+    local = datetime.fromtimestamp(float(epoch), tz)
+    utc = datetime.fromtimestamp(float(epoch), timezone.utc)
+    return {
+        'epoch': int(epoch),
+        'iso': local.isoformat(),
+        'date': local.strftime('%Y-%m-%d'),
+        'time': local.strftime('%H:%M'),
+        'weekday': local.strftime('%A'),
+        'timezone': name,
+        'utc_iso': utc.isoformat(),
+        'utc_date': utc.strftime('%Y-%m-%d'),
+        'utc_time': utc.strftime('%H:%M'),
+    }
+
+
+def _clamped(year: int, month: int, day: int) -> tuple[int, int, int]:
+    """The same day of a different month, or that month's last day."""
+    while month > 12:
+        year, month = year + 1, month - 12
+    while month < 1:
+        year, month = year - 1, month + 12
+    return year, month, min(day, calendar.monthrange(year, month)[1])
+
+
+def shift(epoch: float, amount: int, unit: str, zone: Optional[str] = None) -> dict[str, Any]:
+    """
+    An instant moved by a whole number of units.
+
+    Args:
+        epoch: Unix seconds to move from.
+        amount: How many, negative to go back.
+        unit: One of `UNITS`.
+        zone: The calendar to move within, for calendar units.
+
+    Returns:
+        The new instant, rendered.
+
+    Raises:
+        ValueError: On an unknown unit, which is a caller bug rather than a
+            date that does not exist.
+    """
+    if unit not in UNITS:
+        raise ValueError(f'"unit" must be one of {list(UNITS)}; got {unit!r}')
+
+    if unit in DURATION_UNITS:
+        seconds = {'second': 1, 'minute': 60, 'hour': 3600}[unit]
+        return render(float(epoch) + amount * seconds, zone)
+
+    tz, _ = resolve_zone(zone)
+    local = datetime.fromtimestamp(float(epoch), tz)
+
+    if unit == 'day':
+        moved = local + timedelta(days=amount)
+    elif unit == 'week':
+        moved = local + timedelta(weeks=amount)
+    else:
+        months = amount if unit == 'month' else amount * 12
+        year, month, day = _clamped(local.year, local.month + months, local.day)
+        moved = local.replace(year=year, month=month, day=day)
+
+    # Re-anchored in the zone rather than trusting the arithmetic's tzinfo: a
+    # date built across a DST change carries the offset it started with, and
+    # `timestamp()` on that is an hour out.
+    return render(moved.replace(tzinfo=None).replace(tzinfo=tz).timestamp(), zone)
+
+
+def next_weekday(
+    epoch: float,
+    weekday: str,
+    zone: Optional[str] = None,
+    allow_today: bool = False,
+) -> dict[str, Any]:
+    """
+    The next occurrence of a named weekday.
+
+    STRICTLY IN THE FUTURE BY DEFAULT, and that is a choice worth stating rather
+    than discovering: asked on a Tuesday to book something "next Tuesday", a
+    person means the one coming, not the day they are standing in. A caller that
+    wants "today if today qualifies" passes `allow_today`.
+
+    Time of day is preserved — this moves the date, not the clock.
+
+    Args:
+        epoch: Unix seconds to count from.
+        weekday: A day name, case-insensitive.
+        zone: The calendar to count in.
+        allow_today: Whether landing on today counts as an occurrence.
+
+    Returns:
+        The occurrence, rendered.
+
+    Raises:
+        ValueError: On an unrecognised day name.
+    """
+    wanted = (weekday or '').strip().lower()
+    if wanted not in WEEKDAYS:
+        raise ValueError(f'"weekday" must be one of {list(WEEKDAYS)}; got {weekday!r}')
+
+    tz, _ = resolve_zone(zone)
+    local = datetime.fromtimestamp(float(epoch), tz)
+    ahead = (WEEKDAYS.index(wanted) - local.weekday()) % 7
+    if ahead == 0 and not allow_today:
+        ahead = 7
+    return shift(epoch, ahead, 'day', zone)
+
+
+def boundary(epoch: float, unit: str, edge: str, zone: Optional[str] = None) -> dict[str, Any]:
+    """
+    The first or last instant of the period an instant falls in.
+
+    `end` is the last SECOND of the period, not the first of the next one — so
+    an end-of-month date reads as the 31st rather than the 1st, which is what
+    somebody asking for "end of the month" means and what a CRM wants stored.
+
+    Args:
+        epoch: Unix seconds inside the period.
+        unit: One of `BOUNDARY_UNITS`.
+        edge: 'start' or 'end'.
+        zone: The calendar the period belongs to.
+
+    Returns:
+        The boundary instant, rendered.
+
+    Raises:
+        ValueError: On an unknown unit or edge.
+    """
+    if unit not in BOUNDARY_UNITS:
+        raise ValueError(f'"unit" must be one of {list(BOUNDARY_UNITS)}; got {unit!r}')
+    if edge not in ('start', 'end'):
+        raise ValueError(f'"edge" must be "start" or "end"; got {edge!r}')
+
+    tz, _ = resolve_zone(zone)
+    local = datetime.fromtimestamp(float(epoch), tz)
+    day = local.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    if unit == 'day':
+        first = day
+    elif unit == 'week':
+        first = day - timedelta(days=day.weekday())
+    elif unit == 'month':
+        first = day.replace(day=1)
+    elif unit == 'quarter':
+        first = day.replace(month=((day.month - 1) // 3) * 3 + 1, day=1)
+    else:
+        first = day.replace(month=1, day=1)
+
+    if edge == 'start':
+        moment = first
+    else:
+
+        def _months_on(value, count):
+            year, month, day = _clamped(value.year, value.month + count, 1)
+            return value.replace(year=year, month=month, day=day)
+
+        step = {
+            'day': lambda d: d + timedelta(days=1),
+            'week': lambda d: d + timedelta(days=7),
+            'month': lambda d: _months_on(d, 1),
+            'quarter': lambda d: _months_on(d, 3),
+            'year': lambda d: d.replace(year=d.year + 1),
+        }[unit]
+        moment = step(first) - timedelta(seconds=1)
+
+    return render(moment.replace(tzinfo=None).replace(tzinfo=tz).timestamp(), zone)
+
+
+def difference(start: float, end: float, unit: str, zone: Optional[str] = None) -> dict[str, Any]:
+    """
+    How far apart two instants are.
+
+    BOTH ANSWERS, because the question is ambiguous and picking one silently is
+    how "how many days until Friday" comes back as 0 at 23:00 on Thursday.
+    `elapsed` is the real duration in the requested unit; `calendar_days` is how
+    many dates you cross on a wall calendar in the given zone, which is what a
+    person counting days means.
+
+    Args:
+        start: Unix seconds.
+        end: Unix seconds.
+        unit: One of second, minute, hour, day, week.
+        zone: The calendar `calendar_days` is counted on.
+
+    Returns:
+        `elapsed`, `calendar_days`, and the zone used.
+
+    Raises:
+        ValueError: On an unknown unit.
+    """
+    per = {'second': 1, 'minute': 60, 'hour': 3600, 'day': 86400, 'week': 604800}
+    if unit not in per:
+        raise ValueError(f'"unit" must be one of {list(per)}; got {unit!r}')
+
+    tz, name = resolve_zone(zone)
+    seconds = float(end) - float(start)
+    first = datetime.fromtimestamp(float(start), tz).date()
+    second = datetime.fromtimestamp(float(end), tz).date()
+
+    return {
+        'elapsed': seconds / per[unit],
+        'unit': unit,
+        'calendar_days': (second - first).days,
+        'timezone': name,
+    }
+
+
+def at(date: str, time: str, zone: Optional[str] = None) -> dict[str, Any]:
+    """
+    The instant a wall-clock date and time name in one zone.
+
+    THE INVERSE OF `render`, AND THE GAP THAT MADE THIS NODE HALF A TOOL.
+
+    Every other function here moves an instant it was already given. None of
+    them could accept one: there was no way to say "next Wednesday at 12:30 in
+    America/Los_Angeles". The nearest route was `boundary(day, start, zone)`
+    then `shift(+750, 'minute')`, which is two calls, documented nowhere, and
+    asks the caller to turn 12:30 into 750 — arithmetic in exactly the place
+    this node exists to remove it from.
+
+    A wall time is not always an instant, and both ways it fails are real:
+
+    - **It may name no instant.** On the morning the clocks go forward, 02:30
+      does not happen. Resolved forward to a real instant, with `adjusted` set
+      so the caller can see the hour it actually got rather than discovering it
+      from a booking.
+    - **It may name two.** On the morning they go back, 01:30 happens twice.
+      The earlier one is taken, deterministically, with `ambiguous` set.
+
+    Neither raises. A meeting that has to be booked is better booked at a stated
+    wrong-by-an-hour time than not booked at all, and both flags travel with the
+    answer so the reason is never invisible.
+
+    Args:
+        date: Calendar date, ``YYYY-MM-DD``.
+        time: Wall-clock time, ``HH:MM`` or ``HH:MM:SS``.
+        zone: IANA name the wall time is read in, or None for UTC.
+
+    Returns:
+        The instant, rendered — plus ``requested`` (the wall time asked for),
+        ``adjusted`` and ``ambiguous``.
+
+    Raises:
+        ValueError: If the date or time is not in the documented shape. A
+            misparsed date is not recoverable into an honest answer the way a
+            bad zone is, so this one refuses rather than guessing.
+    """
+    text = f'{str(date).strip()} {str(time).strip()}'
+    for shape in ('%Y-%m-%d %H:%M', '%Y-%m-%d %H:%M:%S'):
+        try:
+            naive = datetime.strptime(text, shape)
+            break
+        except ValueError:
+            continue
+    else:
+        raise ValueError(f'Expected date as YYYY-MM-DD and time as HH:MM, got "{text}"')
+
+    tz, _ = resolve_zone(zone)
+    earlier = naive.replace(tzinfo=tz)
+    later = naive.replace(tzinfo=tz, fold=1)
+
+    answer = render(earlier.timestamp(), zone)
+    # A gap does not round-trip: ask for 02:30 and the instant reads back 03:30.
+    # A fold does round-trip, and is told apart by the two offsets disagreeing.
+    answer['requested'] = f'{naive.strftime("%Y-%m-%d")} {naive.strftime("%H:%M")}'
+    answer['adjusted'] = answer['time'] != naive.strftime('%H:%M')
+    answer['ambiguous'] = not answer['adjusted'] and earlier.utcoffset() != later.utcoffset()
+    return answer
+
+
+def now(zone: Optional[str] = None, at: Optional[float] = None) -> dict[str, Any]:
+    """
+    The current instant.
+
+    Args:
+        zone: IANA name, or None for UTC.
+        at: Override the clock. For tests only — nothing else should pass it,
+            and a tool that reads its own clock is the point of the node.
+
+    Returns:
+        The instant, rendered.
+    """
+    epoch = datetime.now(timezone.utc).timestamp() if at is None else at
+    return render(epoch, zone)

--- a/nodes/src/nodes/tool_datetime/doc.md
+++ b/nodes/src/nodes/tool_datetime/doc.md
@@ -1,0 +1,130 @@
+---
+title: Date & Time
+date: 2026-09-03
+sidebar_position: 1
+---
+
+<head>
+  <title>Date & Time - RocketRide Documentation</title>
+</head>
+
+## What it does
+
+Gives an agent a clock and a calendar it can trust.
+
+A model has no clock, and telling it today's date does not fix arithmetic. It can
+know today is Thursday and still book a follow-up on the wrong Tuesday, or add a
+month to 31 January and produce a date that does not exist. Those errors are
+written straight through to whatever the agent is filling in — most CRM date
+fields are plain strings with no validation — so a wrong date is stored rather
+than rejected.
+
+This node does the counting somewhere that counts correctly.
+
+It is a tool node only: it has no lanes and does not appear in the data flow.
+Bind it to an agent and it appears in that agent's tool list.
+
+## Unix timestamps are the wire format
+
+Every instant in and out is an integer unix timestamp in seconds. A timestamp
+carries no timezone to be wrong about, so nothing is lost passing one between the
+model, this tool, and whatever the agent writes to.
+
+Dates, weekdays and "the start of the month" are a **rendering** of an instant,
+and the optional `timezone` argument is what resolves them. Pass the caller's own
+zone whenever it is known — it decides what date an instant falls on. Every
+answer names the zone it actually used, so a reply reading `"timezone": "UTC"`
+tells you no zone was supplied.
+
+## The descriptions carry the current time
+
+Each tool's description states the current date, time, weekday and timestamp, and
+is re-evaluated every time an agent reads its tool list. So an agent learns what
+"now" is from the tool itself, without anything else having injected it — which
+matters most when the agent doing the work is a sub-agent several delegations
+deep, where an injected anchor tends not to reach.
+
+## Agent tools
+
+Tools are exposed under the `datetime` namespace.
+
+| Tool | Description |
+| --- | --- |
+| `datetime.now` | The current instant. Call before resolving "today", "tomorrow", "next week" |
+| `datetime.at` | A date and a time of day, in a named zone, as an instant — "Wednesday at 12:30" |
+| `datetime.shift` | Add or subtract time — "in 90 days", "a month before the close date" |
+| `datetime.next_weekday` | The next occurrence of a named weekday — "next Tuesday" |
+| `datetime.boundary` | The first or last instant of a day, week, month, quarter or year |
+| `datetime.difference` | How far apart two instants are |
+| `datetime.render` | A timestamp as a date and time in a given zone |
+
+Every instant-returning tool answers with `epoch`, `iso`, `date` (`YYYY-MM-DD`),
+`time` (`HH:MM`), `weekday`, `timezone` — and `utc_iso`, `utc_date`, `utc_time`,
+the same instant written in UTC. Write one of those pairs into a record verbatim
+rather than formatting or converting an instant by hand.
+
+## Which pair to write is a fact about the field
+
+An instant has no single date and time — it has one per zone. Which one a CRM
+field wants belongs to that field, and the CRMs disagree: Pipedrive reads an
+activity's `due_time` as UTC and displays it in each viewer's own zone, while
+GoHighLevel wants an appointment's `startTime` as a local string carrying its own
+offset.
+
+A meeting asked for at 12:30 in California and written to Pipedrive as `12:30` is
+stored as 12:30 UTC and shown back to the person who asked for it as 05:30. It is
+not rejected; a wrong hour looks exactly like a right one.
+
+Both renderings travel on every answer so that writing the right one is reading a
+different key, never subtracting an offset. Read the field's own description — a
+well-written CRM node names the zone there — and take **both** halves from the
+same rendering: converting an hour past midnight moves the date with it.
+
+## Decisions worth knowing
+
+These are choices, not laws. They are stated here because the alternative is
+discovering them from a wrong booking.
+
+**Durations and calendar steps are different.** `second`, `minute` and `hour` move
+the instant. `day`, `week`, `month` and `year` move the calendar and keep the time
+of day. Across a daylight-saving change those disagree by an hour, and the
+calendar answer is the one a person means: "same time tomorrow" is 09:00
+tomorrow, not 08:00 because the clocks moved.
+
+**Month arithmetic clamps.** 31 January plus one month is the last day of
+February — the 28th, or the 29th in a leap year.
+
+**"Next Tuesday" on a Tuesday means the one coming.** `next_weekday` is strictly
+in the future by default; booking today would be a surprise nobody asked for.
+Pass `allow_today` when today should count.
+
+**`end` is the last second of a period**, so end-of-month reads as the 30th or
+31st rather than the 1st of the next month.
+
+**`difference` answers twice.** `elapsed` is the real duration; `calendar_days` is
+how many dates apart the two instants are on a wall calendar. At 23:00 on
+Thursday, midnight is one hour away *and* the next date — answering only one of
+those is how "how many days until" comes back as zero.
+
+**An unusable timezone answers in UTC rather than failing.** A mistyped zone
+should cost a UTC answer the caller can see and correct, not a failed turn.
+
+**A wall-clock time is not always an instant, and `at` says which.** On the
+morning clocks go forward, 02:30 never happens: the answer resolves to the next
+real instant and sets `adjusted`. On the morning they go back, 01:30 happens
+twice: the earlier is taken and `ambiguous` is set. Neither raises — a meeting
+that has to be booked is better booked at a stated wrong-by-an-hour time than not
+booked at all — and both flags travel with the answer, so say so when either is
+true.
+
+**A malformed date IS refused.** Unlike a bad zone, there is no honest fallback:
+every instant `"9 sept"` could mean is a guess.
+
+## Configuration
+
+**Default timezone** is a deployment-wide fallback used only when a caller names
+no zone of its own. It cannot know where the person asking actually is, which is
+why every answer names the zone it used. Leave it empty for UTC.
+
+<!-- ROCKETRIDE:GENERATED:PARAMS START -->
+<!-- ROCKETRIDE:GENERATED:PARAMS END -->

--- a/nodes/src/nodes/tool_datetime/services.json
+++ b/nodes/src/nodes/tool_datetime/services.json
@@ -1,0 +1,50 @@
+{
+	"title": "Date & Time",
+	"protocol": "tool_datetime://",
+	"classType": ["tool"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.tool_datetime",
+	"prefix": "datetime",
+	"documentation": "https://docs.rocketride.org",
+	"description": [
+		"Gives an agent a clock and a calendar it can trust.",
+		"A model has no clock, and telling it today's date does not fix arithmetic: it can know today is Thursday and still book a follow-up on the wrong Tuesday, or add a month to 31 January and produce a date that does not exist.",
+		"Every instant is a unix timestamp, so nothing is lost passing one between the model, this tool and whatever it writes to. The optional timezone argument decides what date an instant falls on.",
+		"Each tool's description states the current time and is refreshed on every read, so an agent learns what now is from the tool itself."
+	],
+	"tile": ["Tool: ${parameters.tool_datetime.serverName}.now"],
+	"lanes": {},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Default",
+				"serverName": "datetime"
+			}
+		}
+	},
+	"fields": {
+		"tool_datetime.serverName": {
+			"hidden": true,
+			"type": "string",
+			"title": "Server name",
+			"description": "Namespace prefix for the tools: <serverName>.now, <serverName>.shift, and so on",
+			"default": "datetime"
+		},
+		"tool_datetime.defaultTimezone": {
+			"type": "string",
+			"title": "Default timezone",
+			"description": "IANA name, e.g. America/Los_Angeles. Used only when a caller names no zone of its own. Leave empty for UTC. A deployment-wide default cannot know where the person asking actually is, so every answer names the zone it used.",
+			"default": ""
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Date & Time",
+			"properties": ["type", "tool_datetime.defaultTimezone"]
+		}
+	]
+}

--- a/nodes/src/nodes/tool_gohighlevel/tools/messages.py
+++ b/nodes/src/nodes/tool_gohighlevel/tools/messages.py
@@ -334,8 +334,15 @@ class MessagesMixin(GoHighLevelToolsBase):
                 'entries, and excludes email, so pass "Email" explicitly to export email.',
                 ('Call', 'SMS', 'Email', 'WhatsApp', 'Instagram', 'Facebook'),
             ),
-            startDate=STR('Earliest message to include, as an ISO 8601 timestamp.'),
-            endDate=STR('Latest message to include, as an ISO 8601 timestamp.'),
+            # A bare local timestamp is the same trap `_APPOINTMENT_TIMEZONE_DESC` names on
+            # the write side: with no zone in the string, the zone is whatever the far end
+            # assumes, and the only symptom is a range that quietly ends in the wrong place.
+            startDate=STR(
+                'Earliest message to include, as an ISO 8601 timestamp carrying its zone - a trailing Z '
+                'for UTC, or a numeric offset. Without one the timestamp is read in whichever timezone '
+                'GoHighLevel assumes, so the range silently starts somewhere else.'
+            ),
+            endDate=STR('Latest message to include, in the same form as startDate.'),
             sortBy=ENUM('Field to sort on. Defaults to createdAt.', ('createdAt', 'updatedAt')),
             sortOrder=ENUM('Sort direction. Defaults to desc.', ('asc', 'desc')),
         ),

--- a/nodes/src/nodes/tool_pipedrive/README.md
+++ b/nodes/src/nodes/tool_pipedrive/README.md
@@ -95,6 +95,31 @@ create and update tool accepts:
 `extra` is merged into the request body after the typed parameters, so it also
 reaches any API parameter this node does not model explicitly.
 
+### Times are UTC, in both directions
+
+Every field carrying a time of day — an activity's `due_date` and `due_time`, a
+record's `add_time` — is UTC on the wire. Pipedrive displays those values in each
+viewer's own timezone, and validates none of them, so a local wall-clock time sent
+here is not rejected. It is stored, and from then on it reads as a real time.
+
+A meeting asked for at 12:30 in California and written as `12:30` comes back to the
+person who asked for it as 05:30.
+
+Convert before writing and convert back before reporting. The hour moves the **date**
+as well: 20:00 Pacific on a Wednesday is 03:00 UTC on the Thursday, so a converted
+time beside an unconverted date is a booking on the wrong day — take both from the
+same rendering. The `tool_datetime` node returns `utc_date` and `utc_time` next to
+`date` and `time` for exactly this.
+
+Two things this does **not** apply to. A `duration` is a length, not an instant:
+`02:00` is two hours in every timezone there is, and converting it corrupts it. A
+pure date with no time — `expected_close_date`, a goal's period — names no instant,
+so no zone can be wrong about it.
+
+The `start_date` / `end_date` filters on `activity_list` and `note_list` compare
+against those same UTC values, so a range that means one whole local day may need
+widening by a day at each end.
+
 ---
 
 ## Authentication

--- a/nodes/src/nodes/tool_pipedrive/tools/_base.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/_base.py
@@ -49,6 +49,35 @@ EXTRA_DESC = (
     'request body after the typed parameters.'
 )
 
+#: Appended to the description of every field that carries a TIME OF DAY.
+#:
+#: WHY EVERY SUCH FIELD SAYS THIS. Pipedrive takes and returns these in UTC and
+#: displays them in each viewer's own timezone. The API validates none of them,
+#: so a local wall-clock time sent here is not rejected — it is stored, and it
+#: reads as a real time from then on. A meeting asked for at 12:30 in California
+#: and written as "12:30" came back to the person who asked for it as 05:30.
+#:
+#: The hour also moves the DATE. 20:00 Pacific on a Wednesday is 03:00 UTC on the
+#: Thursday, so a converted time and an unconverted date is a booking on the
+#: wrong day — take both from the same rendering or neither.
+#:
+#: A pure DATE with no time (`expected_close_date`, a goal's period) names no
+#: instant and needs none of this. A DURATION is a length, not a time of day, and
+#: converting one is a corruption rather than a correction.
+#:
+#: `tool_gohighlevel` already states its own zones this way
+#: (`appointments._APPOINTMENT_TIMEZONE_DESC`, `contact_tasks._DUE_DATE_DESC`) —
+#: which is the convention, and which Pipedrive was the one node not following.
+#: The two CRMs want different formats, so the shared rule is that a node names
+#: the zone of its own time fields, not that any one zone is right.
+UTC_TIME_DESC = (
+    'Pipedrive reads and returns this in UTC, and shows it to each viewer in their own '
+    'timezone - so send the UTC value, not the local wall-clock one, and convert it back '
+    'before reporting it to a person. The datetime tool returns utc_date and utc_time '
+    'beside date and time for exactly this: write those, and never shift an hour yourself. '
+    'Converting can move the date as well as the time; take both from the same rendering.'
+)
+
 
 # ---------------------------------------------------------------------------
 # Schema builders

--- a/nodes/src/nodes/tool_pipedrive/tools/activities.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/activities.py
@@ -37,6 +37,7 @@ from ._base import (
     INT,
     PAGING,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -73,9 +74,15 @@ _ACTIVITY_WRITE_PROPS = {
     'type': STR(
         'Activity type key, e.g. "call", "meeting", "task", "deadline", "email", "lunch". See activity_type_list for the keys configured in this account.'
     ),
-    'due_date': STR('Due date, YYYY-MM-DD.'),
-    'due_time': STR('Due time, HH:MM.'),
-    'duration': STR('Duration, HH:MM.'),
+    # `due_date` carries the zone note too, and not only `due_time`: the pair is
+    # one instant, and converting the hour past midnight moves the day with it.
+    # A converted time beside an unconverted date is a booking on the wrong day.
+    'due_date': STR(f'Due date, YYYY-MM-DD. {UTC_TIME_DESC}'),
+    'due_time': STR(f'Due time, HH:MM. {UTC_TIME_DESC}'),
+    'duration': STR(
+        'Duration, HH:MM. A LENGTH, not a time of day - no timezone applies and converting '
+        'it is a corruption. A two-hour meeting is "02:00" wherever it is held.'
+    ),
     'done': INT('0 for not done, 1 for done.'),
     'busy_flag': BOOL('Whether the activity marks the user as busy in the calendar.'),
     'note': STR('Note body (HTML is accepted).'),
@@ -112,8 +119,11 @@ class ActivitiesMixin(PipedriveToolsBase):
             filter_id=INT('Apply a saved filter by id (see filter_list).'),
             type=STR('Comma-separated activity type keys to include, e.g. "call,meeting".'),
             done=INT('0 for pending activities, 1 for completed. Omit for both.'),
-            start_date=STR('Only activities due on or after this date, YYYY-MM-DD.'),
-            end_date=STR('Only activities due on or before this date, YYYY-MM-DD.'),
+            start_date=STR(
+                'Only activities due on or after this date, YYYY-MM-DD. Filters the UTC due_date, '
+                'so a range that means a whole day to a person may need widening by one day at each end.'
+            ),
+            end_date=STR('Only activities due on or before this date, YYYY-MM-DD. Same UTC caveat as start_date.'),
         ),
         description='List activities, optionally filtered by owner, type, completion state or due-date range.',
     )

--- a/nodes/src/nodes/tool_pipedrive/tools/deals.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/deals.py
@@ -49,6 +49,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -94,7 +95,7 @@ _DEAL_WRITE_PROPS = {
     'lost_reason': STR('Free-text reason, only meaningful when status is "lost".'),
     'visible_to': ENUM('Visibility group id.', ['1', '3', '5', '7']),
     'label': STR('Deal label id, or a comma-separated list of label ids.'),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/src/nodes/tool_pipedrive/tools/notes.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/notes.py
@@ -34,6 +34,7 @@ from ._base import (
     INT,
     PAGING,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -68,7 +69,7 @@ _NOTE_WRITE_PROPS = {
     'lead_id': STR('Lead uuid the note is attached to.'),
     'project_id': INT('Project the note is attached to.'),
     'user_id': INT('Author user id. Defaults to the authenticated user.'),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'pinned_to_deal_flag': ENUM('Pin the note to the deal.', ['0', '1']),
     'pinned_to_person_flag': ENUM('Pin the note to the person.', ['0', '1']),
     'pinned_to_organization_flag': ENUM('Pin the note to the organization.', ['0', '1']),
@@ -88,8 +89,11 @@ class NotesMixin(PipedriveToolsBase):
             person_id=INT('Only notes attached to this person.'),
             org_id=INT('Only notes attached to this organization.'),
             lead_id=STR('Only notes attached to this lead uuid.'),
-            start_date=STR('Only notes added on or after this date, YYYY-MM-DD.'),
-            end_date=STR('Only notes added on or before this date, YYYY-MM-DD.'),
+            start_date=STR(
+                'Only notes added on or after this date, YYYY-MM-DD. Filters the UTC add_time, so a '
+                'range that means a whole day to a person may need widening by one day at each end.'
+            ),
+            end_date=STR('Only notes added on or before this date, YYYY-MM-DD. Same UTC caveat as start_date.'),
             sort=STR('Sort clause, e.g. "add_time DESC".'),
         ),
         description='List notes, optionally filtered by the record they are attached to or by date.',

--- a/nodes/src/nodes/tool_pipedrive/tools/organizations.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/organizations.py
@@ -48,6 +48,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -68,7 +69,7 @@ _ORG_WRITE_PROPS = {
     'address': STR('Postal address as a single line.'),
     'label': INT('Organization label id.'),
     'visible_to': ENUM('Visibility group id.', ['1', '3', '5', '7']),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/src/nodes/tool_pipedrive/tools/persons.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/persons.py
@@ -47,6 +47,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -88,7 +89,7 @@ _PERSON_WRITE_PROPS = {
     'marketing_status': ENUM(
         'Consent status for marketing emails.', ['no_consent', 'unsubscribed', 'subscribed', 'archived']
     ),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/test/test_tool_datetime.py
+++ b/nodes/test/test_tool_datetime.py
@@ -1,0 +1,386 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+The arithmetic behind `tool_datetime`.
+
+NO STUBS, AND THAT IS THE POINT OF THE SPLIT. `datetime_math` imports nothing
+from the engine — no rocketlib, no ai.common — so it is importable and testable
+on a bare interpreter. Every other tool node's tests begin by injecting
+MagicMock modules and removing them again; a node whose whole job is arithmetic
+should not need that between the assertion and the sum.
+
+What is pinned here is the set of answers a model gets wrong: month lengths,
+weekday counting, quarter boundaries, and the hour that appears or vanishes
+when a clock changes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+_MODULE = Path(__file__).resolve().parents[1] / 'src' / 'nodes' / 'tool_datetime' / 'datetime_math.py'
+_spec = importlib.util.spec_from_file_location('tool_datetime_math', _MODULE)
+dtm = importlib.util.module_from_spec(_spec)
+sys.modules['tool_datetime_math'] = dtm
+_spec.loader.exec_module(dtm)
+
+LA = 'America/Los_Angeles'
+
+
+def at(year, month, day, hour=12, minute=0, zone=None):
+    """A unix timestamp, written the way a person would say the moment."""
+    tz = timezone.utc if zone is None else ZoneInfo(zone)
+    return datetime(year, month, day, hour, minute, tzinfo=tz).timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Month lengths
+# ---------------------------------------------------------------------------
+
+
+def test_adding_a_month_to_the_31st_lands_on_a_day_that_exists():
+    """The 31st of February is the canonical wrong answer."""
+    assert dtm.shift(at(2026, 1, 31), 1, 'month')['date'] == '2026-02-28'
+
+
+def test_subtracting_a_month_clamps_the_same_way():
+    assert dtm.shift(at(2026, 3, 31), -1, 'month')['date'] == '2026-02-28'
+
+
+def test_a_leap_february_keeps_its_29th():
+    assert dtm.shift(at(2028, 1, 31), 1, 'month')['date'] == '2028-02-29'
+
+
+def test_a_year_of_months_returns_to_the_same_date():
+    assert dtm.shift(at(2026, 6, 15), 12, 'month')['date'] == '2027-06-15'
+
+
+def test_months_roll_across_the_year_boundary_in_both_directions():
+    assert dtm.shift(at(2026, 11, 15), 3, 'month')['date'] == '2027-02-15'
+    assert dtm.shift(at(2026, 2, 15), -3, 'month')['date'] == '2025-11-15'
+
+
+# ---------------------------------------------------------------------------
+# Counting weekdays
+# ---------------------------------------------------------------------------
+
+
+def test_next_tuesday_from_a_thursday():
+    # 2026-09-03 is a Thursday — the day this node was written to fix.
+    assert dtm.next_weekday(at(2026, 9, 3), 'tuesday')['date'] == '2026-09-08'
+
+
+def test_next_tuesday_asked_on_a_tuesday_means_the_one_coming():
+    """
+    THE DECISION THIS FILE EXISTS TO STATE. There is no right answer, only a
+    stated one: asked on a Tuesday to book something "next Tuesday", a person
+    means the one coming. Booking today would be a surprise nobody asked for.
+    """
+    tuesday = at(2026, 9, 8)
+    assert dtm.next_weekday(tuesday, 'tuesday')['date'] == '2026-09-15'
+
+
+def test_today_counts_only_when_the_caller_says_so():
+    tuesday = at(2026, 9, 8)
+    assert dtm.next_weekday(tuesday, 'tuesday', allow_today=True)['date'] == '2026-09-08'
+
+
+def test_the_time_of_day_survives_the_move():
+    """This moves the date. A follow-up at 09:48 stays at 09:48."""
+    assert dtm.next_weekday(at(2026, 9, 3, 9, 48), 'monday')['time'] == '09:48'
+
+
+def test_a_day_that_is_not_a_day_is_refused():
+    with pytest.raises(ValueError):
+        dtm.next_weekday(at(2026, 9, 3), 'someday')
+
+
+# ---------------------------------------------------------------------------
+# Daylight saving — where naive arithmetic loses an hour silently
+# ---------------------------------------------------------------------------
+
+
+def test_a_calendar_day_across_a_clock_change_keeps_the_wall_time():
+    """
+    US clocks go forward on 2026-03-08. "Same time tomorrow" from Saturday
+    morning is 09:00 on Sunday, even though only 23 hours have passed.
+    """
+    moved = dtm.shift(at(2026, 3, 7, 9, 0, LA), 1, 'day', LA)
+    assert (moved['date'], moved['time']) == ('2026-03-08', '09:00')
+
+
+def test_twenty_four_hours_across_a_clock_change_is_still_twenty_four_hours():
+    """A duration is not a calendar step, and here they disagree by an hour."""
+    moved = dtm.shift(at(2026, 3, 7, 9, 0, LA), 24, 'hour', LA)
+    assert (moved['date'], moved['time']) == ('2026-03-08', '10:00')
+
+
+def test_the_two_kinds_of_shift_differ_by_exactly_the_hour_the_clocks_moved():
+    start = at(2026, 3, 7, 9, 0, LA)
+    calendar_step = dtm.shift(start, 1, 'day', LA)['epoch']
+    duration = dtm.shift(start, 24, 'hour', LA)['epoch']
+    assert duration - calendar_step == 3600
+
+
+# ---------------------------------------------------------------------------
+# Period boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_end_of_month_is_the_last_day_not_the_first_of_the_next():
+    end = dtm.boundary(at(2026, 9, 3), 'month', 'end')
+    assert end['date'] == '2026-09-30'
+    assert end['time'] == '23:59'
+
+
+def test_end_of_february_knows_its_own_length():
+    assert dtm.boundary(at(2026, 2, 10), 'month', 'end')['date'] == '2026-02-28'
+    assert dtm.boundary(at(2028, 2, 10), 'month', 'end')['date'] == '2028-02-29'
+
+
+def test_quarters_end_where_quarters_end():
+    for month, expected in ((2, '2026-03-31'), (5, '2026-06-30'), (9, '2026-09-30'), (11, '2026-12-31')):
+        assert dtm.boundary(at(2026, month, 10), 'quarter', 'end')['date'] == expected
+
+
+def test_a_week_starts_on_monday():
+    # 2026-09-03 is a Thursday.
+    assert dtm.boundary(at(2026, 9, 3), 'week', 'start')['date'] == '2026-08-31'
+
+
+def test_start_of_a_period_is_midnight():
+    assert dtm.boundary(at(2026, 9, 3), 'month', 'start')['time'] == '00:00'
+
+
+# ---------------------------------------------------------------------------
+# Distance
+# ---------------------------------------------------------------------------
+
+
+def test_ninety_days_is_ninety_days_across_month_boundaries():
+    start = at(2026, 9, 3)
+    end = dtm.shift(start, 90, 'day')['epoch']
+    assert dtm.render(end)['date'] == '2026-12-02'
+    assert dtm.difference(start, end, 'day')['calendar_days'] == 90
+
+
+def test_late_at_night_tomorrow_is_one_day_away_and_an_hour_away():
+    """
+    THE AMBIGUITY, PINNED. At 23:00 on Thursday, midnight is 60 minutes off and
+    also the next date. Answering only one of those is how "how many days until"
+    comes back as zero.
+    """
+    late = at(2026, 9, 3, 23, 0)
+    midnight = at(2026, 9, 4, 0, 0)
+
+    answer = dtm.difference(late, midnight, 'hour')
+
+    assert answer['elapsed'] == 1.0
+    assert answer['calendar_days'] == 1
+
+
+def test_going_backwards_is_negative_rather_than_an_error():
+    later = at(2026, 9, 10)
+    assert dtm.difference(later, at(2026, 9, 3), 'day')['calendar_days'] == -7
+
+
+# ---------------------------------------------------------------------------
+# Zones
+# ---------------------------------------------------------------------------
+
+
+def test_a_zone_decides_what_date_an_instant_falls_on():
+    """
+    The whole reason the argument exists. 02:00 UTC on the 4th is still the
+    evening of the 3rd in California, and a follow-up booked "today" differs.
+    """
+    instant = at(2026, 9, 4, 2, 0)
+    assert dtm.render(instant)['date'] == '2026-09-04'
+    assert dtm.render(instant, LA)['date'] == '2026-09-03'
+
+
+def test_an_unusable_zone_answers_in_utc_and_says_so():
+    """
+    Never an exception. A mistyped zone should cost a UTC answer the caller can
+    see and correct, not a failed turn — the same rule `clock.normalize_zone`
+    already follows.
+    """
+    for bad in ('Mars/Olympus', 'not a zone', '', None):
+        assert dtm.render(at(2026, 9, 3), bad)['timezone'] == 'UTC'
+
+
+def test_every_answer_names_the_zone_it_used():
+    assert dtm.render(at(2026, 9, 3), LA)['timezone'] == LA
+    assert dtm.shift(at(2026, 9, 3), 1, 'day', LA)['timezone'] == LA
+    assert dtm.boundary(at(2026, 9, 3), 'month', 'end', LA)['timezone'] == LA
+    assert dtm.difference(at(2026, 9, 3), at(2026, 9, 4), 'day', LA)['timezone'] == LA
+
+
+# ---------------------------------------------------------------------------
+# The shape a CRM is handed
+# ---------------------------------------------------------------------------
+
+
+def test_the_rendered_fields_are_the_formats_the_crms_document():
+    """
+    Pipedrive documents `due_date` as YYYY-MM-DD and `due_time` as HH:MM, and
+    validates neither — so a wrong shape is stored, not rejected. These fields
+    exist so nothing has to format an instant by hand.
+    """
+    rendered = dtm.render(at(2026, 9, 3, 9, 48))
+
+    assert rendered['date'] == '2026-09-03'
+    assert rendered['time'] == '09:48'
+    assert rendered['weekday'] == 'Thursday'
+    assert rendered['epoch'] == int(at(2026, 9, 3, 9, 48))
+
+
+def test_an_unknown_unit_is_refused_rather_than_guessed():
+    with pytest.raises(ValueError):
+        dtm.shift(at(2026, 9, 3), 1, 'fortnight')
+    with pytest.raises(ValueError):
+        dtm.boundary(at(2026, 9, 3), 'decade', 'end')
+    with pytest.raises(ValueError):
+        dtm.boundary(at(2026, 9, 3), 'month', 'middle')
+
+
+# ---------------------------------------------------------------------------
+# The zone a CRM field is read in
+# ---------------------------------------------------------------------------
+# A booking asked for at 12:30 Pacific was written to Pipedrive as "12:30",
+# which that API reads as UTC, and shown back to the person who asked for it as
+# 05:30. The hour was never touched by any tool here — it came from the words
+# and went straight through — so nothing above could have caught it. What was
+# missing was a way to say "12:30 in this zone" and get the UTC form back.
+
+
+def test_every_answer_carries_the_same_instant_in_utc():
+    """
+    Both renderings, on every answer.
+
+    An instant has a different date and time in every zone, and which one a CRM
+    field wants is a fact about the field. Carrying both is what makes writing
+    the right one a matter of reading a different key.
+    """
+    for answer in (
+        dtm.now(LA),
+        dtm.render(at(2026, 9, 9, 12, 30, LA), LA),
+        dtm.shift(at(2026, 9, 9, 12, 30, LA), 1, 'day', LA),
+        dtm.next_weekday(at(2026, 9, 3), 'wednesday', zone=LA),
+        dtm.boundary(at(2026, 9, 9), 'month', 'end', LA),
+        dtm.at('2026-09-09', '12:30', LA),
+    ):
+        assert answer['utc_date'] and answer['utc_time'] and answer['utc_iso']
+        assert dtm.render(answer['epoch'])['time'] == answer['utc_time']
+
+
+def test_the_failing_booking():
+    """
+    THE TURN THIS EXISTS FOR. "meet with anna next wednesday at 12:30pm",
+    asked from California. Pipedrive reads `due_time` as UTC, so 19:30 is the
+    value that displays as 12:30 to the person who asked.
+    """
+    booked = dtm.at('2026-09-09', '12:30', LA)
+
+    assert (booked['date'], booked['time']) == ('2026-09-09', '12:30')
+    assert (booked['utc_date'], booked['utc_time']) == ('2026-09-09', '19:30')
+
+
+def test_late_evening_is_a_different_date_in_utc():
+    """The defect moves days, not only hours: 8pm Wednesday is Thursday in UTC."""
+    booked = dtm.at('2026-09-09', '20:00', LA)
+
+    assert (booked['date'], booked['weekday']) == ('2026-09-09', 'Wednesday')
+    assert (booked['utc_date'], booked['utc_time']) == ('2026-09-10', '03:00')
+
+
+def test_an_hour_that_does_not_exist_is_resolved_and_flagged():
+    """
+    US clocks go forward on 2026-03-08, so 02:30 never happens that morning.
+
+    Booked at the next real instant rather than refused — a meeting that has to
+    be booked is better booked an hour out than not at all — and `adjusted`
+    says so, so the hour is visible instead of surfacing from the calendar.
+    """
+    booked = dtm.at('2026-03-08', '02:30', LA)
+
+    assert booked['time'] == '03:30'
+    assert booked['requested'] == '2026-03-08 02:30'
+    assert booked['adjusted'] is True
+    assert booked['ambiguous'] is False
+
+
+def test_an_hour_that_happens_twice_takes_the_first_and_says_so():
+    """Clocks go back on 2026-11-01: 01:30 comes round at -07:00 and again at -08:00."""
+    booked = dtm.at('2026-11-01', '01:30', LA)
+
+    assert booked['time'] == '01:30'
+    assert booked['utc_time'] == '08:30', 'the earlier of the two, deterministically'
+    assert booked['ambiguous'] is True
+    assert booked['adjusted'] is False
+
+
+def test_an_ordinary_time_is_neither_adjusted_nor_ambiguous():
+    booked = dtm.at('2026-09-09', '12:30', LA)
+
+    assert booked['adjusted'] is False
+    assert booked['ambiguous'] is False
+
+
+def test_at_round_trips_through_render():
+    """What `at` composes, `render` takes apart again."""
+    booked = dtm.at('2026-09-09', '12:30', LA)
+    back = dtm.render(booked['epoch'], LA)
+
+    assert (back['date'], back['time']) == ('2026-09-09', '12:30')
+
+
+def test_at_accepts_seconds_and_drops_them_from_the_crm_fields():
+    assert dtm.at('2026-09-09', '12:30:45', LA)['utc_time'] == '19:30'
+
+
+def test_at_with_no_zone_reads_the_wall_time_as_utc():
+    """Consistent with every other function here, and the answer names the zone."""
+    booked = dtm.at('2026-09-09', '12:30')
+
+    assert booked['timezone'] == 'UTC'
+    assert booked['utc_time'] == '12:30'
+
+
+def test_a_date_that_is_not_a_date_is_refused():
+    """
+    Unlike a bad zone, which answers in UTC and says so. A misparsed date has no
+    honest answer to fall back to — every instant it could mean is a guess.
+    """
+    for date, time in (('9 sept 2026', '12:30'), ('2026-09-09', 'half twelve'), ('', ''), ('2026-13-40', '12:30')):
+        with pytest.raises(ValueError):
+            dtm.at(date, time, LA)

--- a/nodes/test/tool_gohighlevel/test_gohighlevel.py
+++ b/nodes/test/tool_gohighlevel/test_gohighlevel.py
@@ -33,6 +33,17 @@ import pytest
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
+# sys.path: the test packages under it are named `tool_pipedrive` and
+# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
+# shadow the very nodes these tests import.
+_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
+)
+zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
+_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
+audit_time_fields = zone_audit.audit_time_fields
+
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
 
@@ -1739,3 +1750,47 @@ class TestIGlobalGroupWarnings:
             logged = self._logged(warning_mock)
             assert 'unknown tool group' in logged
             assert 'fail to start' in logged
+
+
+# ---------------------------------------------------------------------------
+# Every field that carries a time of day names its zone
+# ---------------------------------------------------------------------------
+# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
+# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
+# meeting asked for at 12:30 in California was written as "12:30" and shown back
+# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
+# looks exactly like a right one.
+#
+# A model cannot infer a field's zone. It reads the description, and where the
+# description is silent it writes the words the person said.
+#
+# The same audit runs against `tool_gohighlevel`, which was already keeping this
+# rule when Pipedrive was not. Two CRMs, two different correct answers, one
+# obligation — which is what makes this the CRM-agnostic half of the fix.
+
+
+class TestEveryTimeFieldNamesItsZone:
+    #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
+    #: there is, and converting it would turn a duration into a wrong duration.
+    #: Exempt by decision rather than by the matcher missing it.
+    ALLOWED = ('duration',)
+
+    def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
+        assert audit_time_fields(IInstance, self.ALLOWED) == []
+
+    def test_the_audit_can_actually_fail(self):
+        """
+        The guard on the guard.
+
+        A matcher that silently stopped matching would leave the test above
+        passing for ever while saying nothing, which is the failure mode of
+        every audit written against a live surface.
+        """
+
+        class Silent:
+            def book(self):
+                pass
+
+            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
+
+        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/tool_pipedrive/test_pipedrive.py
+++ b/nodes/test/tool_pipedrive/test_pipedrive.py
@@ -9,6 +9,7 @@ env-gated live suite.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 import traceback
@@ -22,6 +23,17 @@ import pytest
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
+# sys.path: the test packages under it are named `tool_pipedrive` and
+# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
+# shadow the very nodes these tests import.
+_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
+)
+zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
+_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
+audit_time_fields = zone_audit.audit_time_fields
+
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
 
@@ -1090,3 +1102,47 @@ class TestCursorPagination:
         result = _instance().person_search({'term': 'ada', 'cursor': 'page1'})
         assert mock_request.call_args[1]['params']['cursor'] == 'page1'
         assert result['next_cursor'] == 'page2'
+
+
+# ---------------------------------------------------------------------------
+# Every field that carries a time of day names its zone
+# ---------------------------------------------------------------------------
+# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
+# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
+# meeting asked for at 12:30 in California was written as "12:30" and shown back
+# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
+# looks exactly like a right one.
+#
+# A model cannot infer a field's zone. It reads the description, and where the
+# description is silent it writes the words the person said.
+#
+# The same audit runs against `tool_gohighlevel`, which was already keeping this
+# rule when Pipedrive was not. Two CRMs, two different correct answers, one
+# obligation — which is what makes this the CRM-agnostic half of the fix.
+
+
+class TestEveryTimeFieldNamesItsZone:
+    #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
+    #: there is, and converting it would turn a duration into a wrong duration.
+    #: Exempt by decision rather than by the matcher missing it.
+    ALLOWED = ('duration',)
+
+    def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
+        assert audit_time_fields(IInstance, self.ALLOWED) == []
+
+    def test_the_audit_can_actually_fail(self):
+        """
+        The guard on the guard.
+
+        A matcher that silently stopped matching would leave the test above
+        passing for ever while saying nothing, which is the failure mode of
+        every audit written against a live surface.
+        """
+
+        class Silent:
+            def book(self):
+                pass
+
+            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
+
+        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/zone_audit.py
+++ b/nodes/test/zone_audit.py
@@ -1,0 +1,115 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Every tool parameter that carries a time of day must name its timezone.
+
+WHAT THIS EXISTS TO CATCH. Pipedrive's `activity_create` documented `due_time`
+as ``'Due time, HH:MM.'`` and nothing more. The API stores that value as UTC and
+shows it back in each viewer's own zone, so a meeting asked for at 12:30 in
+California was written as "12:30", stored, and displayed to the person who asked
+for it as 05:30. Nothing rejected it — a wrong hour looks exactly like a right
+one — and the only reason anybody found out was that they looked at the calendar.
+
+A model cannot infer a field's zone. It reads the description, and if the
+description does not say, it writes what the person said. So the rule is that
+the description says.
+
+WHY IT IS A SHARED HELPER. The same rule has to hold for every CRM this app
+speaks to, and the CRMs do not agree on the answer: Pipedrive wants a naked UTC
+``HH:MM``, GoHighLevel wants ISO-8601 carrying a numeric offset. There is no
+CRM-neutral value — only a CRM-neutral obligation to state one. `tool_gohighlevel`
+was already keeping it (`appointments._APPOINTMENT_TIMEZONE_DESC`) when Pipedrive
+was not, which is what made this worth pinning rather than remembering.
+
+Keyed on the DESCRIPTION rather than the field name, deliberately. Pipedrive's
+`add_time` names no time in its key but carries one; `expected_close_date` looks
+like a date field and correctly needs no zone. Only the text says which is which.
+
+Pure stdlib and no engine imports, so it is safe to import from test modules that
+install their own stub modules before importing the node under test.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+#: A description mentioning one of these is describing a time of day, not a date.
+#:
+#: `HH:MM` covers the split date/time pairs and `HH:MM:SS` timestamps; the ISO
+#: and RFC names cover the single-string forms. A bare ``YYYY-MM-DD`` is absent
+#: on purpose — a calendar date names no instant, so no zone can be wrong about
+#: it, and demanding one would be noise on every close date in the API.
+CARRIES_A_TIME = ('HH:MM', 'ISO 8601', 'ISO-8601', 'RFC3339', 'RFC 3339')
+
+#: Any one of these, anywhere in the description, settles the question.
+#:
+#: Deliberately generous: this test is here to catch a field that says NOTHING,
+#: which is the failure that actually happened. Judging whether what it says is
+#: correct is a person's job, and a stricter matcher would only teach people to
+#: append the word "UTC" to get past it.
+NAMES_A_ZONE = ('UTC', 'timezone', 'time zone', 'IANA', 'offset', 'Z"', 'local time')
+
+
+def audit_time_fields(instance_class: Any, allowed: Iterable[str] = ()) -> list[str]:
+    """
+    Published parameters that carry a time of day and never say in which zone.
+
+    Args:
+        instance_class: The node's ``IInstance`` class. Every attribute carrying
+            a ``__tool_meta__`` is treated as a published tool.
+        allowed: Parameter names exempt by deliberate decision — a duration is
+            a length rather than an instant, and converting one corrupts it.
+            Kept as an explicit list so an exemption is a choice somebody made
+            and can be read back, rather than a hole in the matcher.
+
+    Returns:
+        ``tool.parameter`` for each offender, sorted. Empty is the passing case.
+    """
+    exempt = set(allowed)
+    offenders = []
+
+    for name in dir(instance_class):
+        tool = getattr(instance_class, name, None)
+        meta = getattr(tool, '__tool_meta__', None)
+        if not isinstance(meta, dict):
+            continue
+
+        schema = meta.get('input_schema')
+        properties = schema.get('properties') if isinstance(schema, dict) else None
+        if not isinstance(properties, dict):
+            continue
+
+        for field, spec in properties.items():
+            if field in exempt or not isinstance(spec, dict):
+                continue
+            description = str(spec.get('description') or '')
+            if not any(token in description for token in CARRIES_A_TIME):
+                continue
+            if any(token in description for token in NAMES_A_ZONE):
+                continue
+            offenders.append(f'{name}.{field}')
+
+    return sorted(offenders)


### PR DESCRIPTION
Three node changes the **Daybook** app needs on staging. Split out of #2213 and
targeted at `develop` per `04-custom-nodes.md`, so the node can reach staging's
catalog without waiting on #1993.

## `tool_datetime` — new node

A clock and a calendar the crew can trust. Without it a model dates "next
Tuesday" from whenever it was trained.

- `render()` gains `utc_iso` / `utc_date` / `utc_time`.
- New `at(date, time, zone)` returns `requested` / `adjusted` / `ambiguous`, so a
  DST-folded local time is *reported* rather than silently resolved to one of the
  two possible instants.
- Config schema declared; `doc.md` included per the co-located documentation rule.

**36 tests, no stubs.**

## `tool_pipedrive` / `tool_gohighlevel` — every time field names its zone

The bug this fixes: an activity asked for at **12:30pm was written at 05:30**.
GoHighLevel documented the zone its time fields are in; Pipedrive did not, so the
model had nothing to go on and guessed.

A shared `UTC_TIME_DESC` in `tool_pipedrive/tools/_base.py` now covers `due_date`,
`due_time` and the four `add_time` columns. `nodes/test/zone_audit.py` asserts it
across **both** CRM nodes, so the next tool added cannot quietly omit it.

## `llm_anthropic` — workspace id

Carries a workspace id for identity-linked keys, which have no workspace of their
own. Workspace-scoped keys need nothing and reject one if sent — so the value is
usually and correctly unset.

## Tests

```
python -m pytest nodes/test/test_tool_datetime.py -q
  36 passed

python -m pytest nodes/test/tool_pipedrive nodes/test/tool_gohighlevel nodes/test/prompt nodes/test/agent_deepagent -q
  391 passed, 157 skipped
```

Skips are the GoHighLevel live-API tests (`GHL_PIT` / `GHL_LOCATION_ID` unset).

## Notes

- Cherry-picked cleanly onto `develop` — `tool_datetime` is a pure add, and the
  CRM node files were byte-identical between `develop` and the cherry-pick base.
- The consumer is Daybook; its migration contract is at
  `apps/daybook-ui/docs/CONTRACT.md` in the SaaS repo.
- **This gates Daybook's staging deploy** — no deployed pipe may reference an
  unmerged node, and `daybook.pipe` names `tool_datetime`.
- #2213 stays open against `feat/app-2` for the shell and builder half of the
  work; the `--logfile` build change is deliberately left there rather than mixed
  into a node PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFT36d6d3wc4PrddKSk4Sw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Date & Time tool with timezone-aware current time, parsing, calendar arithmetic, weekday lookup, period boundaries, and duration comparisons.
  * Added configurable default timezone support for the Date & Time tool.
  * Added optional Anthropic workspace ID configuration for identity-linked API keys.

* **Documentation**
  * Clarified timezone requirements and UTC handling for GoHighLevel and Pipedrive timestamps, filters, and time fields.
  * Documented Date & Time tool behavior, including daylight-saving transitions and invalid timezone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->