### PR TITLE
chore(security)(n8n-nodes): raise floors for js-yaml, vitest, @vitest/mocker

### DIFF
--- a/packages/n8n-nodes/package-lock.json
+++ b/packages/n8n-nodes/package-lock.json
@@ -13,7 +13,7 @@
 				"eslint": "9.29.0",
 				"prettier": "3.6.2",
 				"typescript": "5.9.2",
-				"vitest": "^4.1.8"
+				"vitest": "^4.1.11"
 			},
 			"peerDependencies": {
 				"n8n-workflow": "*"
@@ -548,9 +548,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+			"integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1974,13 +1974,13 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.144.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
-			"integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+			"version": "0.149.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.149.0.tgz",
+			"integrity": "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
+				"url": "https://github.com/sponsors/oxc-project"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -2000,10 +2000,27 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/@rolldown/binding-android-arm-eabi": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
+			"integrity": "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
-			"integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.8.tgz",
+			"integrity": "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2018,9 +2035,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
-			"integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.8.tgz",
+			"integrity": "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2035,9 +2052,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
-			"integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.8.tgz",
+			"integrity": "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==",
 			"cpu": [
 				"x64"
 			],
@@ -2052,9 +2069,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
-			"integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.8.tgz",
+			"integrity": "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2069,9 +2086,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
-			"integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.8.tgz",
+			"integrity": "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==",
 			"cpu": [
 				"arm"
 			],
@@ -2086,9 +2103,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
-			"integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.8.tgz",
+			"integrity": "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==",
 			"cpu": [
 				"arm64"
 			],
@@ -2106,9 +2123,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
-			"integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.8.tgz",
+			"integrity": "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2126,9 +2143,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
-			"integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.8.tgz",
+			"integrity": "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2146,9 +2163,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
-			"integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.8.tgz",
+			"integrity": "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -2166,9 +2183,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
-			"integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.8.tgz",
+			"integrity": "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==",
 			"cpu": [
 				"x64"
 			],
@@ -2186,9 +2203,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
-			"integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.8.tgz",
+			"integrity": "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==",
 			"cpu": [
 				"x64"
 			],
@@ -2206,9 +2223,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
-			"integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.8.tgz",
+			"integrity": "sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2223,9 +2240,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
-			"integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.8.tgz",
+			"integrity": "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==",
 			"cpu": [
 				"arm64"
 			],
@@ -2240,9 +2257,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
-			"integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.8.tgz",
+			"integrity": "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==",
 			"cpu": [
 				"x64"
 			],
@@ -3002,16 +3019,16 @@
 			]
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+			"integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3020,13 +3037,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+			"integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.10",
+				"@vitest/spy": "4.1.11",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -3047,9 +3064,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+			"integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3060,13 +3077,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+			"integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.10",
+				"@vitest/utils": "4.1.11",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -3074,14 +3091,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+			"integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -3090,9 +3107,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+			"integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3100,13 +3117,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+			"integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
+				"@vitest/pretty-format": "4.1.11",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -6017,9 +6034,9 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -7416,9 +7433,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.26",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"version": "8.5.28",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+			"integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
 			"dev": true,
 			"funding": [
 				{
@@ -7436,7 +7453,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.17",
+				"nanoid": "^3.3.18",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -7691,13 +7708,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
-			"integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.8.tgz",
+			"integrity": "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.144.0",
+				"@oxc-project/types": "=0.149.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -7707,20 +7724,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.2.4",
-				"@rolldown/binding-darwin-arm64": "1.2.4",
-				"@rolldown/binding-darwin-x64": "1.2.4",
-				"@rolldown/binding-freebsd-x64": "1.2.4",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
-				"@rolldown/binding-linux-arm64-gnu": "1.2.4",
-				"@rolldown/binding-linux-arm64-musl": "1.2.4",
-				"@rolldown/binding-linux-ppc64-gnu": "1.2.4",
-				"@rolldown/binding-linux-s390x-gnu": "1.2.4",
-				"@rolldown/binding-linux-x64-gnu": "1.2.4",
-				"@rolldown/binding-linux-x64-musl": "1.2.4",
-				"@rolldown/binding-openharmony-arm64": "1.2.4",
-				"@rolldown/binding-win32-arm64-msvc": "1.2.4",
-				"@rolldown/binding-win32-x64-msvc": "1.2.4"
+				"@rolldown/binding-android-arm-eabi": "1.2.8",
+				"@rolldown/binding-android-arm64": "1.2.8",
+				"@rolldown/binding-darwin-arm64": "1.2.8",
+				"@rolldown/binding-darwin-x64": "1.2.8",
+				"@rolldown/binding-freebsd-x64": "1.2.8",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.8",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.8",
+				"@rolldown/binding-linux-arm64-musl": "1.2.8",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.8",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.8",
+				"@rolldown/binding-linux-x64-gnu": "1.2.8",
+				"@rolldown/binding-linux-x64-musl": "1.2.8",
+				"@rolldown/binding-openharmony-arm64": "1.2.8",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.8",
+				"@rolldown/binding-win32-x64-msvc": "1.2.8"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -8453,16 +8471,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.3.0.tgz",
+			"integrity": "sha512-lhZBVvEHefgE+HQZC9O7EBJgCU/nVzFNl7vkS4RE0APtWLP02/8QVIkQtzBxPquh7lq5/78NHipTj7ODQ6XuyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.33.0",
-				"picomatch": "^4.0.5",
-				"postcss": "^8.5.25",
-				"rolldown": "~1.2.1",
+				"picomatch": "^4.0.7",
+				"postcss": "^8.5.28",
+				"rolldown": "~1.2.6",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
@@ -8479,7 +8497,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.4.0",
+				"@vitejs/devtools": "^0.7.1",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -8546,9 +8564,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/picomatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8559,19 +8577,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+			"integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.10",
-				"@vitest/mocker": "4.1.10",
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/runner": "4.1.10",
-				"@vitest/snapshot": "4.1.10",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
+				"@vitest/expect": "4.1.11",
+				"@vitest/mocker": "4.1.11",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/runner": "4.1.11",
+				"@vitest/snapshot": "4.1.11",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -8599,12 +8617,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.10",
-				"@vitest/browser-preview": "4.1.10",
-				"@vitest/browser-webdriverio": "4.1.10",
-				"@vitest/coverage-istanbul": "4.1.10",
-				"@vitest/coverage-v8": "4.1.10",
-				"@vitest/ui": "4.1.10",
+				"@vitest/browser-playwright": "4.1.11",
+				"@vitest/browser-preview": "4.1.11",
+				"@vitest/browser-webdriverio": "4.1.11",
+				"@vitest/coverage-istanbul": "4.1.11",
+				"@vitest/coverage-v8": "4.1.11",
+				"@vitest/ui": "4.1.11",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/n8n-nodes/package-lock.json
+++ b/packages/n8n-nodes/package-lock.json
@@ -10,7 +10,9 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "0.34.0",
+				"@vitest/mocker": "^4.1.11",
 				"eslint": "9.29.0",
+				"js-yaml": "^4.3.2",
 				"prettier": "3.6.2",
 				"typescript": "5.9.2",
 				"vitest": "^4.1.11"

--- a/packages/n8n-nodes/package.json
+++ b/packages/n8n-nodes/package.json
@@ -66,16 +66,14 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "0.34.0",
+		"@vitest/mocker": "^4.1.11",
 		"eslint": "9.29.0",
+		"js-yaml": "^4.3.2",
 		"prettier": "3.6.2",
 		"typescript": "5.9.2",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"
-	},
-	"overrides": {
-		"js-yaml": ">=4.3.2 <5",
-		"@vitest/mocker": ">=4.1.11 <5"
 	}
 }

