### PR TITLE
fix(ai,ui): stop silently dropping webhook bodies sent on an unread lane

### DIFF
--- a/apps/shared/src/components/pipeline-actions/EndpointInfoModal.tsx
+++ b/apps/shared/src/components/pipeline-actions/EndpointInfoModal.tsx
@@ -13,7 +13,7 @@
 import React, { ReactElement, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IEndpointInfo } from './PipelineActions';
-import { appendAuthQueryParam, buildIntegrationExamples, type IntegrationTabId } from './endpointIntegrationExamples';
+import { appendAuthQueryParam, buildIntegrationExamples, defaultWebhookPayloadId, getWebhookPayload, WEBHOOK_PAYLOADS, type IntegrationTabId, type WebhookPayloadId } from './endpointIntegrationExamples';
 import { commonStyles } from 'shell';
 
 // =============================================================================
@@ -272,9 +272,20 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 	const [isTokenVisible, setIsTokenVisible] = useState(false);
 	const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
 	const [activeTab, setActiveTab] = useState<IntegrationTabId>('curl');
+	// The picked payload is an OVERRIDE, not the value itself: the modal stays
+	// mounted between openings, so seeding state from the lanes would freeze the
+	// first pipeline's answer. Deriving on each render keeps the preselection
+	// honest, while a click still wins until the endpoint changes.
+	const [payloadOverride, setPayloadOverride] = useState<WebhookPayloadId | null>(null);
 
 	const onCloseRef = React.useRef(onClose);
 	onCloseRef.current = onClose;
+
+	// Drop a manual pick when the panel is showing a different endpoint.
+	const endpointKey = endpointInfo?.['url-link'] ?? null;
+	React.useEffect(() => {
+		setPayloadOverride(null);
+	}, [endpointKey]);
 
 	if (!endpointInfo || !isOpen) return null;
 
@@ -285,7 +296,11 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 	const isLocalEndpoint = /localhost|127\.0\.0\.1|0\.0\.0\.0/i.test(endpointUrl);
 	const isWebhookEndpoint = /web[\s-]?hook/i.test(endpointUrl) || /web[\s-]?hook/i.test(processed['url-text'] ?? '');
 
