### PR TITLE
fix(shell): 404 on missing /shell/static/* assets instead of SPA HTML

### DIFF
--- a/packages/ai/src/ai/modules/shell/shell.py
+++ b/packages/ai/src/ai/modules/shell/shell.py
@@ -267,6 +267,17 @@ async def shell_static(request: Request):
     if file_path.exists() and file_path.is_file():
         return FileResponse(file_path)
 
+    # A missing build asset under /shell/static/ must 404 — it must NOT fall
+    # through to the index.html SPA response below. Those are content-hashed
+    # bundles, not navigation routes; behind the staging CloudFront the 200
+    # HTML gets cached under the .js/.css URL (the /shell/static/* behavior is
+    # edge-cached + immutable), so every viewer is then served HTML-as-JS and
+    # the app fails to boot. A real 404 keeps the missing chunk uncacheable as
+    # a valid asset and lets the client recover. Only genuine navigation routes
+    # get the SPA fallback.
+    if request.url.path.startswith('/shell/static/'):
+        raise HTTPException(status_code=404, detail='Not found')
+
     # SPA fallback: serve index.html for any unmatched route so that
     # client-side routing (React Router, etc.) can handle it.
     index_path = Path(_shell_root) / 'index.html'

--- a/packages/ai/tests/ai/modules/shell/test_shell_routes.py
+++ b/packages/ai/tests/ai/modules/shell/test_shell_routes.py
@@ -303,3 +303,33 @@ def test_add_route_registry_unchanged_when_router_rejects(web_server, monkeypatc
 
     monkeypatch.undo()
     web_server.add_route('/rejected', _handler, ['GET'])
+
+
+# ---------------------------------------------------------------------------
+# Missing /shell/static/* assets 404 (do not fall through to index.html)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_shell_static_asset_404s(shell_root):
+    """A missing /shell/static/* asset must 404, not the index.html SPA fallback.
+
+    Behind the staging CloudFront the /shell/static/* behavior is edge-cached +
+    immutable; a 200 index.html served under a .js/.css URL gets cached as
+    HTML-under-a-JS-URL and poisons every viewer, breaking app boot. Regression
+    guard: content-hashed asset misses must be a real 404.
+    """
+    app = FastAPI()
+    app.get('/shell/{file_path:path}')(shell_static)
+    client = TestClient(app)
+    r = client.get('/shell/static/js/does-not-exist.deadbeef.js')
+    assert r.status_code == 404
+
+
+def test_shell_navigation_route_still_serves_index(shell_root):
+    """A non-static /shell/* route still gets the SPA index.html fallback."""
+    app = FastAPI()
+    app.get('/shell/{file_path:path}')(shell_static)
+    client = TestClient(app)
+    r = client.get('/shell/some/client/route')
+    assert r.status_code == 200
+    assert '<title>shell</title>' in r.text


### PR DESCRIPTION
## What
`shell_static()` returns a real **404** for a missing content-hashed asset under `/shell/static/*`, instead of falling through to the `index.html` SPA response. The SPA fallback stays for genuine navigation routes.

## Why (the staging front-door defect)
The staging `staging.rocketride.ai` CloudFront distribution edge-caches `/shell/static/*` with an **immutable** `Cache-Control` (the #252 shell perf win). Today a missing chunk makes the engine return **200 `index.html`** under the `.js`/`.css` URL, so CloudFront (and the browser) cache **HTML-under-a-JS-URL for a year** — every viewer then loads HTML as a script and the app fails to boot until the cache clears. This is the missing-chunk poisoning @anandray flagged in #ops.

Returning 404 keeps the missing chunk uncacheable as a valid asset and lets the client recover. `apps_static()` already 404s on miss; this brings the shell path in line.

## Scope
- 3-line guard in `shell_static` (only paths starting `/shell/static/`); navigation SPA fallback and `/pricing`-style public routes are unaffected.
- Regression tests: missing `/shell/static/*` → 404; non-static `/shell/*` → index.html.

## Verification
`py_compile` clean; ruff/gitleaks pre-commit green; the added branch logic verified in isolation (present→serve, missing-static→404, navigation→index). Full pytest runs in CI (engine build env); it couldn't run locally without the `engLib` build.

No terraform change is required for this fix — the immutable header is correct once misses 404. (Separately confirmed: `/apps/*` is served by the caching-disabled, auth-forwarding default behavior, so it is **not** edge-cached; nothing to remove there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing shell static assets now return a 404 error instead of the application’s main HTML page.
  - Shell navigation routes continue to load the application as expected.

- **Tests**
  - Added coverage confirming correct handling of missing static assets and navigation routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->