### PR TITLE
fix(client-typescript): remove the 10s budget on the root server-probe hook

### DIFF
--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -2291,7 +2291,8 @@ Integration tests may fail. Please ensure:
 3. Server accepts connections from test client
     `);
 	}
-}, 10000);
+	// No timeout: a failed root hook fails every spec in the file, and this one only warns.
+});
 
 type LifecycleSentRequest = {
 	socket: LifecycleBrowserWebSocket;


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- Drop the private 10s timeout on the root `beforeAll` in `RocketRideClient.test.ts`, so it inherits `testTimeout` from `jest.config.js` like every other hook. The hook only prints a hint when the server is unreachable — it asserts nothing, so a bound there guards nothing, while `jest-jasmine2` stamps a failed root hook onto every spec in the file.
- Record in a comment why the hook must not get a limit back.
- No change to worker counts, `testTimeout`, or the tests themselves.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Both runs via `./builder client-typescript:test`, no flags, jest default worker count, on a 32-core machine:

| configuration | result | jest time |
|---|---|---|
| before | 98 failed, 8 skipped, 163 passed | 408.46 s |
| after | 0 failed, 8 skipped, 261 passed | 370.46 s |

Same 269 specs, same 8 skipped, no `ms timeout` message left in the log. Full parallelism is now both green and faster than the `--maxWorkers=2` workaround.

Server-unavailable path checked separately with `ROCKETRIDE_URI` pointed at a closed port: one line, `⚠️ RocketRide server not available at http://localhost:59999`, server-free specs pass, exit 0 — instead of ~100 timeouts.

Only `client-typescript:test` was run, not the full `./builder test`.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #2234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated server availability checks to run without a fixed timeout, preventing unnecessary failures across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->