### PR TITLE
fix(build): retry transiently locked files during sync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
   "cmake.configureOnOpen": false,
   "cmake.sourceDirectory": "${workspaceFolder}/packages/server",
   "explorer.excludeGitIgnore": true,
+  "files.watcherExclude": {
+    "**/build/**": true,
+    "**/dist/**": true
+  },
   "python.analysis.exclude": [
     "**/.*",
     "**/__pycache__",

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -211,6 +211,38 @@ async function mkdirIfNotExists(dirPath) {
 // Copy Operations
 // =============================================================================
 
+// Windows reports a path another process holds open as EBUSY/EPERM/EACCES, and
+// hands the error to whoever touches it second — the holder need not be writing:
+// an editor's language server indexing dist/, a file watcher or an AV pass is
+// enough. A sync that walks thousands of files meets that window eventually, so
+// the operations that cross it retry briefly rather than failing a whole build
+// on one busy millisecond. A path that stays locked still raises its real error.
+const TRANSIENT_LOCK_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
+
+/**
+ * Run a filesystem operation, retrying while the path is transiently locked.
+ *
+ * The delay grows per attempt (100, 200, 300, 400 ms), so a genuinely held path
+ * costs one second before it reports. Anything that is not a lock propagates at
+ * once — a missing file must not be retried into a slow failure.
+ *
+ * @template T
+ * @param {() => Promise<T>} op - Operation to attempt
+ * @param {number} [attempts] - Total attempts, including the first
+ * @param {number} [delayMs] - Base delay, multiplied by the attempt number
+ * @returns {Promise<T>} Whatever the operation returns
+ */
+async function retryTransientLock(op, attempts = 5, delayMs = 100) {
+    for (let attempt = 1; ; attempt++) {
+        try {
+            return await op();
+        } catch (err) {
+            if (attempt >= attempts || !TRANSIENT_LOCK_CODES.has(err.code)) throw err;
+            await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
+        }
+    }
+}
+
 /**
  * Copy a file
  * @param {string} src - Source file path
@@ -219,7 +251,7 @@ async function mkdirIfNotExists(dirPath) {
  * @returns {Promise<void>}
  */
 async function copyFile(src, dest, mode) {
-    return fsp.copyFile(src, dest, mode);
+    return retryTransientLock(() => fsp.copyFile(src, dest, mode));
 }
 
 /**
@@ -230,7 +262,7 @@ async function copyFile(src, dest, mode) {
  */
 async function copyFileEnsure(src, dest) {
     await fsp.mkdir(path.dirname(dest), { recursive: true });
-    return fsp.copyFile(src, dest);
+    return retryTransientLock(() => fsp.copyFile(src, dest));
 }
 
 /**
@@ -278,9 +310,9 @@ async function filesEqual(a, b) {
     // would leak the first handle if the second open rejected (Promise.all
     // rejects at once, orphaning the resolved handle) — a slow FD leak that can
     // build to EMFILE across a large sync.
-    const fhA = await fsp.open(a, 'r');
+    const fhA = await retryTransientLock(() => fsp.open(a, 'r'));
     try {
-        const fhB = await fsp.open(b, 'r');
+        const fhB = await retryTransientLock(() => fsp.open(b, 'r'));
         try {
             const bufA = Buffer.allocUnsafe(CHUNK_SIZE);
             const bufB = Buffer.allocUnsafe(CHUNK_SIZE);

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -211,13 +211,17 @@ async function mkdirIfNotExists(dirPath) {
 // Copy Operations
 // =============================================================================
 
-// Windows reports a path another process holds open as EBUSY/EPERM/EACCES, and
-// hands the error to whoever touches it second — the holder need not be writing:
-// an editor's language server indexing dist/, a file watcher or an AV pass is
+// Windows reports a path another process holds open as EBUSY or EPERM, and hands
+// the error to whoever touches it second — the holder need not be writing: an
+// editor's language server indexing dist/, a file watcher or an AV pass is
 // enough. A sync that walks thousands of files meets that window eventually, so
 // the operations that cross it retry briefly rather than failing a whole build
 // on one busy millisecond. A path that stays locked still raises its real error.
-const TRANSIENT_LOCK_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
+//
+// EACCES is deliberately not here: an exclusively held file reports EBUSY, while
+// on Unix EACCES is a permission denial that must surface at once instead of after
+// a second of retries. clean.js and vendor-shell.js classify a lock the same way.
+const TRANSIENT_LOCK_CODES = new Set(['EBUSY', 'EPERM']);
 
 /**
  * Run a filesystem operation, retrying while the path is transiently locked.

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -222,22 +222,27 @@ const TRANSIENT_LOCK_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
 /**
  * Run a filesystem operation, retrying while the path is transiently locked.
  *
- * The delay grows per attempt (100, 200, 300, 400 ms), so a genuinely held path
- * costs one second before it reports. Anything that is not a lock propagates at
- * once — a missing file must not be retried into a slow failure.
+ * The delay grows per attempt (delayMs, x2, x3, ...), so on the defaults a
+ * genuinely held path costs one second before it reports. Anything that is not a
+ * lock propagates at once — a missing file must not be retried into a slow failure.
+ *
+ * Callers whose operation has its own notion of "transient" pass their own set:
+ * a directory swap also treats ENOTEMPTY as retryable, which is meaningless here.
  *
  * @template T
- * @param {() => Promise<T>} op - Operation to attempt
- * @param {number} [attempts] - Total attempts, including the first
- * @param {number} [delayMs] - Base delay, multiplied by the attempt number
+ * @param {() => Promise<T> | T} op - Operation to attempt
+ * @param {object} [options] - Retry tuning
+ * @param {number} [options.attempts] - Total attempts, including the first
+ * @param {number} [options.delayMs] - Base delay, multiplied by the attempt number
+ * @param {Set<string>} [options.codes] - Error codes treated as transient
  * @returns {Promise<T>} Whatever the operation returns
  */
-async function retryTransientLock(op, attempts = 5, delayMs = 100) {
+async function retryTransientLock(op, { attempts = 5, delayMs = 100, codes = TRANSIENT_LOCK_CODES } = {}) {
     for (let attempt = 1; ; attempt++) {
         try {
             return await op();
         } catch (err) {
-            if (attempt >= attempts || !TRANSIENT_LOCK_CODES.has(err.code)) throw err;
+            if (attempt >= attempts || !codes.has(err.code)) throw err;
             await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
         }
     }
@@ -786,6 +791,7 @@ module.exports = {
     // Copying
     copyFile,
     copyFileEnsure,
+    retryTransientLock,
     copyDir,
     copyDirEnsure,
 

--- a/scripts/lib/sync.test.js
+++ b/scripts/lib/sync.test.js
@@ -19,7 +19,7 @@ const os = require('node:os');
 const path = require('node:path');
 const fs = require('node:fs');
 
-const { filesEqual } = require('./fs');
+const { filesEqual, retryTransientLock } = require('./fs');
 const { syncFile, syncDir } = require('./sync');
 
 /**
@@ -146,4 +146,75 @@ test('syncDir: same-size changed file with older mtime is updated; identical fil
     assert.equal(stats.updated, 1);
     assert.equal(stats.unchanged, 1);
     assert.equal(fs.readFileSync(path.join(dest, 'changed.js'), 'utf8'), 'v=<BBBB>');
+});
+
+// --- retryTransientLock ----------------------------------------------------
+
+/**
+ * Build a fake operation that throws the given codes in order, then succeeds.
+ * @param {string[]} codes - Error codes to throw, one per early attempt
+ * @returns {{op: () => Promise<string>, calls: () => number}} Operation and its call count
+ */
+function failingOp(codes) {
+    let n = 0;
+    return {
+        op: async () => {
+            if (n < codes.length) {
+                const err = new Error(codes[n]);
+                err.code = codes[n];
+                n++;
+                throw err;
+            }
+            n++;
+            return 'ok';
+        },
+        calls: () => n,
+    };
+}
+
+test('retryTransientLock: a lock that clears is retried and the value returned', async () => {
+    const { op, calls } = failingOp(['EBUSY', 'EPERM']);
+
+    const got = await retryTransientLock(op, { delayMs: 1 });
+
+    assert.equal(got, 'ok');
+    assert.equal(calls(), 3); // two failures, then the success
+});
+
+test('retryTransientLock: a non-lock error propagates on the first attempt', async () => {
+    const { op, calls } = failingOp(['ENOENT', 'ENOENT', 'ENOENT']);
+
+    await assert.rejects(
+        () => retryTransientLock(op, { delayMs: 1 }),
+        (err) => err.code === 'ENOENT'
+    );
+    // A missing file must not be retried into a slow failure.
+    assert.equal(calls(), 1);
+});
+
+test('retryTransientLock: a path held past the last attempt raises its real error', async () => {
+    const { op, calls } = failingOp(['EBUSY', 'EBUSY', 'EBUSY', 'EBUSY']);
+
+    await assert.rejects(
+        () => retryTransientLock(op, { attempts: 3, delayMs: 1 }),
+        (err) => err.code === 'EBUSY'
+    );
+    // Gives up rather than swallowing it — a permanent lock still stops the build.
+    assert.equal(calls(), 3);
+});
+
+test('retryTransientLock: the transient set is per caller', async () => {
+    const plain = failingOp(['ENOTEMPTY']);
+    await assert.rejects(
+        () => retryTransientLock(plain.op, { delayMs: 1 }),
+        (err) => err.code === 'ENOTEMPTY'
+    );
+    assert.equal(plain.calls(), 1);
+
+    // The directory swap in vendor-shell.js opts ENOTEMPTY in.
+    const swap = failingOp(['ENOTEMPTY']);
+    const got = await retryTransientLock(swap.op, { delayMs: 1, codes: new Set(['ENOTEMPTY']) });
+
+    assert.equal(got, 'ok');
+    assert.equal(swap.calls(), 2);
 });

--- a/scripts/lib/sync.test.js
+++ b/scripts/lib/sync.test.js
@@ -192,6 +192,18 @@ test('retryTransientLock: a non-lock error propagates on the first attempt', asy
     assert.equal(calls(), 1);
 });
 
+test('retryTransientLock: EACCES is a permission denial, not a lock', async () => {
+    const { op, calls } = failingOp(['EACCES']);
+
+    await assert.rejects(
+        () => retryTransientLock(op, { delayMs: 1 }),
+        (err) => err.code === 'EACCES'
+    );
+    // A held file reports EBUSY; on Unix EACCES means the caller may never open it,
+    // so retrying only delays a failure that is already final.
+    assert.equal(calls(), 1);
+});
+
 test('retryTransientLock: a path held past the last attempt raises its real error', async () => {
     const { op, calls } = failingOp(['EBUSY', 'EBUSY', 'EBUSY', 'EBUSY']);
 

--- a/scripts/lib/vendor-shell.js
+++ b/scripts/lib/vendor-shell.js
@@ -49,6 +49,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { retryTransientLock } = require('./fs');
 
 // =============================================================================
 // WORKSPACE SCAN
@@ -121,25 +122,27 @@ function resolveHost(cliShell) {
 	return (cliShell || getenv().ROCKETRIDE_URI || 'http://localhost:5565').replace(/\/$/, '');
 }
 
+// A directory swap adds ENOTEMPTY to the usual lock codes: the destination can
+// still hold entries an indexer is walking, which clears the same way a lock does.
+const RENAME_LOCK_CODES = new Set(['EPERM', 'EBUSY', 'ENOTEMPTY']);
+
 /**
  * Renames with a few retries: on Windows a freshly-written directory can be
  * transiently locked (antivirus/indexer scanning the new files), failing
  * the swap with EPERM/EBUSY even though nothing holds it moments later.
  *
+ * Backs off 200 ms per attempt, twice the default, because a directory swap
+ * waits on a whole tree being released rather than one file handle.
+ *
  * @param {string} from - Source path.
  * @param {string} to - Destination path.
+ * @returns {Promise<void>}
  */
 async function renameWithRetry(from, to) {
-	for (let attempt = 1; ; attempt++) {
-		try {
-			fs.renameSync(from, to);
-			return;
-		} catch (err) {
-			const transient = err.code === 'EPERM' || err.code === 'EBUSY' || err.code === 'ENOTEMPTY';
-			if (attempt >= 5 || !transient) throw err;
-			await new Promise((resolve) => setTimeout(resolve, attempt * 200));
-		}
-	}
+	await retryTransientLock(() => fs.renameSync(from, to), {
+		delayMs: 200,
+		codes: RENAME_LOCK_CODES,
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary

- `copyFile`, `copyFileEnsure` and both opens in `filesEqual` (`scripts/lib/fs.js`) now retry while a path is transiently locked, so one busy millisecond no longer aborts a whole build
- Non-lock errors (`ENOENT` and friends) still propagate immediately; a path held indefinitely still fails with its real error
- `renameWithRetry` (`vendor-shell.js`) now delegates to the same helper, so "transient" has one definition instead of two that disagreed
- Excluded `dist/` and `build/` from the VS Code file watcher, removing one standing cause rather than the symptom

Windows hands `EBUSY`/`EPERM` to whoever opens a file second, and the holder need not be writing — an editor's language server indexing `dist/`, a watcher or an AV pass is enough. `scripts/lib/fs.js` sits under `syncDir`, used by 11 build tasks; `ai:build` alone walks ~2650 files per run.

`EACCES` was measured out of the set: a file held exclusively reports `EBUSY`, and on Unix `EACCES` is a permission denial that must fail at once rather than after a second of retries. All three lock classifications in the repo (`clean.js`, `fs.js`, `vendor-shell.js`) now agree on `EBUSY` + `EPERM`.

### On sharing the helper

`renameWithRetry` ran the same loop with a different code list and a different backoff (200 ms per attempt, not 100). Rather than flatten those, `retryTransientLock` now takes `{ attempts, delayMs, codes }` and each caller keeps its own behaviour exactly:

| | copy / open | directory swap |
|---|---|---|
| codes | `EBUSY`, `EPERM` | `EBUSY`, `EPERM`, `ENOTEMPTY` |
| backoff | `100·attempt` → 1 s | `200·attempt` → 2 s |

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`scripts/lib/sync.test.js` passes 11/11, including four new cases for the helper: a lock that clears is retried, a non-lock code propagates on the first attempt, a path held past the last attempt raises its real error, and the transient set is honoured per caller.

Direct measurement under a 400 ms exclusive lock taken before the process starts:

| copying via | result |
|---|---|
| bare `fsp.copyFile` | `FAILED EBUSY after 5 ms` |
| `copyFileEnsure` with retry | `COPIED after 636 ms`, contents correct |

Negative cases: `ENOENT` returns in 0–2 ms (not retried); a permanently held file still fails with a real `EBUSY` after ~1036 ms.

`renameWithRetry` after the refactor is unchanged in behaviour: a permanently un-renameable directory still fails at 2045 ms (200+400+600+800 as before), and a missing source still returns `ENOENT` at 0 ms.

Full parallel build: verified on a run where the sync genuinely copied rather than reporting "no changes" — 230 files were deleted from `dist/server/ai` beforehand, and `ai:sync` reported `+230 added, 51 unchanged`, while `nodes:sync` exercised the compare path over `2656 files up to date`. No lock errors in 782 lines of output; exit 0.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none

## Linked Issue

Fixes #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file copying, comparison, and directory replacement operations by retrying temporary filesystem access conflicts.
  * Non-retryable filesystem errors continue to be reported immediately, while repeated temporary conflicts are handled with progressively longer retry delays.

* **Chores**
  * Reduced unnecessary VS Code file-watching activity for build and distribution directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->