### PR TITLE
docs: clarify reusable flow event pipe slots (#2103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - media stream descriptors + end-to-end source provenance (#1525)
 
 ### Fixed
+- **docs**: clarify that flow event `body.id` is a reusable pipe slot and trace identity comes from the begin event's `body.logSeq` (#2103)
 - **agent**: optional require_tool_call runtime fabrication guard (#1490)
 - **ai**: install test deps via depends() so engine constraints apply (#1466) (#1471)
 - **ai**: migrate GPU import guard to find_spec/exec_module (Python 3.12+) (#1460)

--- a/packages/ai/tests/ai/modules/task/test_log_stream.py
+++ b/packages/ai/tests/ai/modules/task/test_log_stream.py
@@ -428,6 +428,11 @@ class TestSeededReads:
         assert len(windows) == 3, 'seed must contain three requests'
         slot7 = [w for w in windows if w[1][0]['body'].get('id') == 7]
         assert len(slot7) == 2, 'slot 7 must be recycled'
+        assert slot7[0][0] != slot7[1][0], 'recycled slots must have distinct trace identities'
+        # This slot value is not a begin seq, so it cannot resolve a trace.
+        assert 7 not in {begin_seq for begin_seq, _ in windows}
+        with pytest.raises(KeyError):
+            await session.get_trace(7)
         assert any(e.get('event') == 'apaevt_sse' for _, w in windows for e in w), 'seed must narrate'
         for begin_seq, expected in windows:
             detail = await session.get_trace(begin_seq)

--- a/packages/client-python/src/rocketride/types/events.py
+++ b/packages/client-python/src/rocketride/types/events.py
@@ -275,7 +275,9 @@ class TASK_EVENT_FLOW(TypedDict, total=False):
     a specific pipe within the pipeline.
     """
 
-    id: int  # REQUIRED - Pipe index within the pipeline
+    # Reusable pipe slot, not an event or trace identifier.
+    # Use the begin event's body.logSeq as trace identity within the task's log stream.
+    id: int  # REQUIRED
     op: str  # REQUIRED - Operation type: 'begin', 'enter', 'leave', 'end'
     pipes: List[str]  # REQUIRED - Component names in the current pipe's execution path
     trace: dict  # REQUIRED - Trace data: lane, input/output data, result, error

--- a/packages/client-typescript/src/client/types/events.ts
+++ b/packages/client-typescript/src/client/types/events.ts
@@ -238,7 +238,7 @@ export type TaskEvent = TaskEventRunning | TaskEventBegin | TaskEventEnd | TaskE
  * - ALL: Comprehensive monitoring
  */
 export interface TaskEventFlow {
-	/** Pipe index within the pipeline. */
+	/** Reusable pipe slot, not an event or trace identifier. Use the begin event's body.logSeq as trace identity within the task's log stream. */
 	id: number;
 
 	/** Operation type. */

--- a/packages/server/docs/observability.md
+++ b/packages/server/docs/observability.md
@@ -162,7 +162,7 @@ component's entry and exit with its lane data and any error.
 
 ```ts
 {
-  id: number,                              // pipe index within the pipeline
+  id: number,                              // reusable pipe slot, not an event or trace identifier
   op: "begin" | "enter" | "leave" | "end",
   pipes: string[],                         // current component stack for this pipe
   component?: string,                      // component this op refers to (on "leave", the leaving one) — pair enter/leave by identity, not stack position
@@ -172,6 +172,11 @@ component's entry and exit with its lane data and any error.
   source: string
 }
 ```
+
+`body.id` is reused across requests, so keying traces by it causes collisions.
+Use the `op: "begin"` event's `body.logSeq` (the continuum sequence) as the trace
+identity within the task's log stream; this is the `beginSeq` carried by chat
+completions and the key accepted by `getTrace` (`get_trace` in Python).
 
 `trace` is free-form and varies by node and trace level, store it as JSON, don't
 flatten it.


### PR DESCRIPTION
### Summary

Reviewed and refined the existing documentation patch. Flow event IDs are now documented as reusable slots, with task-scoped trace identity explained. Focused regression passed; docs build remains blocked by missing Node.

`Fixes` #2103.

Clarify at the TypeScript/Python flow fields and in server observability docs that body.id is a reusable pipe slot. Trace identity is the begin event’s body.logSeq within the task’s log stream. Preserve the protocol and add an Unreleased changelog entry.

Extend the existing regression to explicitly check distinct identities for recycled slots and rejection of a slot value with no corresponding begin event. The focused test passed using real log storage through a stub API, with dependency installation disabled. git diff --check passed. Documentation build remains unverified in this session because Node is unavailable; full integration tests were not run. Earlier module history is unavailable in this shallow checkout.

AI-assisted review and refinement of an existing working-tree patch. No publication or human review is claimed.

Fixes #2103

### Verification
- git diff --check — passed.
- python3 -m pytest --version — failed: system Python has no pytest.
- From dist/server: PIP_NO_INDEX=1 PYTHONPATH=../../packages/ai/src:../../packages/client-python/src ./engine -m pytest ../../packages/ai/tests/ai/modules/task/test_log_stream.py -k test_get_trace_by_begin_seq — collection blocked by dependency bootstrap attempting an inaccessible uv cache.
- From dist/server: PIP_NO_INDEX=1 UV_OFFLINE=1 UV_CACHE_DIR=./.uv-cache PYTHONPATH=../../packages/ai/src:../../packages/client-python/src ./engine -c 'import depends; depends.depends = lambda *args, **kwargs: None; import pytest; raise SystemExit(pytest.main(["../../packages/ai/tests/ai/modules/task/test_log_stream.py", "-k", "test_get_trace_by_begin_seq", "--timeout=60"]))' — passed after final edits: 1 passed, 13 deselected. Dependency installation disabled; real writer/reader exercised through
- ./builder docs:build — blocked: node not found. Supervisor setup: provide Node >=20 and pnpm 10.33.0 on PATH; run pnpm install --frozen-lockfile --ignore-scripts, then ./builder docs:build.

> Prepared by IssuePilot with Codex. This is a draft and requires human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that flow event IDs represent reusable pipe slots, not trace identifiers.
  * Documented that traces should be identified using the begin event’s sequence value, including guidance for chat completions and trace lookup.
  * Updated Python and TypeScript event reference documentation and the unreleased changelog.

* **Tests**
  * Added coverage confirming recycled pipe slots retain distinct trace identities and cannot be used directly for trace lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->