-	const examples = buildIntegrationExamples({ endpointUrl, authKey, isWebhook: isWebhookEndpoint });
+	const connectedLanes = endpointInfo.lanes;
+	const payloadId = payloadOverride ?? defaultWebhookPayloadId(connectedLanes);
+	const examples = buildIntegrationExamples({ endpointUrl, authKey, isWebhook: isWebhookEndpoint, payloadId });
+	const payload = getWebhookPayload(payloadId);
+	const readsChosenLane = connectedLanes?.includes(payload.lane) ?? true;
 
 	const handleCopy = (text: string, label: string) => {
 		navigator.clipboard
@@ -409,7 +424,29 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 					{/* Integration examples */}
 					<div style={styles.testBox}>
 						<div style={styles.testTitle}>Integration examples</div>
-						<div style={styles.envHint}>{isWebhookEndpoint ? 'Webhook: POST JSON with Bearer auth, or use the URL with ?auth= if supported.' : 'Chat / UI: prefer opening the URL with auth in a browser or embedded webview.'}</div>
+						<div style={styles.envHint}>{isWebhookEndpoint ? 'Webhook: POST with Bearer auth, or use the URL with ?auth= if supported.' : 'Chat / UI: prefer opening the URL with auth in a browser or embedded webview.'}</div>
+						{isWebhookEndpoint && (
+							<>
+								<div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 4 }}>
+									{WEBHOOK_PAYLOADS.map((option) => (
+										<button key={option.id} style={commonStyles.toggleButton(payloadId === option.id)} onClick={() => setPayloadOverride(option.id)}>
+											{option.label}
+										</button>
+									))}
+								</div>
+								<div style={styles.envHint}>
+									Sends <code>{payload.contentType}</code>, which the engine delivers on the <strong>{payload.lane}</strong> lane.
+									{connectedLanes?.length ? (
+										<>
+											{' '}
+											This pipeline reads <strong>{connectedLanes.join(', ')}</strong>.{!readsChosenLane && <> Nothing reads the {payload.lane} lane, so this body is answered 200 OK but reaches no component.</>}
+										</>
+									) : (
+										<> Pick the lane your first component reads — a body sent on a lane nothing reads is answered 200 OK but reaches no component.</>
+									)}
+								</div>
+							</>
+						)}
 						<div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 8 }}>
 							{INTEGRATION_TABS.map((tab) => (
 								<button key={tab.id} style={commonStyles.toggleButton(activeTab === tab.id)} onClick={() => setActiveTab(tab.id as IntegrationTabId)}>

--- a/apps/shared/src/components/pipeline-actions/PipelineActions.tsx
+++ b/apps/shared/src/components/pipeline-actions/PipelineActions.tsx
@@ -59,6 +59,12 @@ export interface IEndpointInfo {
 	'token-text'?: string;
 	/** The actual private token value. */
 	'token-key'?: string;
+	/**
+	 * Data lanes some component downstream of this source reads, as reported by
+	 * the running pipeline. Drives which Content-Type the endpoint panel
+	 * preselects. Absent on older engines or when the wiring could not be read.
+	 */
+	lanes?: string[];
 }
 
 export interface IPipelineActionsProps {

--- a/apps/shared/src/components/pipeline-actions/endpointIntegrationExamples.test.ts
+++ b/apps/shared/src/components/pipeline-actions/endpointIntegrationExamples.test.ts
@@ -1,0 +1,147 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+// =============================================================================
+// Unit tests: webhook integration examples.
+//
+// The Content-Type in these snippets is not decoration — it selects the lane
+// the engine delivers the body on, and a body sent on a lane the pipeline does
+// not read is answered `200 OK` while reaching no component. The snippets are
+// emitted in seven dialects, so the pinned invariant is that the SELECTED
+// Content-Type appears in every one of them and no other Content-Type leaks in.
+//
+// Run via `shared:test` (node --import tsx --test), matching the package
+// convention.
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildIntegrationExamples, defaultWebhookPayloadId, getWebhookPayload, WEBHOOK_PAYLOADS, type IntegrationTabId, type WebhookPayloadId } from './endpointIntegrationExamples';
+
+// --- Fixtures ---------------------------------------------------------------
+
+const ENDPOINT = 'http://localhost:5565/webhook/00000000-0000-0000-0000-000000000000/webhook_1';
+/** Obviously-not-a-credential stand-in: real-looking keys trip secret scanners. */
+const AUTH_KEY = 'pk_EXAMPLE_NOT_A_REAL_KEY';
+
+/** Every tab the generator emits — each one is a separate copy-paste snippet. */
+const ALL_TABS: IntegrationTabId[] = ['curl', 'curlCmd', 'powershell', 'wget', 'typescript', 'python', 'http'];
+
+/** Build the webhook snippets for one payload choice. */
+function webhookExamples(payloadId?: WebhookPayloadId): Record<IntegrationTabId, string> {
+	return buildIntegrationExamples({ endpointUrl: ENDPOINT, authKey: AUTH_KEY, isWebhook: true, payloadId });
+}
+
+/** Content-Types the generator can emit, used to assert none of the others leak in. */
+const ALL_CONTENT_TYPES = WEBHOOK_PAYLOADS.map((payload) => payload.contentType);
+
+// --- The selected Content-Type reaches every dialect ------------------------
+
+for (const payload of WEBHOOK_PAYLOADS) {
+	test(`webhook examples: '${payload.id}' puts ${payload.contentType} in every snippet`, () => {
+		const examples = webhookExamples(payload.id);
+		for (const tab of ALL_TABS) {
+			assert.ok(examples[tab].includes(payload.contentType), `tab '${tab}' is missing Content-Type ${payload.contentType}: ${examples[tab]}`);
+		}
+	});
+
+	test(`webhook examples: '${payload.id}' leaks no other Content-Type`, () => {
+		const examples = webhookExamples(payload.id);
+		const others = ALL_CONTENT_TYPES.filter((contentType) => contentType !== payload.contentType);
+		for (const tab of ALL_TABS) {
+			for (const other of others) {
+				assert.ok(!examples[tab].includes(other), `tab '${tab}' still mentions ${other} while '${payload.id}' is selected: ${examples[tab]}`);
+			}
+		}
+	});
+}
+
+// --- Defaults and fallbacks -------------------------------------------------
+
+test('webhook examples: JSON is the default when no payload is named', () => {
+	const examples = webhookExamples();
+	for (const tab of ALL_TABS) {
+		assert.ok(examples[tab].includes('application/json'), `tab '${tab}' did not default to JSON`);
+	}
+});
+
+test('getWebhookPayload: an unknown id falls back to JSON rather than returning undefined', () => {
+	const payload = getWebhookPayload('nonsense' as WebhookPayloadId);
+	assert.equal(payload.id, 'json');
+	assert.equal(payload.contentType, 'application/json');
+});
+
+test('WEBHOOK_PAYLOADS: each entry names a distinct lane and Content-Type', () => {
+	const lanes = new Set(WEBHOOK_PAYLOADS.map((payload) => payload.lane));
+	const contentTypes = new Set(ALL_CONTENT_TYPES);
+	assert.equal(lanes.size, WEBHOOK_PAYLOADS.length);
+	assert.equal(contentTypes.size, WEBHOOK_PAYLOADS.length);
+});
+
+// --- Which payload a freshly opened panel preselects -------------------------
+
+test('default payload: JSON when the pipeline reads the json lane', () => {
+	assert.equal(defaultWebhookPayloadId(['json']), 'json');
+});
+
+test('default payload: text when the pipeline reads text but not json', () => {
+	assert.equal(defaultWebhookPayloadId(['text']), 'text');
+});
+
+test('default payload: JSON wins when the pipeline reads both lanes', () => {
+	assert.equal(defaultWebhookPayloadId(['text', 'json']), 'json');
+});
+
+test('default payload: JSON when the pipeline reads neither lane', () => {
+	assert.equal(defaultWebhookPayloadId(['tags', 'documents']), 'json');
+});
+
+test('default payload: JSON when the engine reported no lanes at all', () => {
+	assert.equal(defaultWebhookPayloadId([]), 'json');
+	assert.equal(defaultWebhookPayloadId(undefined), 'json');
+});
+
+test('default payload: every answer names a payload that actually exists', () => {
+	for (const lanes of [['json'], ['text'], ['tags'], [], undefined]) {
+		const id = defaultWebhookPayloadId(lanes);
+		assert.ok(
+			WEBHOOK_PAYLOADS.some((payload) => payload.id === id),
+			`lanes ${JSON.stringify(lanes)} produced unknown payload '${id}'`
+		);
+	}
+});
+
+// --- Body shape per payload -------------------------------------------------
+
+test("webhook examples: the JSON payload uses each language's JSON helper", () => {
+	const examples = webhookExamples('json');
+	assert.ok(examples.typescript.includes('JSON.stringify({"event":"test","message":"hello"})'));
+	assert.ok(examples.python.includes('json={"event":"test","message":"hello"},'));
+});
+
+test('webhook examples: a text payload is sent as a plain string, not as JSON', () => {
+	const examples = webhookExamples('text');
+	assert.ok(!examples.typescript.includes('JSON.stringify('), `text body should not be wrapped in JSON.stringify: ${examples.typescript}`);
+	assert.ok(examples.python.includes('data="hello from RocketRide",'), examples.python);
+});
+
+test('webhook examples: the cmd snippet escapes double quotes in the body', () => {
+	const examples = webhookExamples('json');
+	assert.ok(examples.curlCmd.includes('-d "{\\"event\\":\\"test\\",\\"message\\":\\"hello\\"}"'), examples.curlCmd);
+});
+
+// --- Chat / dropper endpoints are untouched ---------------------------------
+
+test('chat endpoints ignore the payload choice and stay GET-shaped', () => {
+	const asJson = buildIntegrationExamples({ endpointUrl: 'http://localhost:5565/chat/p/chat_1', authKey: AUTH_KEY, isWebhook: false, payloadId: 'json' });
+	const asText = buildIntegrationExamples({ endpointUrl: 'http://localhost:5565/chat/p/chat_1', authKey: AUTH_KEY, isWebhook: false, payloadId: 'text' });
+
+	assert.deepEqual(asJson, asText);
+	for (const contentType of ALL_CONTENT_TYPES) {
+		assert.ok(!asJson.curl.includes(contentType), `chat curl should carry no Content-Type, found ${contentType}`);
+	}
+	assert.ok(asJson.http.startsWith('GET '), asJson.http);
+});

--- a/apps/shared/src/components/pipeline-actions/endpointIntegrationExamples.ts
+++ b/apps/shared/src/components/pipeline-actions/endpointIntegrationExamples.ts
@@ -7,9 +7,62 @@
  * Builds copy-paste integration examples for the endpoint modal (curl, wget,
  * TypeScript, Python, raw HTTP). Supports webhook POST flows and UI-style
  * endpoints (chat/dropper) where auth can be passed as `?auth=` on the URL.
+ *
+ * A webhook's `Content-Type` selects which lane the engine delivers the body on,
+ * so it is a choice the caller has to make, not boilerplate: a body sent on a
+ * lane the pipeline does not read is accepted, answered `200 OK` and consumed by
+ * nobody. Hence `WEBHOOK_PAYLOADS` — one entry per lane a plain POST can reach.
  */
 
 export type IntegrationTabId = 'curl' | 'curlCmd' | 'powershell' | 'wget' | 'typescript' | 'python' | 'http';
+
+export type WebhookPayloadId = 'json' | 'text' | 'raw';
+
+export interface IWebhookPayload {
+	id: WebhookPayloadId;
+	/** Short label for the payload picker. */
+	label: string;
+	/** Lane the engine routes this Content-Type to, when a component reads it. */
+	lane: string;
+	contentType: string;
+	/** Single-line request body to send. */
+	body: string;
+}
+
+/**
+ * The lanes a plain webhook POST can reach, and the Content-Type that selects each.
+ *
+ * Mirrors the engine's MIME → lane routing (`_determine_lane` in
+ * `packages/ai/src/ai/modules/data/data_conn.py`). `application/octet-stream`
+ * matches no typed branch there and falls through to the raw/tags lane, which is
+ * what document-ingestion pipelines (parse, dropper-style) read.
+ */
+export const WEBHOOK_PAYLOADS: IWebhookPayload[] = [
+	{ id: 'json', label: 'JSON', lane: 'json', contentType: 'application/json', body: '{"event":"test","message":"hello"}' },
+	{ id: 'text', label: 'Text', lane: 'text', contentType: 'text/plain', body: 'hello from RocketRide' },
+	{ id: 'raw', label: 'Raw bytes', lane: 'tags', contentType: 'application/octet-stream', body: 'hello from RocketRide' },
+];
+
+/** Returns the payload for `id`, falling back to JSON for an unknown value. */
+export function getWebhookPayload(id?: WebhookPayloadId): IWebhookPayload {
+	return WEBHOOK_PAYLOADS.find((payload) => payload.id === id) ?? WEBHOOK_PAYLOADS[0];
+}
+
+/**
+ * Picks which payload a freshly opened panel should show, from the lanes the
+ * running pipeline actually reads (published in the endpoint note).
+ *
+ * JSON wins when both are read, because it is the richer body and the
+ * longstanding default; text is offered only when JSON would reach nobody.
+ * With no lane information — an older engine, or a pipeline whose wiring could
+ * not be read — the answer is JSON, matching the previous fixed behaviour.
+ */
+export function defaultWebhookPayloadId(lanes?: string[]): WebhookPayloadId {
+	const read = new Set(lanes ?? []);
+	if (read.has('json')) return 'json';
+	if (read.has('text')) return 'text';
+	return 'json';
+}
 
 /** Appends `?auth=` (or `&auth=`) so integrations can use the full URL without an Authorization header. */
 export function appendAuthQueryParam(url: string, authKey: string): string {
@@ -27,6 +80,8 @@ export interface IBuildIntegrationExamplesParams {
 	endpointUrl: string;
 	authKey: string;
 	isWebhook: boolean;
+	/** Which lane the webhook examples should target. Defaults to JSON. Ignored for chat/dropper. */
+	payloadId?: WebhookPayloadId;
 }
 
 function parseHttpUrl(url: string): { host: string; pathWithQuery: string } {
@@ -38,46 +93,55 @@ function parseHttpUrl(url: string): { host: string; pathWithQuery: string } {
 	}
 }
 
-export function buildIntegrationExamples({ endpointUrl, authKey, isWebhook }: IBuildIntegrationExamplesParams): Record<IntegrationTabId, string> {
+export function buildIntegrationExamples({ endpointUrl, authKey, isWebhook, payloadId }: IBuildIntegrationExamplesParams): Record<IntegrationTabId, string> {
 	const urlWithAuth = appendAuthQueryParam(endpointUrl, authKey);
 	const { host, pathWithQuery } = parseHttpUrl(endpointUrl);
-	const jsonOneLine = '{"event":"test","message":"hello"}';
-	/** Escape double quotes for JSON inside CMD `curl.exe ... -d "..."` */
-	const jsonOneLineCmd = jsonOneLine.replace(/"/g, '\\"');
 
 	if (isWebhook) {
+		const { contentType, body } = getWebhookPayload(payloadId);
+		/** Escape double quotes for the body inside CMD `curl.exe ... -d "..."` */
+		const bodyCmd = body.replace(/"/g, '\\"');
+		/** PowerShell single-quoted strings escape a quote by doubling it. */
+		const bodyPs = body.replace(/'/g, "''");
+		const pythonAuthKey = authKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		// A JSON body reads better through each language's own JSON helper; the
+		// text and raw payloads are plain strings and go out verbatim.
+		const isJsonBody = contentType === 'application/json';
+		const tsBody = isJsonBody ? `JSON.stringify(${body})` : JSON.stringify(body);
+		const pythonBodyArg = isJsonBody ? `json=${body},` : `data=${JSON.stringify(body)},`;
+
 		const curlBash = `curl -X POST "${endpointUrl}" \\
-  -H "Content-Type: application/json" \\
+  -H "Content-Type: ${contentType}" \\
   -H "Authorization: Bearer ${authKey}" \\
-  -d '${jsonOneLine}'`;
+  -d '${body}'`;
 
 		const curlCmdOnly = `REM Use curl.exe so cmd does not use a PowerShell alias
 curl.exe -X POST "${endpointUrl}" ^
-  -H "Content-Type: application/json" ^
+  -H "Content-Type: ${contentType}" ^
   -H "Authorization: Bearer ${authKey}" ^
-  -d "${jsonOneLineCmd}"`;
+  -d "${bodyCmd}"`;
 
 		const psInvoke = `$headers = @{
   Authorization = "Bearer ${authKey}"
 }
-$body = '${jsonOneLine}'
-Invoke-RestMethod -Uri "${endpointUrl}" -Method Post -Headers $headers -ContentType "application/json" -Body $body`;
+$body = '${bodyPs}'
+Invoke-RestMethod -Uri "${endpointUrl}" -Method Post -Headers $headers -ContentType "${contentType}" -Body $body`;
 
 		return {
 			curl: curlBash,
 			curlCmd: curlCmdOnly,
 			powershell: psInvoke,
 			wget: `wget -qO- --method=POST "${endpointUrl}" \\
-  --header='Content-Type: application/json' \\
+  --header='Content-Type: ${contentType}' \\
   --header='Authorization: Bearer ${authKey}' \\
-  --body-data='${jsonOneLine}'`,
+  --body-data='${body}'`,
 			typescript: `const res = await fetch("${endpointUrl}", {
   method: "POST",
   headers: {
-    "Content-Type": "application/json",
+    "Content-Type": "${contentType}",
     Authorization: "Bearer ${authKey}",
   },
-  body: JSON.stringify({ event: "test", message: "hello" }),
+  body: ${tsBody},
 });
 console.log(await res.text());`,
 			python: `import requests
@@ -85,18 +149,18 @@ console.log(await res.text());`,
 r = requests.post(
     "${endpointUrl}",
     headers={
-        "Content-Type": "application/json",
-        "Authorization": "Bearer ${authKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}",
+        "Content-Type": "${contentType}",
+        "Authorization": "Bearer ${pythonAuthKey}",
     },
-    json={"event": "test", "message": "hello"},
+    ${pythonBodyArg}
 )
 print(r.text)`,
 			http: `POST ${pathWithQuery} HTTP/1.1
 Host: ${host}
-Content-Type: application/json
+Content-Type: ${contentType}
 Authorization: Bearer ${authKey}
 
-${jsonOneLine}`,
+${body}`,
 		};
 	}
 

--- a/docs/agents/ROCKETRIDE_INTEGRATIONS.md
+++ b/docs/agents/ROCKETRIDE_INTEGRATIONS.md
@@ -248,6 +248,39 @@ curl -X POST "$WEBHOOK_URL" \
      -d '{"customer": "ACME", "total": 129.90}'
 ```
 
+### Content-Type selects the lane
+
+The `Content-Type` is routing, not decoration: it decides which **lane** the body is
+delivered on. The engine picks the lane that both matches the MIME type and has a component
+reading it; anything unmatched falls through to the raw/tags lane.
+
+| Send | Lane, when a component reads it |
+| --- | --- |
+| `application/json` | `json` |
+| `text/*` | `text` |
+| `image/*`, `video/*`, `audio/*` | `image`, `video`, `audio` |
+| `application/rocketride-question+json` | `questions` |
+| anything else (e.g. `application/pdf`) | raw, delivered on `tags` — what `parse` reads |
+
+**Match the header to the lane your first component reads.** When nothing reads the chosen
+lane the request still succeeds — accepted, counted as completed, answered `200 OK` — and no
+component ever sees the body; only `resultTypes` comes back empty. The mismatch is symmetric,
+so no single header is right for every pipeline: `text/plain` into a `json`-first pipeline
+fails exactly the way `application/json` fails into a `text`-first one.
+
+A body that reaches nobody raises a task warning naming the lane it went to and the lanes the
+pipeline reads:
+
+```text
+Data sent as "application/json" went to the "raw" lane, which no component in this
+pipeline reads, so nothing received it. Lanes this pipeline reads: text.
+Send a Content-Type that maps to one of those instead.
+```
+
+Read it from `get_task_status(token)['warnings']`, or in the source's errors/warnings pane.
+The endpoint panel offers one ready-made example per lane and preselects the lane the running
+pipeline reads.
+
 ### What comes back
 
 The HTTP response is built by the pipeline's `response_*` nodes — each contributes its

--- a/nodes/src/nodes/webhook/IEndpoint.py
+++ b/nodes/src/nodes/webhook/IEndpoint.py
@@ -35,6 +35,47 @@ requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
 depends(requirements)
 
 
+# Binder methods that are lifecycle hooks rather than data lanes. Every bound
+# component listens on them, so they say nothing about what the pipeline reads.
+LIFECYCLE_METHODS = frozenset({'open', 'closing', 'close'})
+
+
+def _connectedLanes(target) -> list:
+    """Return the data lanes that some component downstream of this source reads.
+
+    Published in the endpoint note so the UI can offer the Content-Type that
+    actually reaches a component: the MIME type of a request selects the lane it
+    is delivered on, and a body sent on an unread lane is answered ``200 OK``
+    while reaching nobody.
+
+    Borrows a pipe solely to ask the binder which lanes have listeners and
+    returns it immediately. Any failure yields an empty list — the lanes are a
+    display hint, and losing the hint must never stop the endpoint from serving.
+
+    Args:
+        target: The target endpoint (``IServiceEndpoint``) this source feeds.
+
+    Returns:
+        list: Sorted lane names, or an empty list if they could not be read.
+    """
+    if target is None:
+        return []
+
+    pipe = None
+    try:
+        pipe = target.getPipe()
+        return sorted(set(pipe.getListeners()) - LIFECYCLE_METHODS)
+    except Exception as e:
+        debug(f'Could not read the connected lanes: {e}')
+        return []
+    finally:
+        if pipe is not None:
+            try:
+                target.putPipe(pipe)
+            except Exception as e:
+                debug(f'Could not return the borrowed pipe: {e}')
+
+
 class IEndpoint(IEndpointBase):
     """
     The IEndpoint class handles the actual HTTP request endpoint.
@@ -102,6 +143,9 @@ class IEndpoint(IEndpointBase):
                     'auth-key': '{public_auth}',
                     'token-text': 'Private Token',
                     'token-key': '{token}',
+                    # Lets the endpoint panel preselect a Content-Type that
+                    # actually reaches a component. Empty when unavailable.
+                    'lanes': _connectedLanes(self.target),
                 }
                 monitorOther('usr', json.dumps([info]))
                 monitorStatus('Webhook ready - system is ready to accept requests')

--- a/nodes/test/webhook/test_endpoint.py
+++ b/nodes/test/webhook/test_endpoint.py
@@ -22,7 +22,7 @@ NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
 if str(NODES_SRC) not in sys.path:
     sys.path.insert(0, str(NODES_SRC))
 
-from webhook.IEndpoint import IEndpoint  # noqa: E402
+from webhook.IEndpoint import IEndpoint, _connectedLanes  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -257,3 +257,56 @@ def test_run_does_not_start_waiting_when_guard_fails():
             ep._run()
 
     event_ctor.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _connectedLanes — the lanes published in the endpoint note
+# ---------------------------------------------------------------------------
+
+
+def _target_with_listeners(listeners):
+    """A target endpoint whose borrowed pipe reports the given listeners."""
+    target = MagicMock(name='target-endpoint')
+    pipe = MagicMock(name='pipe')
+    pipe.getListeners = MagicMock(return_value=list(listeners))
+    target.getPipe = MagicMock(return_value=pipe)
+    return target, pipe
+
+
+def test_connected_lanes_reports_data_lanes_sorted():
+    """The panel needs the readable lanes, so lifecycle hooks are filtered out."""
+    target, _ = _target_with_listeners(['text', 'open', 'closing', 'close', 'json'])
+
+    assert _connectedLanes(target) == ['json', 'text']
+
+
+def test_connected_lanes_returns_the_borrowed_pipe():
+    """The pipe is borrowed from a pool — never leak it, or the pool starves."""
+    target, pipe = _target_with_listeners(['json'])
+
+    _connectedLanes(target)
+
+    target.putPipe.assert_called_once_with(pipe)
+
+
+def test_connected_lanes_returns_the_pipe_even_when_reading_fails():
+    """A failure while reading must not leak the pipe either."""
+    target, pipe = _target_with_listeners([])
+    pipe.getListeners = MagicMock(side_effect=RuntimeError('boom'))
+
+    assert _connectedLanes(target) == []
+    target.putPipe.assert_called_once_with(pipe)
+
+
+def test_connected_lanes_is_empty_when_no_pipe_can_be_borrowed():
+    """Losing the hint is acceptable; failing the endpoint startup is not."""
+    target = MagicMock(name='target-endpoint')
+    target.getPipe = MagicMock(side_effect=RuntimeError('endpoint not open'))
+
+    assert _connectedLanes(target) == []
+    target.putPipe.assert_not_called()
+
+
+def test_connected_lanes_is_empty_without_a_target():
+    """A source with no bound target advertises nothing rather than raising."""
+    assert _connectedLanes(None) == []

--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -40,6 +40,7 @@ from rocketlib import (
     monitorCompleted,
     monitorFailed,
     monitorOther,
+    warning,
 )
 
 # Only import for type checking to avoid circular import errors
@@ -55,6 +56,22 @@ if TYPE_CHECKING:
 # trace events ride the run-log continuum, so unbounded tool payloads would
 # bloat segments without adding replay value.
 TOOL_TRACE_DATA_CAP = 2048
+
+
+# =============================================================================
+# LANE CONSTANTS
+# =============================================================================
+
+# Lane names as `_determine_lane` returns them, mapped to the binder method a
+# write on that lane dispatches to. Only names that differ need an entry: the
+# `tag` and `raw` lanes both ride the `tags` method (writeTag / writeTagData),
+# so asking the pipe about `raw` would always answer "no listener".
+LANE_BINDER_METHODS = {'tag': 'tags', 'raw': 'tags'}
+
+# Binder methods that are lifecycle hooks, not data lanes. Every bound component
+# listens on them, so they always come back from getListeners() and must be kept
+# out of any "lanes you could send to" list.
+LANE_LIFECYCLE_METHODS = frozenset({'open', 'closing', 'close'})
 
 
 def _trim_tool_data(value: Any) -> Any:
@@ -303,6 +320,36 @@ class DataConn(DAPConn):
         # and output it to the data lane
         else:
             return 'raw'
+
+    def _warn_on_unconsumed_lane(self, mime_type: str, lane: str, pipe_instance: IServiceFilterPipe):
+        """
+        Warn when the chosen lane has no consumer, so the data reaches nothing.
+
+        A lane that no component reads is not an error — a source may legitimately
+        offer several lanes while the pipeline wires up one. What is never intended
+        is *this* object landing on one of the unread ones: it is accepted, counted
+        as completed and answered with status OK, yet no component ever sees it.
+        The warning is the only signal that separates that outcome from a real one.
+
+        Args:
+            mime_type (str): MIME type the sender supplied, as received.
+            lane (str): Lane chosen for it by :pyfunc:`_determine_lane`.
+            pipe_instance (IServiceFilterPipe): Pipe the data would be written to.
+
+        Returns:
+            None
+        """
+        method = LANE_BINDER_METHODS.get(lane, lane)
+        if pipe_instance.hasListener(method):
+            return
+
+        data_lanes = set(pipe_instance.getListeners()) - LANE_LIFECYCLE_METHODS
+        consumed = ', '.join(sorted(data_lanes)) or 'none'
+        warning(
+            f'Data sent as "{mime_type}" went to the "{lane}" lane, which no component in this '
+            f'pipeline reads, so nothing received it. Lanes this pipeline reads: {consumed}. '
+            'Send a Content-Type that maps to one of those instead.'
+        )
 
     def _begin(self, pipe_conn: DataConnPipe):
         """
@@ -575,6 +622,7 @@ class DataConn(DAPConn):
                     # Get the id and determine the lane
                     pipe_id = pipe_instance.pipeId
                     lane = self._determine_lane(mime_type, pipe_instance)
+                    self._warn_on_unconsumed_lane(mime_type, lane, pipe_instance)
 
                     # Open the object for processing
                     pipe_instance.open(entry)

--- a/packages/ai/tests/ai/modules/data/test_data_conn.py
+++ b/packages/ai/tests/ai/modules/data/test_data_conn.py
@@ -40,9 +40,15 @@ def _make_conn():
 
 
 def _make_pipe_with_listeners(listeners):
-    """Build a fake IServiceFilterPipe whose getListeners() returns the supplied set."""
+    """Build a fake IServiceFilterPipe whose getListeners() returns the supplied set.
+
+    ``hasListener`` answers from the same set, the way the engine's Binder does —
+    a bare MagicMock would return a truthy mock for every lane and hide exactly
+    the "nobody reads this" case these tests exist to pin.
+    """
     pipe = MagicMock()
     pipe.getListeners = MagicMock(return_value=set(listeners))
+    pipe.hasListener = MagicMock(side_effect=lambda lane: lane in set(listeners))
     return pipe
 
 
@@ -141,6 +147,98 @@ def test_determine_lane_unknown_mime_goes_to_raw():
     conn = _make_conn()
     pipe = _make_pipe_with_listeners(['text', 'image'])  # listeners don't matter here
     assert conn._determine_lane('application/x-unknown', pipe) == 'raw'
+
+
+# ---------------------------------------------------------------------------
+# _warn_on_unconsumed_lane
+# ---------------------------------------------------------------------------
+
+
+def test_warn_on_unconsumed_lane_stays_quiet_when_the_lane_is_read(monkeypatch):
+    """A lane with a consumer produces no warning."""
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners(['text'])
+    conn._warn_on_unconsumed_lane('text/plain', 'text', pipe)
+
+    assert warnings == []
+
+
+def test_warn_on_unconsumed_lane_warns_when_nothing_reads_it(monkeypatch):
+    """JSON sent to a text-only pipeline warns, naming the MIME and the read lanes."""
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners(['text'])
+    conn._warn_on_unconsumed_lane('application/json', 'raw', pipe)
+
+    assert len(warnings) == 1
+    message = warnings[0]
+    assert 'application/json' in message
+    assert 'text' in message
+
+
+def test_warn_on_unconsumed_lane_resolves_raw_through_the_tags_method(monkeypatch):
+    """The 'raw' lane is checked against 'tags' — a tags consumer silences it.
+
+    ``writeTagData`` dispatches on the binder's ``tags`` method, so a pipeline
+    whose first node reads ``tags`` does receive raw-routed data and must not
+    be warned about.
+    """
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners(['tags'])
+    conn._warn_on_unconsumed_lane('application/json', 'raw', pipe)
+
+    assert warnings == []
+
+
+def test_warn_on_unconsumed_lane_reports_no_read_lanes_as_none(monkeypatch):
+    """With nothing wired downstream the message says so rather than printing an empty list."""
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners([])
+    conn._warn_on_unconsumed_lane('application/json', 'raw', pipe)
+
+    assert len(warnings) == 1
+    assert 'none' in warnings[0]
+
+
+def test_warn_on_unconsumed_lane_omits_lifecycle_methods_from_the_suggestion(monkeypatch):
+    """open/closing/close are bound on every component and must not be offered as lanes."""
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners(['open', 'closing', 'close', 'text'])
+    conn._warn_on_unconsumed_lane('application/json', 'raw', pipe)
+
+    assert len(warnings) == 1
+    message = warnings[0]
+    assert 'reads: text.' in message
+    for lifecycle in ('open', 'closing', 'close'):
+        assert f'{lifecycle},' not in message
+
+
+def test_warn_on_unconsumed_lane_is_symmetric_for_text_on_a_json_pipeline(monkeypatch):
+    """The mismatch is not JSON-specific: text into a json-only pipeline warns too."""
+    warnings = []
+    monkeypatch.setattr('ai.modules.data.data_conn.warning', warnings.append)
+
+    conn = _make_conn()
+    pipe = _make_pipe_with_listeners(['json'])
+    conn._warn_on_unconsumed_lane('text/plain', 'raw', pipe)
+
+    assert len(warnings) == 1
+    assert 'text/plain' in warnings[0]
+    assert 'json' in warnings[0]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/docs/index.md
+++ b/packages/server/docs/index.md
@@ -156,6 +156,51 @@ commands:
 The pipeline JSON sent over the socket is identical to the JSON you author
 visually or by hand, the protocol just transports it.
 
+## MIME type selects the lane
+
+Every write carries a MIME type — the `mimeType` argument of `rrext_process` /
+`open`, which the HTTP `/webhook/{project_id}/{source}` route fills in from the
+request's `Content-Type` header. That MIME type is **routing, not metadata**: it
+picks which lane the body is delivered on.
+
+The choice is made against the pipeline's live wiring, not a fixed table. A
+branch is taken only when the MIME type matches **and** some component actually
+reads that lane; anything unmatched falls through to the raw/tags lane.
+
+| MIME type | Lane, when a component reads it |
+| --- | --- |
+| `application/json` | `json` |
+| `text/*` | `text` |
+| `image/*`, `video/*`, `audio/*` | `image`, `video`, `audio` |
+| `application/rocketride-question+json` | `questions` |
+| `application/rocketlib-tag` | `tags` |
+| anything else, or no reader above | raw, delivered on `tags` |
+
+The prefix `lane/<name>` bypasses detection and targets a lane directly.
+
+### When nothing reads the chosen lane
+
+The write still succeeds. The object is accepted, counted as completed and
+answered `200 OK`; only `resultTypes` comes back empty, because no component
+received the body. Nothing about the response, the HTTP log line or the task
+counters distinguishes this from a successful run.
+
+Because that outcome is indistinguishable from success, the engine emits a task
+**warning** naming the lane the data went to and the lanes the pipeline reads.
+It is a warning rather than an error: a source may legitimately offer several
+lanes while a pipeline wires up one, so an unread lane is not by itself a fault
+— but *this object reaching nobody* is never what the sender intended, and the
+warning is the only signal that separates the two.
+
+Read the warnings from `get_task_status(token)['warnings']`, or subscribe to
+`apaevt_status_warning` (see [Observability](/protocols/websocket/observability)).
+
+Note that the mismatch is symmetric: `text/plain` into a pipeline whose first
+component reads `json` fails exactly the way `application/json` fails into a
+`text`-first one. There is no single header that is correct for every pipeline,
+which is why the endpoint panel offers one example per lane and preselects the
+one the running pipeline reads.
+
 ## Keepalive & timeouts
 
 The connection is long-lived: a task stays open while it streams. The SDK


### PR DESCRIPTION
## Summary

- A webhook body whose `Content-Type` maps to a lane no component reads was accepted, counted
  as completed and answered `200 OK` while reaching nobody. It now raises a task warning
  naming the lane it went to and the lanes the pipeline does read.
- The endpoint panel's examples were hardcoded to `application/json` in all seven dialects.
  They are now per-lane, and the panel preselects the lane the running pipeline actually
  reads — `json` when it reads json, `text` when it reads text but not json, `json` otherwise.
- The webhook endpoint note now publishes the pipeline's readable lanes, which is what drives
  that preselection.

The mismatch is symmetric — `text/plain` into a `json`-first pipeline failed the same way — so
no fixed default could have fixed it; the lane has to follow the wiring.

### Pipeline

<img width="1310" height="1202" alt="image" src="https://github.com/user-attachments/assets/23968148-6e2e-4535-918d-7e67edf83fef" />

### Before

<img width="792" height="755" alt="Screenshot 2026-09-09 195843" src="https://github.com/user-attachments/assets/f6411392-a1b5-46bb-bdc8-a8d87598bd6f" />

### After — pipeline reads `json`

<img width="1537" height="1183" alt="image" src="https://github.com/user-attachments/assets/805e6968-ed33-4bdd-ba02-f2987887236d" />

### After — pipeline reads `text` (`Text` automatically selected)

<img width="850" height="850" alt="image" src="https://github.com/user-attachments/assets/31ca8ab3-8f47-4512-bb99-c946b5422f43" />

### After — pipeline reads both `json` and `text` (`JSON` automatically selected)

<img width="836" height="827" alt="image" src="https://github.com/user-attachments/assets/f8128179-f6b9-4c01-8f46-fdff204e6410" />

### Warning on a lane mismatch

<img width="1242" height="346" alt="image" src="https://github.com/user-attachments/assets/ac4f5d9b-dce0-433f-bbc1-9c5041d93285" />
## Type

fix (plus a small UI feature: the per-lane example picker)

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./builder test` was not run in full. Measured on this branch's base (`c302cd2dc`):

| gate                   | result                    |
| ---------------------- | ------------------------- |
| `ai:run-pytest`        | 2908 passed, 122 skipped  |
| `shared:test`          | 103 pass, 0 fail          |
| `nodes/test/webhook`   | 14 passed                 |

`shared:test` was 84 before this change and `nodes/test/webhook` was 9; the deltas are the new
tests. On the pre-rebase base the full gate set (`ai:run-pytest`, `server:run-rocketlib-test`,
`shared:test`, `client-typescript:test`, `client-python:test`) was green before and after, with
only the two suites above changing count.

`nodes:test` could not run through the builder here — it rebuilds `engine.exe`, which a running
engine held locked — so the webhook suite was run directly against the deployed binary. Upstream
touched none of the files this PR changes, so the base move does not affect them.

`tsc`, `prettier` (TS) and `ruff 0.16.5` are clean; `ui:build`, `nodes:build` and
`client-typescript:build` succeed.

Every new test was mutation-checked — breaking the behaviour it names makes that test, and only
that test, fail. Reverting one of the seven dialects to a hardcoded `application/json` is
caught, which is the original defect.

End-to-end against a live engine:

- `webhook --text--> response_text` with `application/json` → warning raised, `status` stays `OK`
- the same pipeline with `text/plain` → no warning, data delivered
- the endpoint note reports `["text"]` and `["json"]` for the respective pipelines

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

No breaking change: the warning alters neither routing nor response status, and the panel's
default is unchanged for pipelines that read `json`.

## Linked Issue

Fixes #2229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook endpoint examples now support JSON, plain text, and raw payload formats.
  * Endpoint information displays a payload and data-lane selector with contextual guidance.
  * The default payload is selected based on the lanes consumed by the pipeline.
  * Integration examples now generate matching content types and request bodies across supported languages.
  * Pipelines report warnings when incoming data targets a lane that no component reads.

* **Documentation**
  * Added guidance on MIME type routing, data lanes, fallback behavior, warnings, and endpoint examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->