### PR TITLE
fix(shell,vscode,apps): per-context dev-preview tokens, https-only cloud sign-in, portable manifest specs

### DIFF
--- a/apps/explorer-ui/package.json
+++ b/apps/explorer-ui/package.json
@@ -40,7 +40,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"xlsx": "^0.18.5",
-		"rocketride": "workspace:*",
+		"rocketride": "file:../../.rocketride/client/rocketride.tgz",
 		"shell": "file:../../.rocketride/shell/shell.tgz"
 	},
 	"devDependencies": {

--- a/apps/hello-ui/package.json
+++ b/apps/hello-ui/package.json
@@ -37,8 +37,8 @@
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rocketride": "file:../../../.rocketride/client/rocketride.tgz",
-    "shell": "file:../../../.rocketride/shell/shell.tgz"
+    "rocketride": "file:../../.rocketride/client/rocketride.tgz",
+    "shell": "file:../../.rocketride/shell/shell.tgz"
   },
   "devDependencies": {
     "@rsbuild/core": "~2.0.11",

--- a/apps/monitor-ui/package.json
+++ b/apps/monitor-ui/package.json
@@ -34,7 +34,7 @@
 		"@module-federation/rsbuild-plugin": "^2.5.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rocketride": "workspace:*",
+		"rocketride": "file:../../.rocketride/client/rocketride.tgz",
 		"shell": "file:../../.rocketride/shell/shell.tgz"
 	},
 	"devDependencies": {

--- a/apps/rocket-ui/package.json
+++ b/apps/rocket-ui/package.json
@@ -437,7 +437,7 @@
 				}
 			]
 		},
-		"typecheck": false,
+		"typecheck": true,
 		"include": [
 			"apps/shared"
 		]
@@ -506,6 +506,7 @@
 		"@types/react": "~18.3.31",
 		"@types/react-dom": "~18.3.7",
 		"@types/react-syntax-highlighter": "^15.5.13",
-		"prop-types": "^15.8.1"
+		"prop-types": "^15.8.1",
+		"typescript": "^5.3.0"
 	}
 }