--- a/packages/n8n-nodes/package.json
+++ b/packages/n8n-nodes/package.json
@@ -69,9 +69,13 @@
 		"eslint": "9.29.0",
 		"prettier": "3.6.2",
 		"typescript": "5.9.2",
-		"vitest": "^4.1.8"
+		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"
+	},
+	"overrides": {
+		"js-yaml": ">=4.3.2 <5",
+		"@vitest/mocker": ">=4.1.11 <5"
 	}
 }


### PR DESCRIPTION
## Summary

Closes 3 open Dependabot alerts on `packages/n8n-nodes/package-lock.json` (the standalone npm sublockfile, not part of the pnpm workspace). Follow-up to #2237 which handled the workspace-wide overrides.

## Changes

Two files, both under `packages/n8n-nodes/`:

- **`package.json`**: direct dev-dep `vitest` bumped from `^4.1.8` to `^4.1.11`. Added an `overrides` block for the two transitive deps that npm doesn't allow overriding when they're also direct (`js-yaml`, `@vitest/mocker`).
- **`package-lock.json`**: regenerated with `npm install --package-lock-only` on npm 11.13.0.

## Resolved versions

| package | GHSA | severity | resolved |
|---|---|---|---|
| `js-yaml` | GHSA-2883-xcg3-v3hh | high | 4.3.2 |
| `vitest` | GHSA-82fw-gwwq-j7x9 | medium | 4.1.11 |
| `@vitest/mocker` | GHSA-82fw-gwwq-j7x9 | medium | 4.1.11 |

## What is not in this PR

`npm audit` on this subproject also reports 16 unrelated warnings under `@langchain/*` and `@n8n/ai-utilities` (via `uuid`). Closing them requires bumping `@n8n/node-cli` from `0.34.0` to `0.47.2` (a major-version upgrade), which is a rework rather than a security floor and needs its own PR + test pass.

Also not in this PR (deliberately, to keep the security-floor scope tight):

- `packages/ai/src/ai/modules/mcp/apps/package.json` declares `vitest: ^3.0.0`. Alert #335 targets it. Fixing means a v3 → v4 vitest migration in that mcp/apps workspace, which has breaking-change potential and should be a separate migration PR.
- Workflow hygiene (5 Scorecard alerts on workflow files): follow-up PR.

## Test plan

- [ ] `npm ci` in `packages/n8n-nodes/` succeeds against the new lockfile.
- [ ] `n8n-nodes CI` workflow stays green.
- [ ] After merge, alerts `#340`, `#337`, `#336` auto-close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development tooling packages and version constraints to improve compatibility and maintainability.
  - Added required tooling for testing and configuration file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->