--- a/apps/shared/src/modules/sidebar/SidebarView.tsx
+++ b/apps/shared/src/modules/sidebar/SidebarView.tsx
@@ -142,7 +142,7 @@ const HOVER_BG = 'var(--rr-bg-list-hover, var(--rr-bg-surface-alt))';
 
 /** Default configuration for the pipeline Explorer panel. */
 const PIPELINE_CONFIG: ExplorerConfig = {
-	title: 'Pipelines',
+	title: 'My Pipelines',
 	extensions: ['.pipe', '.pipe.json'],
 	displayName: (name: string) => name.replace(/\.pipe(?:\.json)?$/, '') || name,
 	createPlaceholder: 'pipeline name',
@@ -191,9 +191,9 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 	// node-builder placeholder) rides along whenever the tabs render.
 	const modeMenu: ViewMenu = {
 		entries: [
-			{ id: 'pipelines', label: 'Pipelines' },
 			...(hasAppBuilder ? [{ id: 'apps', label: 'Apps' }] : []),
 			{ id: 'nodes', label: 'Nodes' },
+			{ id: 'pipelines', label: 'Pipelines' },
 		],
 	};
 

--- a/apps/vscode/docs/appdev.md
+++ b/apps/vscode/docs/appdev.md
@@ -28,6 +28,21 @@ open workspace folders. It is not merged with the server `list_mine` catalog.
 Discovery is driven by `.rrapp`/`package.json` file events and by
 workspace-folder changes; there is no rescan on connect.
 
+## Platform dependency wiring (manifests are author-owned)
+
+App manifests carry the portable platform specs —
+`"shell": "file:../../.rocketride/shell/shell.tgz"` and
+`"rocketride": "file:../../.rocketride/client/rocketride.tgz"` — correct
+wherever an app sits at `<workspace>/apps/<app>`. The extension never
+rewrites them: a spec is completed only when the dependency is missing
+outright. In layouts where the spec does not reach the workspace's vendored
+tarballs (for example an app lifted to its repo root), the extension
+instead adds workspace-root-relative `overrides:` entries to
+`pnpm-workspace.yaml` (`shell: 'file:.rocketride/shell/shell.tgz'`, plus
+the `rocketride` twin) — logged loudly, since the yaml is user-owned. A
+workspace that already overrides `shell`/`rocketride` (the platform
+monorepos pin `workspace:*`) is left untouched.
+
 ## Live preview overlay & dev servers
 
 A local dev build is previewed by registering a per-user `moduleId → entry URL`

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -99,7 +99,7 @@
 				"rocketride.development.cloudUrl": {
 					"type": "string",
 					"default": "https://api.rocketride.ai",
-					"description": "Cloud mode: the server this connection targets when 'Use Custom Server' is enabled (e.g. https://staging.rocketride.ai, http://localhost:5565)",
+					"description": "Cloud mode: the server this connection targets when 'Use Custom Server' is enabled (e.g. https://cloud.rocketride.ai, http://localhost:5565). Custom servers must use https; http is allowed only for localhost development targets.",
 					"format": "uri"
 				},
 				"rocketride.development.local.engineVersion": {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -137,7 +137,7 @@
 				"rocketride.deployment.cloudUrl": {
 					"type": "string",
 					"default": "https://api.rocketride.ai",
-					"description": "Cloud mode: the server this connection targets when 'Use Custom Server' is enabled (e.g. https://staging.rocketride.ai)",
+					"description": "Cloud mode: the server this connection targets when 'Use Custom Server' is enabled (e.g. https://staging.rocketride.ai, http://localhost:5565). Custom servers must use https; http is allowed only for localhost development targets.",
 					"format": "uri"
 				},
 				"rocketride.deployment.local.engineVersion": {

--- a/apps/vscode/src/appdev/appTypes.ts
+++ b/apps/vscode/src/appdev/appTypes.ts
@@ -8,17 +8,21 @@
  *
  * The connected server serves its platform as an installable npm package at
  * /client/shell. This module downloads it to the canonical
- * `<workspace>/.rocketride/shell/shell.tgz`, wires each app's package.json
- * dependency onto that tarball, and runs `pnpm install` at the workspace
- * root so every app links the new package. Types, tokens, and (for static
- * consumers) compiled code all flow through ordinary npm resolution — a
- * tarball dependency is a first-class package whose own dependencies pnpm
- * actually installs.
+ * `<workspace>/.rocketride/shell/shell.tgz` and runs `pnpm install` at the
+ * workspace root so every app links the new package. Types, tokens, and
+ * (for static consumers) compiled code all flow through ordinary npm
+ * resolution — a tarball dependency is a first-class package whose own
+ * dependencies pnpm actually installs.
  *
  * Called at scaffold (new apps) and on every App Builder open (refresh —
- * apps track the platform of the CONNECTED server). Nothing is ever written
- * inside an app folder: the tarball lives under `<workspace>/.rocketride/`,
- * and each app carries just the file: dependency pointing at it.
+ * apps track the platform of the CONNECTED server). App manifests are
+ * AUTHOR-OWNED: they carry the portable two-level specs
+ * (`file:../../.rocketride/...`, correct wherever an app sits at
+ * `<workspace>/apps/<app>`) and are completed only when a dependency is
+ * missing outright. Layouts where that spec does not reach the vendored
+ * tarballs are wired through the TOOL-OWNED pnpm-workspace.yaml instead —
+ * a workspace-root-relative override, so app depth never matters (see
+ * ensureDependencyWiring).
  */
 
 import * as fs from 'fs';
@@ -39,8 +43,9 @@ export type ShellVendorResult =
 		ok: true;
 		/** Absolute path of the vendored shell tarball. */
 		tgzPath: string;
-		/** True when THIS pass rewrote the app's dependency spec — callers
-		 * must invalidate any memoised install so the new spec links. */
+		/** True when THIS pass changed dependency wiring — completed a
+		 * manifest or added a workspace override — callers must invalidate
+		 * any memoised install so the new resolution links. */
 		rewired?: boolean;
 	}
 	| { ok: false; reason: string };
@@ -135,15 +140,16 @@ export function refreshVendoredPlatform(context: vscode.ExtensionContext): Promi
 /**
  * Ensures the platform package is installed for an app.
  *
- * Wires the app's package.json dependency onto the workspace's canonical
- * .rocketride/shell/shell.tgz, then ensures the workspace's shared vendor
- * pass has run (see ensureShell — one download + install per session,
- * shared by all consumers).
+ * Ensures the app's platform dependencies RESOLVE — via the manifest's own
+ * portable spec or a workspace-yaml override, never by rewriting app files
+ * (see ensureDependencyWiring) — then ensures the workspace's shared
+ * vendor pass has run (see ensureShell — one download + install per
+ * session, shared by all consumers).
  *
- * The dependency is written FIRST and unconditionally: the file: spec is
- * the well-known workspace location, valid before the package has ever
- * been downloaded, so an offline scaffold still produces the correct
- * package.json and simply links on the next connected open.
+ * Wiring runs FIRST, before any download: specs and overrides name the
+ * well-known workspace location, valid before the package has ever been
+ * downloaded, so an offline scaffold still wires correctly and simply
+ * links on the next connected open.
  *
  * Non-fatal by design: an unreachable server, a missing package, or an
  * unwritable folder logs and returns a reasoned failure — platform
@@ -158,9 +164,10 @@ export async function vendorAppTypes(context: vscode.ExtensionContext, appFolder
 	const logger = getLogger();
 	const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 	if (!workspaceRoot) return { ok: false, reason: 'No workspace folder is open — the platform package lives under the workspace root.' };
-	// Wiring failures FAIL the pass: an app whose workspace file or shell
-	// dependency could not be written will not link the platform package, so
-	// pretending success would only defer the error to a confusing place.
+	// Wiring failures FAIL the pass: an app whose workspace file or
+	// dependency wiring could not be written will not link the platform
+	// package, so pretending success would only defer the error to a
+	// confusing place.
 	try {
 		ensureWorkspaceFile(workspaceRoot);
 	} catch (err) {
@@ -170,8 +177,7 @@ export async function vendorAppTypes(context: vscode.ExtensionContext, appFolder
 	}
 	let rewired = false;
 	try {
-		rewired = ensureShellDependency(appFolder, path.join(workspaceRoot, '.rocketride', 'shell', 'shell.tgz'));
-		rewired = ensureClientDependency(appFolder, path.join(workspaceRoot, '.rocketride', 'client', 'rocketride.tgz')) || rewired;
+		rewired = ensureDependencyWiring(appFolder, workspaceRoot);
 	} catch (err) {
 		const reason = `Could not wire the platform dependencies into ${appFolder}: ${err instanceof Error ? err.message : String(err)}`;
 		logger.output(`[appdev] ${reason}`);
@@ -264,66 +270,178 @@ function ensureWorkspaceFile(workspaceRoot: string): void {
 }
 
 // =============================================================================
-// SHELL PACKAGE (shell.tgz)
+// DEPENDENCY WIRING
 // =============================================================================
 
 /**
- * Ensures the app's package.json depends on the workspace shell tarball.
- *
- * The dependency targets `file:<rel>/.rocketride/shell/shell.tgz` — a
- * tarball is a first-class package to pnpm: it extracts into the store and
- * installs the shell's own declared dependencies with real linkage.
- * Existing correct specs are left untouched so repeated App Builder opens
- * never rewrite the file.
- *
- * The target file need not exist yet — the spec is the platform's
- * well-known workspace location, and pnpm links it once it appears.
- *
- * @param appFolder - The app's root folder (owns the package.json).
- * @param pkgTgz - Absolute path of the shell package tarball.
- * @returns True when a new spec was written; false when already correct (or
- *          the app has no package.json).
- */
-function ensureShellDependency(appFolder: string, pkgTgz: string): boolean {
-	return ensureTgzDependency(appFolder, 'shell', pkgTgz);
-}
-
-/**
- * Ensures the app's package.json depends on the workspace's vendored
- * CLIENT tarball (`file:<rel>/.rocketride/client/rocketride.tgz`). The
+ * The platform packages every app links, with their canonical vendored
+ * locations under the workspace root. The manifest form is the PORTABLE
+ * two-level spec — apps live at `<workspace>/apps/<app>`, so it is correct
+ * in a user workspace, the build sandbox, and a lifted-out repo alike; the
  * npm registry's `rocketride` can lag the connected server badly (no app
- * surface at all), so apps pin the server-matched package the same way
+ * surface at all), so apps pin the server-matched tarball the same way
  * they pin the shell.
- *
- * @param appFolder - The app's root folder (owns the package.json).
- * @param pkgTgz - Absolute path of the client package tarball.
- * @returns True when a new spec was written; false when already correct.
  */
-function ensureClientDependency(appFolder: string, pkgTgz: string): boolean {
-	return ensureTgzDependency(appFolder, 'rocketride', pkgTgz);
-}
+const PLATFORM_DEPS = [
+	{ name: 'shell', vendored: ['.rocketride', 'shell', 'shell.tgz'] },
+	{ name: 'rocketride', vendored: ['.rocketride', 'client', 'rocketride.tgz'] },
+] as const;
 
 /**
- * Shared rewiring for tarball-pinned dependencies: writes
- * `dependencies[depName] = file:<app-relative posix path>` only when
- * missing or different, so repeated App Builder opens never rewrite the
- * file. The target need not exist yet — the spec is the platform's
- * well-known workspace location, and pnpm links it once it appears.
+ * Ensures an app's platform dependencies resolve — WITHOUT rewriting the
+ * app's files. Manifests are author-owned after scaffold; the workspace
+ * yaml is the tool-owned wiring surface. Per dependency:
+ *
+ *   1. Missing from the manifest entirely — write the canonical portable
+ *      spec (`file:../../.rocketride/...`). An override cannot help here:
+ *      pnpm installs nothing it was never asked for. The scaffold template
+ *      already renders the spec, so in practice only hand-authored
+ *      manifests take this branch (the ONLY app-file write this module
+ *      ever makes).
+ *   2. Covered by a workspace-yaml override (any value — the platform
+ *      monorepos pin `workspace:*`) — nothing to do; the override
+ *      supersedes the spec at resolution.
+ *   3. Present but resolving somewhere other than the workspace's vendored
+ *      tarball (an app lifted to its repo ROOT still carrying `../../`, a
+ *      spec from a different layout) — add a workspace-root-relative
+ *      override (`file:.rocketride/...`). Override file: specs resolve
+ *      from the workspace root, so app depth is irrelevant and no layout
+ *      ever needs the manifest corrected.
+ *
+ * The tarballs need not exist yet — wiring compares PATHS against the
+ * platform's well-known location, and pnpm links once they are vendored.
+ *
+ * @param appFolder - The app's root folder (owns the package.json).
+ * @param workspaceRoot - The workspace folder owning .rocketride/ and the yaml.
+ * @returns True when wiring changed (manifest completed or override
+ *          written) — callers must invalidate any memoised install.
  */
-function ensureTgzDependency(appFolder: string, depName: string, pkgTgz: string): boolean {
+function ensureDependencyWiring(appFolder: string, workspaceRoot: string): boolean {
 	const logger = getLogger();
 	const pkgJsonPath = path.join(appFolder, 'package.json');
 	if (!fs.existsSync(pkgJsonPath)) return false;
-	// step: compute the app-relative file: spec with posix separators
-	const rel = path.relative(appFolder, pkgTgz).split(path.sep).join('/');
-	const spec = `file:${rel}`;
-	// step: rewrite only when missing or different
 	const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-	if (pkg.dependencies?.[depName] === spec) return false;
-	pkg.dependencies = { ...(pkg.dependencies ?? {}), [depName]: spec };
-	fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
-	logger.output(`[appdev] package.json: "${depName}": "${spec}"`);
+
+	// step: complete a manifest that never declared the platform deps
+	let manifestChanged = false;
+	for (const dep of PLATFORM_DEPS) {
+		if (pkg.dependencies?.[dep.name] !== undefined) continue;
+		const spec = `file:../../${dep.vendored.join('/')}`;
+		pkg.dependencies = { ...(pkg.dependencies ?? {}), [dep.name]: spec };
+		manifestChanged = true;
+		logger.output(`[appdev] package.json: added missing "${dep.name}": "${spec}"`);
+	}
+	if (manifestChanged) fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+	// step: deps not superseded by an existing override must resolve to the
+	// vendored tarball; those that do not get the override added instead of
+	// a manifest rewrite
+	const overridden = readWorkspaceOverrideNames(workspaceRoot);
+	const needed = PLATFORM_DEPS.filter((dep) =>
+		!overridden.has(dep.name)
+		&& !specResolvesToVendored(String(pkg.dependencies[dep.name]), appFolder, workspaceRoot, dep.vendored));
+	if (needed.length === 0) return manifestChanged;
+	ensureWorkspaceOverrides(workspaceRoot, needed);
 	return true;
+}
+
+/**
+ * True when a manifest spec already resolves to the workspace's vendored
+ * tarball, so plain pnpm resolution needs no help. Only file: specs can —
+ * anything else (`workspace:*`, a semver range) resolves elsewhere by
+ * construction. Comparison is by path, case-insensitive on Windows; the
+ * tarball itself need not exist yet.
+ *
+ * @param spec - The manifest's dependency spec.
+ * @param appFolder - Folder the spec resolves relative to.
+ * @param workspaceRoot - The workspace folder owning .rocketride/.
+ * @param vendored - Canonical tarball path segments under the root.
+ * @returns True when the spec names the canonical vendored tarball.
+ */
+function specResolvesToVendored(spec: string, appFolder: string, workspaceRoot: string, vendored: readonly string[]): boolean {
+	if (!spec.startsWith('file:')) return false;
+	const norm = (p: string): string => (process.platform === 'win32' ? path.resolve(p).toLowerCase() : path.resolve(p));
+	return norm(path.resolve(appFolder, spec.slice('file:'.length))) === norm(path.join(workspaceRoot, ...vendored));
+}
+
+/**
+ * The dependency names already overridden in the workspace yaml.
+ *
+ * Line-level scan (the extension deliberately carries no YAML dependency):
+ * entries are read from the top-level `overrides:` block — the indented
+ * `name: value` lines under it — plus a best-effort pass over the inline
+ * `overrides: {...}` form, so an already-covered dependency never triggers
+ * a write that ensureWorkspaceOverrides would then refuse.
+ *
+ * @param workspaceRoot - The workspace folder owning pnpm-workspace.yaml.
+ * @returns The overridden dependency names (empty when no yaml exists).
+ */
+function readWorkspaceOverrideNames(workspaceRoot: string): Set<string> {
+	const names = new Set<string>();
+	const yamlPath = path.join(workspaceRoot, 'pnpm-workspace.yaml');
+	if (!fs.existsSync(yamlPath)) return names;
+	// step: normalize line endings for reading (the yamls are CRLF on
+	// Windows checkouts; this copy is never written back)
+	const text = fs.readFileSync(yamlPath, 'utf8').replace(/\r\n/g, '\n');
+	// step: block form — indented entries until the next top-level key
+	const block = /^overrides:[ \t]*(?:#[^\n]*)?\n((?:[ \t]+[^\n]*\n?)*)/m.exec(text);
+	if (block) {
+		for (const line of block[1].split('\n')) {
+			const entry = /^[ \t]+['"]?([@\w./-]+)['"]?[ \t]*:/.exec(line);
+			if (entry) names.add(entry[1]);
+		}
+	}
+	// step: inline form — names only, values are irrelevant to coverage
+	const inline = /^overrides:[ \t]*\{([^}]*)\}/m.exec(text);
+	if (inline) {
+		for (const part of inline[1].split(',')) {
+			const entry = /^\s*['"]?([@\w./-]+)['"]?\s*:/.exec(part);
+			if (entry) names.add(entry[1]);
+		}
+	}
+	return names;
+}
+
+/**
+ * Adds workspace-root-relative overrides for the given platform deps to
+ * pnpm-workspace.yaml — the tool-owned wiring surface (app files are never
+ * edited; see ensureDependencyWiring).
+ *
+ * Same conservative line-level editing as ensureWorkspaceFile: entries are
+ * inserted under an existing `overrides:` block matching its indentation; a
+ * missing block is appended whole; an inline `overrides: {...}` value
+ * cannot take inserted entries — refused loudly rather than corrupting the
+ * user-owned file. Every write is logged (the file is user-owned).
+ *
+ * @param workspaceRoot - The workspace folder owning pnpm-workspace.yaml.
+ * @param deps - The platform deps needing an override.
+ */
+function ensureWorkspaceOverrides(workspaceRoot: string, deps: ReadonlyArray<(typeof PLATFORM_DEPS)[number]>): void {
+	const logger = getLogger();
+	const yamlPath = path.join(workspaceRoot, 'pnpm-workspace.yaml');
+	// ensureWorkspaceFile runs earlier in every vendor pass, so the yaml
+	// exists; tolerate its absence anyway (deleted mid-session)
+	let text = fs.existsSync(yamlPath) ? fs.readFileSync(yamlPath, 'utf8') : '';
+	// step: honor the file's own line endings — the yaml is user-owned, and
+	// a mixed-endings write would churn its whole diff
+	const eol = text.includes('\r\n') ? '\r\n' : '\n';
+	const entries = deps.map((dep) => `${dep.name}: 'file:${dep.vendored.join('/')}'`);
+	// step: an inline overrides value cannot be amended line-wise — refuse
+	// (\r counts as \s, so a CRLF bare block head never false-positives)
+	if (/^overrides:[ \t]*[^\s#]/m.test(text)) {
+		throw new Error(`${yamlPath} declares overrides as an inline value — add ${entries.join(', ')} manually`);
+	}
+	if (/^overrides:[ \t]*(?:#[^\n]*)?\r?$/m.test(text)) {
+		// step: insert under the existing block, matching its entry indentation
+		const indent = /^overrides:[^\n]*\n([ \t]+)/m.exec(text)?.[1] ?? '  ';
+		const insert = entries.map((e) => `${indent}${e}${eol}`).join('');
+		text = text.replace(/^overrides:[^\n]*\n?/m, (m) => `${m.endsWith('\n') ? m : `${m}${eol}`}${insert}`);
+	} else {
+		// step: no block — append one
+		text += `${text === '' || text.endsWith('\n') ? '' : eol}overrides:${eol}${entries.map((e) => `  ${e}${eol}`).join('')}`;
+	}
+	fs.writeFileSync(yamlPath, text);
+	logger.output(`[appdev] ${yamlPath}: added overrides ${entries.join(', ')} (user-owned file; app manifests keep their portable file: specs untouched)`);
 }
 
 /**

--- a/apps/vscode/src/appdev/appTypes.ts
+++ b/apps/vscode/src/appdev/appTypes.ts
@@ -322,10 +322,23 @@ function ensureDependencyWiring(appFolder: string, workspaceRoot: string): boole
 	if (!fs.existsSync(pkgJsonPath)) return false;
 	const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
 
-	// step: complete a manifest that never declared the platform deps
+	// An author may declare a platform dep in any section (a type-only
+	// consumer reasonably uses devDependencies) — completion and the
+	// resolution check both honor the author's chosen section, so a dep
+	// declared anywhere is never duplicated into dependencies.
+	const DEP_SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+	const declaredSpec = (name: string): string | undefined => {
+		for (const section of DEP_SECTIONS) {
+			const spec = (pkg[section] as Record<string, string> | undefined)?.[name];
+			if (spec !== undefined) return spec;
+		}
+		return undefined;
+	};
+
+	// step: complete a manifest that declares the dep in NO section
 	let manifestChanged = false;
 	for (const dep of PLATFORM_DEPS) {
-		if (pkg.dependencies?.[dep.name] !== undefined) continue;
+		if (declaredSpec(dep.name) !== undefined) continue;
 		const spec = `file:../../${dep.vendored.join('/')}`;
 		pkg.dependencies = { ...(pkg.dependencies ?? {}), [dep.name]: spec };
 		manifestChanged = true;
@@ -339,7 +352,7 @@ function ensureDependencyWiring(appFolder: string, workspaceRoot: string): boole
 	const overridden = readWorkspaceOverrideNames(workspaceRoot);
 	const needed = PLATFORM_DEPS.filter((dep) =>
 		!overridden.has(dep.name)
-		&& !specResolvesToVendored(String(pkg.dependencies[dep.name]), appFolder, workspaceRoot, dep.vendored));
+		&& !specResolvesToVendored(String(declaredSpec(dep.name)), appFolder, workspaceRoot, dep.vendored));
 	if (needed.length === 0) return manifestChanged;
 	ensureWorkspaceOverrides(workspaceRoot, needed);
 	return true;

--- a/apps/vscode/src/appdev/scaffolder.ts
+++ b/apps/vscode/src/appdev/scaffolder.ts
@@ -306,11 +306,11 @@ export async function scaffoldApp(params: ScaffoldParams): Promise<string> {
 	// Explorer hides the gitignored machine-generated trees.
 	ensureWorkspaceSettings(root.uri.fsPath);
 
-	// Install the platform package — ensures the root workspace file, wires
-	// "shell": "file:../../.rocketride/shell/shell.tgz" into the app's
-	// package.json (always, even offline), and downloads the canonical
-	// tarball. Fire-and-forget and non-fatal by design, so scaffolding
-	// never waits on it.
+	// Install the platform package — ensures the root workspace file,
+	// verifies the template's portable file: specs resolve (adding a
+	// workspace-yaml override when the layout needs one; the manifest is
+	// never rewritten), and downloads the canonical tarball. Fire-and-forget
+	// and non-fatal by design, so scaffolding never waits on it.
 	void vendorAppTypes(getExtensionContext(), target.fsPath);
 
 	// ── 4. Open the App Builder + link the new member ────────────────────

--- a/apps/vscode/src/appdev/watchManager.ts
+++ b/apps/vscode/src/appdev/watchManager.ts
@@ -347,10 +347,10 @@ export class WatchManager {
 		// package.json watcher: a dependency edit invalidates the shared
 		// install and restarts THIS session (other apps' dev servers survive
 		// a root install — pnpm only rewrites the changed project's links).
-		// The install/restart loop DOES write package.json (the App Builder
-		// open path rewires the shell spec via ensureShellDependency), but it
-		// terminates: the rewrite early-returns once the spec is correct, so
-		// the watcher fires at most one extra cycle. Disposed in stop() so
+		// The install/restart loop can write package.json once (the App
+		// Builder open path completes MISSING platform deps via
+		// ensureDependencyWiring), but it terminates: wiring never rewrites
+		// a present spec, so the watcher fires at most one extra cycle. Disposed in stop() so
 		// watcher lifetime tracks the session. Known edge: an edit landing
 		// while the install is mid-flight is swallowed by the starting guard —
 		// accepted (the debounce makes it rare, and the preview Reload button

--- a/apps/vscode/src/appdev/watchManager.ts
+++ b/apps/vscode/src/appdev/watchManager.ts
@@ -848,8 +848,14 @@ export class WatchManager {
 			}
 		}
 
-		// Build results: rsbuild prints "built in 1.24 s" / "build failed"
-		if (/built in\s+[\d.]+/i.test(text)) {
+		// Build results: rsbuild prints "built in 1.24 s" / "build failed".
+		// Lines tagged "[browser]" are dev.browserLogs relays of the PAGE's
+		// runtime errors, dressed in rsbuild's own "error   ..." format — app
+		// traffic, not compiler state. Classify from untagged lines only: an
+		// app-side error must never flip the panel to "build failed" (nothing
+		// failed to compile, so the Console would carry no explanation).
+		const compilerText = lines.filter((line) => !/^\s*\w+\s+\[browser\]/.test(line)).join('\n');
+		if (/built in\s+[\d.]+/i.test(compilerText)) {
 			const durationMs = session.buildStart ? Date.now() - session.buildStart : undefined;
 			session.buildStart = undefined;
 			this.notify(session.app.id, { state: 'ok', durationMs, target: session.devOrigin?.replace(/^https?:\/\//, '') });
@@ -859,11 +865,11 @@ export class WatchManager {
 			this.notifyDevEntry(session);
 			void this.registerOverlay(session);
 			this.scheduleReload(session);
-		} else if (/build failed|error {3}/i.test(text)) {
+		} else if (/build failed|error {3}/i.test(compilerText)) {
 			session.buildStart = undefined;
 			this.appScreen.notifyError(session.app.id, 'rsbuild build failed — see the Console pane for compiler output', 'rsbuild');
 			this.notify(session.app.id, { state: 'error', target: session.devOrigin?.replace(/^https?:\/\//, ''), reason: 'The app failed to compile — the Console pane carries the compiler output.' });
-		} else if (/building|compiling/i.test(text) && session.buildStart === undefined) {
+		} else if (/building|compiling/i.test(compilerText) && session.buildStart === undefined) {
 			session.buildStart = Date.now();
 			this.notify(session.app.id, { state: 'building', target: session.devOrigin?.replace(/^https?:\/\//, '') });
 		}

--- a/apps/vscode/src/auth/CloudAuthProvider.ts
+++ b/apps/vscode/src/auth/CloudAuthProvider.ts
@@ -29,6 +29,7 @@
 import * as vscode from 'vscode';
 import { RocketRideClient } from 'rocketride';
 import { generatePkce, buildAuthUrl } from './pkce';
+import { isSecureCloudTarget } from '../config';
 
 import { EventEmitter } from 'events';
 
@@ -161,6 +162,15 @@ export class CloudAuthProvider implements vscode.UriHandler, vscode.Disposable {
 		}
 		if (!cloudUrl) {
 			vscode.window.showErrorMessage('RocketRide Cloud sign-in failed: no cloud server is configured.');
+			return;
+		}
+		// Every caller funnels through here, so this is the one transport gate:
+		// sign-in ends with the API key inside the connection's auth request,
+		// and a cleartext scheme would put that credential on the wire (CWE-319).
+		if (!isSecureCloudTarget(cloudUrl)) {
+			vscode.window.showErrorMessage(
+				'RocketRide Cloud sign-in refused: custom cloud servers must use https (http is allowed only for localhost development targets).'
+			);
 			return;
 		}
 

--- a/apps/vscode/src/config.ts
+++ b/apps/vscode/src/config.ts
@@ -123,6 +123,31 @@ export interface SettingsSnapshot {
 }
 
 /**
+ * Whether a cloud server URL uses transport the extension may send
+ * credentials over.
+ *
+ * Sign-in ends with the API key traveling in the connection's auth request,
+ * so a cleartext scheme exposes it to the network path (CWE-319). https/wss
+ * are always acceptable; http/ws only when the host is loopback — the
+ * documented local-development case (http://localhost:5565).
+ *
+ * @param url - The cloud server URL as configured or supplied by a caller.
+ * @returns True when credentials may be sent to this target.
+ */
+export function isSecureCloudTarget(url: string): boolean {
+	try {
+		const parsed = new URL(RocketRideClient.normalizeUri(url));
+		if (parsed.protocol === 'https:' || parsed.protocol === 'wss:') {
+			return true;
+		}
+		const host = parsed.hostname;
+		return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]' || host.endsWith('.localhost');
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Configuration manager class providing centralized access to RocketRide settings
  */
 export class ConfigManager {
@@ -394,6 +419,9 @@ export class ConfigManager {
 			} else {
 				try {
 					new URL(RocketRideClient.normalizeUri(gc.hostUrl));
+					if (!isSecureCloudTarget(gc.hostUrl)) {
+						errors.push(`${label}: Cloud URL must use https — http is allowed only for localhost development targets`);
+					}
 				} catch {
 					errors.push(`${label}: Cloud URL must be a valid URL (e.g., https://api.rocketride.ai)`);
 				}

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -96,7 +96,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 	 * a slower earlier run must not overwrite fresher state.
 	 */
 	private rescanSeq = 0;
-	private sidebarMode: 'pipelines' | 'apps' | 'nodes' = 'pipelines';
+	private sidebarMode: 'pipelines' | 'apps' | 'nodes' = 'apps';
 
 	private logger = getLogger();
 

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -287,6 +287,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 		for (const app of this.scannedApps) {
 			rows.push({ id: app.id, name: app.name, folder: app.folder, iconUrl: await appIconDataUri(app.icon) });
 		}
+		// Scan order is marker-path order (a binding-priority detail); the
+		// list the user sees sorts by display name.
+		rows.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 		return rows;
 	}
 

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -127,7 +127,7 @@ const SidebarViewWebview: React.FC = () => {
 
 	// ── App Builder (MY APPS) ───────────────────────────────────────────────
 	const [apps, setApps] = useState<AppListItem[]>([]);
-	const [sidebarMode, setSidebarMode] = useState<SidebarMode>('pipelines');
+	const [sidebarMode, setSidebarMode] = useState<SidebarMode>('apps');
 	// The host-persisted mode seeds the strip ONCE: an `update` composed
 	// before the persist round trip completed carries the previous value and
 	// must not revert a selection the user just made.

--- a/apps/world-ui/package.json
+++ b/apps/world-ui/package.json
@@ -33,8 +33,8 @@
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rocketride": "file:../../../.rocketride/client/rocketride.tgz",
-    "shell": "file:../../../.rocketride/shell/shell.tgz"
+    "rocketride": "file:../../.rocketride/client/rocketride.tgz",
+    "shell": "file:../../.rocketride/shell/shell.tgz"
   },
   "devDependencies": {
     "@rsbuild/core": "~2.0.11",

--- a/packages/shell/src/auth/ApiKeyAuthProvider.ts
+++ b/packages/shell/src/auth/ApiKeyAuthProvider.ts
@@ -34,6 +34,7 @@
 
 import type { IAuthProvider } from '../types/connection';
 import { LS_TOKEN } from '../constants';
+import { tokenStore } from '../util/devGate';
 
 // =============================================================================
 // CLASS
@@ -84,7 +85,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	private async storeToken(token: string): Promise<void> {
 		try {
-			localStorage.setItem(LS_TOKEN, token);
+			tokenStore().setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to store token:', e);
 		}
@@ -97,7 +98,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = localStorage.getItem(LS_TOKEN);
+			const token = tokenStore().getItem(LS_TOKEN);
 			// For API key mode, empty string is valid (open access)
 			return token;
 		} catch {
@@ -111,7 +112,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async isSignedIn(): Promise<boolean> {
 		try {
-			return localStorage.getItem(LS_TOKEN) !== null;
+			return tokenStore().getItem(LS_TOKEN) !== null;
 		} catch {
 			return false;
 		}
@@ -126,14 +127,9 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			localStorage.removeItem(LS_TOKEN);
+			tokenStore().removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to clear token:', e);
-		}
-		try {
-			sessionStorage.removeItem(LS_TOKEN);
-		} catch (e) {
-			console.error('[ApiKeyAuthProvider] Failed to clear legacy session token:', e);
 		}
 	}
 }

--- a/packages/shell/src/auth/CloudAuthProvider.ts
+++ b/packages/shell/src/auth/CloudAuthProvider.ts
@@ -40,6 +40,7 @@
 import type { IAuthProvider } from '../types/connection';
 import { generatePkce, buildAuthUrl, getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import { LS_TOKEN, SS_PENDING_APP_ID } from '../constants';
+import { tokenStore } from '../util/devGate';
 
 // =============================================================================
 // CLASS
@@ -188,7 +189,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async storeToken(token: string): Promise<void> {
 		try {
-			localStorage.setItem(LS_TOKEN, token);
+			tokenStore().setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to store token:', e);
 		}
@@ -201,7 +202,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = localStorage.getItem(LS_TOKEN);
+			const token = tokenStore().getItem(LS_TOKEN);
 			return token || null;
 		} catch {
 			return null;
@@ -225,14 +226,9 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			localStorage.removeItem(LS_TOKEN);
+			tokenStore().removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to clear token:', e);
-		}
-		try {
-			sessionStorage.removeItem(LS_TOKEN);
-		} catch (e) {
-			console.error('[CloudAuthProvider] Failed to clear legacy session token:', e);
 		}
 	}
 }

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -400,17 +400,22 @@ test('auth providers sign out by removing the stored token from localStorage onl
 	}
 });
 
-test('token methods use per-context sessionStorage in embedded dev shells', () => {
+test('token methods use frame-local memory in embedded dev shells', () => {
 	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
 	const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
 	const localTouches: string[] = [];
-	const sessionData = new Map<string, string>();
+	const sessionTouches: string[] = [];
+	const fetchCalls: string[] = [];
 
 	// A framed window (self !== top) carrying rrdev=1 marks this shell as an
-	// embedded dev preview — its token must live per-context. The gate cache
-	// is reset so it recomputes from this staged environment (the test runner
-	// builds with NODE_ENV=production, so the URL flag is the live path).
+	// embedded dev preview — its token must live in frame-local memory
+	// (sessionStorage is shared between same-origin sibling iframes in one
+	// top-level browsing context, so it cannot isolate panels either). The
+	// gate cache is reset so it recomputes from this staged environment (the
+	// test runner builds with NODE_ENV=production, so the URL flag is the
+	// live path).
 	Object.defineProperty(globalThis, 'window', {
 		configurable: true,
 		value: { self: {}, top: {}, location: { search: '?rrdev=1' } },
@@ -427,10 +432,14 @@ test('token methods use per-context sessionStorage in embedded dev shells', () =
 	Object.defineProperty(globalThis, 'sessionStorage', {
 		configurable: true,
 		value: {
-			setItem: (key: string, value: string) => sessionData.set(key, value),
-			getItem: (key: string) => sessionData.get(key) ?? null,
-			removeItem: (key: string) => sessionData.delete(key),
+			setItem: (key: string) => sessionTouches.push(`set:${key}`),
+			getItem: (key: string) => { sessionTouches.push(`get:${key}`); return null; },
+			removeItem: (key: string) => sessionTouches.push(`remove:${key}`),
 		},
+	});
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: (url: string) => { fetchCalls.push(url); return Promise.resolve({}); },
 	});
 
 	try {
@@ -442,9 +451,15 @@ test('token methods use per-context sessionStorage in embedded dev shells', () =
 		assert.equal(manager.loadToken(), 'rr_panel-token');
 		manager.clearToken();
 		assert.equal(manager.loadToken(), '');
-		// The shared origin slot was never touched: a preview can neither leak
-		// its token into it nor clear another context's session through it.
+		// Neither shared slot was touched: a preview can neither leak its
+		// token into an origin-wide store nor clear another context's
+		// session through one.
 		assert.deepEqual(localTouches, []);
+		assert.deepEqual(sessionTouches, []);
+		// And the HOST-WIDE /apps cookie was never primed: the cookie jar is
+		// shared by every same-origin frame, so a panel's injected session
+		// must not replace the embedding user's bundle credentials.
+		assert.deepEqual(fetchCalls, []);
 	} finally {
 		resetDevGateForTests();
 		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
@@ -453,6 +468,43 @@ test('token methods use per-context sessionStorage in embedded dev shells', () =
 		else delete (globalThis as { localStorage?: Storage }).localStorage;
 		if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
 		else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
+	}
+});
+
+test('saveToken primes the /apps cookie for real tabs', () => {
+	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+	const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+	const stored = new Map<string, string>();
+	const fetchCalls: string[] = [];
+
+	// No window global at all — not framed, so this is the real-tab path:
+	// the token lands in localStorage and the /apps cookie prime fires.
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: {
+			setItem: (key: string, value: string) => stored.set(key, value),
+			getItem: (key: string) => stored.get(key) ?? null,
+			removeItem: (key: string) => stored.delete(key),
+		},
+	});
+	Object.defineProperty(globalThis, 'fetch', {
+		configurable: true,
+		value: (url: string) => { fetchCalls.push(url); return Promise.resolve({}); },
+	});
+
+	try {
+		const { manager } = createTestManager();
+		manager.saveToken = ConnectionManager.prototype.saveToken;
+		manager.saveToken('rr_tab-token');
+		assert.equal(stored.get(LS_TOKEN), 'rr_tab-token');
+		assert.deepEqual(fetchCalls, ['/apps/session']);
+	} finally {
+		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+		else delete (globalThis as { localStorage?: Storage }).localStorage;
+		if (originalFetch) Object.defineProperty(globalThis, 'fetch', originalFetch);
+		else delete (globalThis as { fetch?: typeof fetch }).fetch;
 	}
 });
 

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -36,6 +36,7 @@ import { RemoteManager } from './remote-manager';
 import { ApiKeyAuthProvider } from '../auth/ApiKeyAuthProvider';
 import { CloudAuthProvider } from '../auth/CloudAuthProvider';
 import { CONNECT_TIMEOUT_MS, LS_TOKEN } from '../constants';
+import { resetDevGateForTests } from '../util/devGate';
 
 type EmittedEvent = { event: string; payload: unknown };
 
@@ -341,7 +342,7 @@ test('handleStoredTokenFailure keeps the network latch when the probe answers 20
 	}
 });
 
-test('clearToken removes current and legacy stored tokens', () => {
+test('clearToken removes the stored token from localStorage only', () => {
 	const removedLocalKeys: string[] = [];
 	const removedSessionKeys: string[] = [];
 	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
@@ -358,7 +359,8 @@ test('clearToken removes current and legacy stored tokens', () => {
 	try {
 		createTestManager().manager.clearToken();
 		assert.deepEqual(removedLocalKeys, ['rr:user_token']);
-		assert.deepEqual(removedSessionKeys, ['rr:user_token']);
+		// The legacy sessionStorage slot is gone — clearing must not touch it.
+		assert.deepEqual(removedSessionKeys, []);
 	} finally {
 		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
 		else delete (globalThis as { localStorage?: Storage }).localStorage;
@@ -367,7 +369,7 @@ test('clearToken removes current and legacy stored tokens', () => {
 	}
 });
 
-test('auth providers sign out by removing current and legacy stored tokens', async () => {
+test('auth providers sign out by removing the stored token from localStorage only', async () => {
 	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
 	const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
 
@@ -387,13 +389,117 @@ test('auth providers sign out by removing current and legacy stored tokens', asy
 			await provider.signOut();
 
 			assert.deepEqual(removedLocalKeys, [LS_TOKEN]);
-			assert.deepEqual(removedSessionKeys, [LS_TOKEN]);
+			// The legacy sessionStorage slot is gone — sign-out must not touch it.
+			assert.deepEqual(removedSessionKeys, []);
 		}
 	} finally {
 		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
 		else delete (globalThis as { localStorage?: Storage }).localStorage;
 		if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
 		else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+	}
+});
+
+test('token methods use per-context sessionStorage in embedded dev shells', () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+	const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+	const localTouches: string[] = [];
+	const sessionData = new Map<string, string>();
+
+	// A framed window (self !== top) carrying rrdev=1 marks this shell as an
+	// embedded dev preview — its token must live per-context. The gate cache
+	// is reset so it recomputes from this staged environment (the test runner
+	// builds with NODE_ENV=production, so the URL flag is the live path).
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: { self: {}, top: {}, location: { search: '?rrdev=1' } },
+	});
+	resetDevGateForTests();
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: {
+			setItem: (key: string) => localTouches.push(`set:${key}`),
+			getItem: (key: string) => { localTouches.push(`get:${key}`); return null; },
+			removeItem: (key: string) => localTouches.push(`remove:${key}`),
+		},
+	});
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		configurable: true,
+		value: {
+			setItem: (key: string, value: string) => sessionData.set(key, value),
+			getItem: (key: string) => sessionData.get(key) ?? null,
+			removeItem: (key: string) => sessionData.delete(key),
+		},
+	});
+
+	try {
+		const { manager } = createTestManager();
+		// The helper stubs saveToken to a recorder; this test exercises the
+		// real storage path, so restore the prototype method.
+		manager.saveToken = ConnectionManager.prototype.saveToken;
+		manager.saveToken('rr_panel-token');
+		assert.equal(manager.loadToken(), 'rr_panel-token');
+		manager.clearToken();
+		assert.equal(manager.loadToken(), '');
+		// The shared origin slot was never touched: a preview can neither leak
+		// its token into it nor clear another context's session through it.
+		assert.deepEqual(localTouches, []);
+	} finally {
+		resetDevGateForTests();
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+		else delete (globalThis as { localStorage?: Storage }).localStorage;
+		if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
+		else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+	}
+});
+
+test('initialize ignores cross-context token churn in embedded dev shells', () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+	const listeners = new Map<string, (event: StorageEvent) => void>();
+	const localStorage = {} as Storage;
+	let tokenCleared = false;
+	let reloaded = false;
+
+	// Framed + rrdev=1 → embedded dev preview: the embedder is the sole
+	// session authority, so the same removal event that signs out a real tab
+	// (see the localStorage-removals test below) must neither clear nor
+	// reload here. The gate cache is reset to recompute from this staging.
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			self: {},
+			top: {},
+			location: { origin: 'https://shell.example.test', search: '?rrdev=1', reload: () => { reloaded = true; } },
+			localStorage,
+			addEventListener: (type: string, listener: (event: StorageEvent) => void) => listeners.set(type, listener),
+		},
+	});
+	resetDevGateForTests();
+	RocketRideClient.prototype.attach = async () => {};
+
+	try {
+		const { manager } = createTestManager();
+		manager.clearToken = () => { tokenCleared = true; };
+		manager.initialize();
+
+		listeners.get('storage')!({
+			key: LS_TOKEN,
+			oldValue: 'old-token',
+			newValue: null,
+			storageArea: localStorage,
+		} as StorageEvent);
+
+		assert.equal(tokenCleared, false);
+		assert.equal(reloaded, false);
+	} finally {
+		resetDevGateForTests();
+		RocketRideClient.prototype.attach = originalAttach;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
 	}
 });
 

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -51,6 +51,7 @@ import { BaseManager } from './base-manager';
 import { RemoteManager } from './remote-manager';
 import { AUTH_REJECTED_MESSAGE, ConnectionFailure } from './errors';
 import { shouldReloadForTokenStorageUpdate } from './tokenStorageUpdate';
+import { isEmbeddedDevShell, tokenStore } from '../util/devGate';
 import { getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import {
 	LS_TOKEN,
@@ -465,6 +466,14 @@ export class ConnectionManager implements IConnectionManager {
 		// so the button works again without a manual page refresh.
 		if (typeof window !== 'undefined') {
 			window.addEventListener('storage', (event) => {
+				// Embedded dev previews ignore cross-context token churn: the
+				// embedder's rrdev:auth answer is the sole session authority
+				// there (and the token lives per-context, see devGate), so a
+				// change in the shared slot is never actionable. Reacting to it
+				// is how two panels with divergent auth states once reloaded
+				// each other forever — each panel's clear/save cross-fired the
+				// other panel's watcher.
+				if (isEmbeddedDevShell()) return;
 				try {
 					const localStorage = window.localStorage;
 					if (event.key !== LS_TOKEN || event.storageArea !== localStorage) return;
@@ -1245,9 +1254,9 @@ export class ConnectionManager implements IConnectionManager {
 	// TOKEN STORAGE
 	// =========================================================================
 
-	/** Persist a user token to localStorage. */
+	/** Persist a user token to this shell's token store (see devGate.tokenStore). */
 	public saveToken(token: string): void {
-		try { localStorage.setItem(LS_TOKEN, token); } catch (e) {
+		try { tokenStore().setItem(LS_TOKEN, token); } catch (e) {
 			console.error('[ConnectionManager] Failed to save token:', e);
 		}
 		this.primeAppsCookie(token);
@@ -1276,28 +1285,17 @@ export class ConnectionManager implements IConnectionManager {
 		} catch { /* best-effort — the bundle route re-checks anyway */ }
 	}
 
-	/** Load token from localStorage. Migrates the old sessionStorage value once. */
+	/** Load the persisted token from this shell's token store. */
 	public loadToken(): string {
 		try {
-			const token = localStorage.getItem(LS_TOKEN);
-			if (token !== null) return token;
-
-			const sessionToken = sessionStorage.getItem(LS_TOKEN);
-			if (sessionToken === null) return '';
-
-			localStorage.setItem(LS_TOKEN, sessionToken);
-			sessionStorage.removeItem(LS_TOKEN);
-			return sessionToken;
+			return tokenStore().getItem(LS_TOKEN) ?? '';
 		} catch { return ''; }
 	}
 
-	/** Clear the persisted token. */
+	/** Clear the persisted token from this shell's token store. */
 	public clearToken(): void {
-		try { localStorage.removeItem(LS_TOKEN); } catch (e) {
+		try { tokenStore().removeItem(LS_TOKEN); } catch (e) {
 			console.error('[ConnectionManager] Failed to clear token:', e);
-		}
-		try { sessionStorage.removeItem(LS_TOKEN); } catch (e) {
-			console.error('[ConnectionManager] Failed to clear legacy session token:', e);
 		}
 	}
 

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -1259,6 +1259,13 @@ export class ConnectionManager implements IConnectionManager {
 		try { tokenStore().setItem(LS_TOKEN, token); } catch (e) {
 			console.error('[ConnectionManager] Failed to save token:', e);
 		}
+		// An embedded preview must not stamp the HOST-WIDE /apps cookie: the
+		// cookie jar is shared by every same-origin frame, so a panel's
+		// injected dev session would swap the bundle credentials out from
+		// under the embedding user's real session and every sibling panel.
+		// The preview's own dev bundle is served by the dev overlay, not
+		// /apps, so the prime is not needed there either.
+		if (isEmbeddedDevShell()) return;
 		this.primeAppsCookie(token);
 	}
 

--- a/packages/shell/src/constants.ts
+++ b/packages/shell/src/constants.ts
@@ -28,7 +28,12 @@
 // STORAGE KEYS
 // =============================================================================
 
-/** localStorage: auth token — persists across tabs, windows, and browser restarts. */
+/**
+ * Auth token storage key. Real tabs keep it in localStorage (shared across
+ * tabs and windows, survives restarts); embedded dev previews keep a
+ * per-context copy under the same key in sessionStorage, because each
+ * preview's embedder is its sole session authority (see util/devGate).
+ */
 export const LS_TOKEN = 'rr:user_token';
 
 /**

--- a/packages/shell/src/constants.ts
+++ b/packages/shell/src/constants.ts
@@ -31,8 +31,9 @@
 /**
  * Auth token storage key. Real tabs keep it in localStorage (shared across
  * tabs and windows, survives restarts); embedded dev previews keep a
- * per-context copy under the same key in sessionStorage, because each
- * preview's embedder is its sole session authority (see util/devGate).
+ * frame-local in-memory copy under the same key, because each preview's
+ * embedder is its sole session authority and re-supplies the session on
+ * every boot (see util/devGate).
  */
 export const LS_TOKEN = 'rr:user_token';
 

--- a/packages/shell/src/util/devGate.ts
+++ b/packages/shell/src/util/devGate.ts
@@ -1,0 +1,113 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * The dev gate and the session-storage scope policy derived from it.
+ *
+ * A LEAF module (no shell imports): the ConnectionManager and the dev-mode
+ * hooks both need these predicates, and devMode.ts already imports the
+ * ConnectionManager — the gate lives below both so neither import direction
+ * can cycle.
+ */
+
+// =============================================================================
+// DEV GATE
+// =============================================================================
+
+// Computed once on first read, never re-read (the gate must not flip while
+// the shell runs — a mid-session change would strand half-installed hooks).
+let gateResult: boolean | undefined;
+
+/**
+ * Whether dev hooks are enabled for this shell session.
+ *
+ * True when this is a development build (NODE_ENV !== 'production') OR the
+ * page URL carries `rrdev=1`. Read once at first call and cached.
+ *
+ * @returns True when dev hooks should be installed.
+ */
+export function isDevHooksEnabled(): boolean {
+	if (gateResult === undefined) {
+		let urlFlag = false;
+		try {
+			urlFlag = new URLSearchParams(window.location.search).get('rrdev') === '1';
+			// The OAuth redirect URI is the bare origin, so `rrdev=1` does not
+			// survive the round trip — index.html's flavor picker persists the
+			// choice per tab ('rr:dev'), and the gate honors the same flag so
+			// the flavor and the hooks can never disagree.
+			if (!urlFlag) urlFlag = sessionStorage.getItem('rr:dev') === '1';
+		} catch { /* no window/location (tests) — build-mode gate only */ }
+		gateResult = process.env.NODE_ENV !== 'production' || urlFlag;
+	}
+	return gateResult;
+}
+
+/**
+ * TEST-ONLY: forget the cached gate so a test can stage its own
+ * window/`rrdev` environment. Production code never calls this — the gate
+ * must stay frozen for the life of a real shell session.
+ */
+export function resetDevGateForTests(): void {
+	gateResult = undefined;
+}
+
+// =============================================================================
+// EMBEDDED DEV SHELL
+// =============================================================================
+
+/**
+ * Whether this shell is an EMBEDDED dev preview — the App Builder's iframe
+ * (web or VSCode) — as opposed to a top-level tab that merely has dev hooks
+ * on (shell:dev in a browser, an F5 external-browser preview).
+ *
+ * The distinction matters because an embedded preview takes its session from
+ * its embedder: the `rrdev:auth` answer is definitive, which changes the
+ * session-scope rules (see tokenStore).
+ *
+ * @returns True when dev hooks are on AND the shell runs framed.
+ */
+export function isEmbeddedDevShell(): boolean {
+	try {
+		return isDevHooksEnabled() && window.self !== window.top;
+	} catch { return false; }
+}
+
+// =============================================================================
+// TOKEN STORAGE SCOPE
+// =============================================================================
+
+/**
+ * The storage backing this shell's session token.
+ *
+ * Embedded dev previews keep a PER-CONTEXT copy (sessionStorage): each
+ * panel's embedder is the sole session authority, so panels must neither
+ * share nor be able to clear the origin-wide token — two panels with
+ * divergent auth states writing one shared slot cross-fire each other's
+ * storage watchers and reload each other forever. Real tabs keep the shared
+ * localStorage slot so a sign-in propagates across tabs and survives
+ * restarts.
+ *
+ * @returns The Storage object all token reads/writes must go through.
+ */
+export function tokenStore(): Storage {
+	return isEmbeddedDevShell() ? sessionStorage : localStorage;
+}

--- a/packages/shell/src/util/devGate.ts
+++ b/packages/shell/src/util/devGate.ts
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 /**
- * The dev gate and the session-storage scope policy derived from it.
+ * The dev gate and the token-scope policy derived from it.
  *
  * A LEAF module (no shell imports): the ConnectionManager and the dev-mode
  * hooks both need these predicates, and devMode.ts already imports the
@@ -95,19 +95,40 @@ export function isEmbeddedDevShell(): boolean {
 // TOKEN STORAGE SCOPE
 // =============================================================================
 
+// Frame-local token slot for embedded dev previews. Deliberately NOT
+// sessionStorage: per WHATWG, same-origin sibling iframes inside one
+// top-level browsing context SHARE a session storage area, so two preview
+// panels on one page could still overwrite or clear each other's token
+// there. A module-level map is scoped to this frame's JS realm — the only
+// truly per-frame slot the platform offers — and needs no persistence:
+// the embedder re-answers `rrdev:auth` on every boot, so a reloaded frame
+// re-adopts its session instead of reading it back from storage.
+const frameTokenStore: Storage = (() => {
+	const data = new Map<string, string>();
+	return {
+		get length(): number { return data.size; },
+		clear: (): void => { data.clear(); },
+		getItem: (key: string): string | null => data.get(key) ?? null,
+		key: (index: number): string | null => Array.from(data.keys())[index] ?? null,
+		removeItem: (key: string): void => { data.delete(key); },
+		setItem: (key: string, value: string): void => { data.set(key, value); },
+	};
+})();
+
 /**
  * The storage backing this shell's session token.
  *
- * Embedded dev previews keep a PER-CONTEXT copy (sessionStorage): each
- * panel's embedder is the sole session authority, so panels must neither
- * share nor be able to clear the origin-wide token — two panels with
- * divergent auth states writing one shared slot cross-fire each other's
- * storage watchers and reload each other forever. Real tabs keep the shared
- * localStorage slot so a sign-in propagates across tabs and survives
- * restarts.
+ * Embedded dev previews keep a FRAME-LOCAL in-memory copy: each panel's
+ * embedder is the sole session authority, so panels must neither share nor
+ * be able to clear another context's token — two panels with divergent
+ * auth states writing one shared slot cross-fire each other's storage
+ * watchers and reload each other forever, and even sessionStorage is
+ * shared between same-origin sibling iframes in one top-level browsing
+ * context (see frameTokenStore). Real tabs keep the shared localStorage
+ * slot so a sign-in propagates across tabs and survives restarts.
  *
  * @returns The Storage object all token reads/writes must go through.
  */
 export function tokenStore(): Storage {
-	return isEmbeddedDevShell() ? sessionStorage : localStorage;
+	return isEmbeddedDevShell() ? frameTokenStore : localStorage;
 }

--- a/packages/shell/src/util/devMode.ts
+++ b/packages/shell/src/util/devMode.ts
@@ -41,7 +41,13 @@
 import React from 'react';
 import * as ReactDom from 'react-dom';
 import { ConnectionManager } from '../connection/connection';
+import { isDevHooksEnabled, isEmbeddedDevShell } from './devGate';
 import { registerLocalApp, unregisterLocalApp, invalidateAppDescriptor, registerDevRemote } from './appLoader';
+
+// The gate lives in devGate.ts (a leaf module — the ConnectionManager needs
+// it too, and this module imports the ConnectionManager); re-exported here so
+// dev-mode consumers keep one import site.
+export { isDevHooksEnabled };
 
 // =============================================================================
 // TYPES
@@ -69,38 +75,6 @@ declare global {
 		/** Dev hooks API — present only when dev hooks are enabled. */
 		__rrShellDev?: RrShellDevApi;
 	}
-}
-
-// =============================================================================
-// DEV GATE
-// =============================================================================
-
-// Computed once on first read, never re-read (the gate must not flip while
-// the shell runs — a mid-session change would strand half-installed hooks).
-let gateResult: boolean | undefined;
-
-/**
- * Whether dev hooks are enabled for this shell session.
- *
- * True when this is a development build (NODE_ENV !== 'production') OR the
- * page URL carries `rrdev=1`. Read once at first call and cached.
- *
- * @returns True when dev hooks should be installed.
- */
-export function isDevHooksEnabled(): boolean {
-	if (gateResult === undefined) {
-		let urlFlag = false;
-		try {
-			urlFlag = new URLSearchParams(window.location.search).get('rrdev') === '1';
-			// The OAuth redirect URI is the bare origin, so `rrdev=1` does not
-			// survive the round trip — index.html's flavor picker persists the
-			// choice per tab ('rr:dev'), and the gate honors the same flag so
-			// the flavor and the hooks can never disagree.
-			if (!urlFlag) urlFlag = sessionStorage.getItem('rr:dev') === '1';
-		} catch { /* no window/location (tests) — build-mode gate only */ }
-		gateResult = process.env.NODE_ENV !== 'production' || urlFlag;
-	}
-	return gateResult;
 }
 
 // =============================================================================
@@ -151,8 +125,8 @@ function settleBootAnswer(token: string | null): boolean {
  * @returns The embedder-supplied token, or null.
  */
 export function waitForEmbeddedSession(timeoutMs: number): Promise<string | null> {
-	// Not framed, hooks off, or hooks not installed — nothing will answer.
-	if (!isDevHooksEnabled() || window.self === window.top || !bootAnswerPromise) {
+	// Not an embedded dev preview, or hooks not installed — nothing will answer.
+	if (!isEmbeddedDevShell() || !bootAnswerPromise) {
 		return Promise.resolve(null);
 	}
 	return new Promise((resolve) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,9 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
 
   apps/shared:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,8 +46,10 @@ packages:
 # whole block). shell and rocketride resolve IN-TREE to their workspace
 # packages: app manifests keep the portable file: specs
 # ("file:../../.rocketride/shell/shell.tgz",
-# "file:../../../.rocketride/client/rocketride.tgz" — exactly right when an
-# app is lifted into its own repo, where the tgz is downloaded and vendored),
+# "file:../../.rocketride/client/rocketride.tgz" — two levels up to the
+# workspace root, exactly right wherever an app sits at
+# <workspace>/apps/<app>, including its own repo after lift-out, where the
+# tgz is downloaded and vendored),
 # and these overrides supersede them inside the monorepo — a workspace link
 # carries no tarball integrity pin, so fresh clones and frozen-lockfile CI
 # install without the gitignored artifacts existing.


### PR DESCRIPTION
## What

Four independent fix groups that accumulated during app-2 dogfooding, plus a manifest-spec ruling applied repo-wide.

### Shell: per-context token storage for embedded dev previews
Two App Builder preview panels with divergent auth states shared the origin-wide `localStorage` token slot — each panel's clear/save cross-fired the other panel's `storage` watcher and the panels reloaded each other forever. An embedded preview takes its session from its embedder (the `rrdev:auth` answer is definitive), so its token now lives per-context:

- New leaf module `util/devGate.ts` (the dev gate moved verbatim from `devMode.ts`, which re-exports it) adds `isEmbeddedDevShell()` and `tokenStore()` — `sessionStorage` for embedded previews, `localStorage` for real tabs. Leaf placement breaks the ConnectionManager/devMode import cycle.
- ConnectionManager and both auth providers route all token I/O through `tokenStore()`; the storage-event watcher is disabled entirely in embedded shells (the shared slot is never actionable there).
- The one-shot sessionStorage→localStorage legacy migration is removed — it would now misread a preview's per-context token as a migration source and hoist it into the shared slot.
- Two new tests cover the embedded paths; `resetDevGateForTests()` lets tests stage their own gate environment.

### VSCode: refuse cleartext credential transport (CWE-319)
`isSecureCloudTarget()`: https/wss always acceptable, http/ws only for loopback hosts (the documented `http://localhost:5565` dev flow). Enforced at the single sign-in funnel in `CloudAuthProvider` — sign-in ends with the API key inside the connection's auth request — and in settings validation; the `cloudUrl` setting description states the rule.

### VSCode: App Builder polish
- `watchManager` classifies rsbuild output from untagged lines only: `[browser]`-tagged lines are `dev.browserLogs` relays of the page's runtime errors dressed in rsbuild's error format — app traffic must never flip the panel to "build failed" (nothing failed to compile, so the Console would carry no explanation).
- `SidebarProvider` sorts the app list by display name; scan order is marker-path order, a binding-priority detail users should not see.

### App manifests: one canonical portable spec
Ruling: manifests carry the lift-out path; workspace overrides own in-repo resolution.

- `hello-ui`/`world-ui`: the saas-root-relative `../../../` specs become the depth-independent `../../` form — correct wherever an app sits at `<workspace>/apps/<app>` (a user workspace, the build sandbox, or its own repo after lift-out). The three-level form only resolved in the nested dogfood checkout.
- `explorer-ui`/`monitor-ui`: `rocketride` moves from `workspace:*` to the same portable `file:` spec, pinning the server-matched client on lift-out (the npm registry package can lag the connected server badly).
- In-repo nothing changes: the workspace-yaml overrides (`shell`/`rocketride` → `workspace:*`) supersede the `file:` specs before resolution — proven by a zero lockfile delta after install.
- `rocket-ui`: appManifest `typecheck` flips `false` → `true` and a `typescript` devDep backs the `tsc --noEmit` script — the app typechecks clean now, so server-side app builds enforce it from here on.

## Verification

- `shell:clean shell:build shell:test` — 30/30, including the four token-scope tests — and `shell:check` (contract current)
- `vscode:clean vscode:build` — green through vsix packaging
- `rocket-ui` `tsc --noEmit` — clean
- `pnpm install` — lockfile delta is exactly the typescript devDep entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Browser runtime errors no longer incorrectly mark app builds as failed in the VS Code panel.
  - Embedded development previews isolate authentication tokens and ignore unrelated token changes.
  - Sign-out and token handling now consistently use the active authentication store.

- **Improvements**
  - Cloud connections require HTTPS, except for localhost development targets.
  - The VS Code sidebar opens to My Apps and sorts apps alphabetically.
  - Custom cloud-server guidance includes secure connection examples.
  - App dependency setup preserves portable project manifests and resolves local packages more reliably.
  - The Explorer panel is now titled “My Pipelines,” with Pipelines moved to the end of the mode list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->