### PR TITLE
fix(shell): derive the dev-preview registration skip instead of persisting dev ownership

### DIFF
--- a/packages/shell/src/components/workspace/WorkspaceContext.tsx
+++ b/packages/shell/src/components/workspace/WorkspaceContext.tsx
@@ -36,7 +36,7 @@ import type { IGridConfigGetDetail, IGridConfigSetDetail, IGridConfigClearDetail
 import type { DataGridLayout } from '../data-grid/persistence';
 import { ConnectionManager } from '../../connection/connection';
 import { HOME_APP_ID, HELLO_APP_ID } from '../../constants';
-import { resetRemote, setDescriptorInvalidator, isDevPreviewPage, previewLockedAppId, waitForDevRemote, isDevRemote } from '../../util/appLoader';
+import { resetRemote, setDescriptorInvalidator, isDevPreviewPage, previewLockedAppId, waitForDevRemote, isDevRemote, fallbackSkippedRemote } from '../../util/appLoader';
 import { getAppVersionOverride, clearAppVersionOverride } from '../../util/versionOverride';
 import { SHELL_API_VERSION } from '../../apiver';
 
@@ -394,12 +394,20 @@ export const WorkspaceProvider: React.FC<IWorkspaceProviderProps> = ({ apps, wor
 			if (isDevPreviewPage() && previewLockedAppId() === appId) {
 				console.log(`[WorkspaceContext] holding "${appId}" until its dev remote registers`);
 				const DEV_REMOTE_TIMEOUT = 300000;
-				await Promise.race([
-					waitForDevRemote(appId),
-					new Promise<never>((_, reject) =>
-						setTimeout(() => reject(new Error(`Dev remote for "${appId}" did not register within ${DEV_REMOTE_TIMEOUT / 1000}s — is the app's dev server running?`)), DEV_REMOTE_TIMEOUT),
-					),
-				]);
+				try {
+					await Promise.race([
+						waitForDevRemote(appId),
+						new Promise<never>((_, reject) =>
+							setTimeout(() => reject(new Error(`Dev remote for "${appId}" did not register within ${DEV_REMOTE_TIMEOUT / 1000}s — is the app's dev server running?`)), DEV_REMOTE_TIMEOUT),
+						),
+					]);
+				} catch (waitErr) {
+					// Self-heal: the boot skipped this app's manifest registration
+					// expecting the injection. If a published bundle exists, register
+					// it and load THAT instead of stranding the app — a stale build
+					// on screen beats a dead preview. Rethrow only with no fallback.
+					if (!fallbackSkippedRemote(appId)) throw waitErr;
+				}
 			}
 			// Load with timeout to avoid indefinite hangs on unreachable remotes
 			const APP_LOAD_TIMEOUT = 15000;

--- a/packages/shell/src/util/appLoader.ts
+++ b/packages/shell/src/util/appLoader.ts
@@ -105,6 +105,15 @@ const registeredEntries = new Map<string, string>();
 // consults this to decide repoint-in-place vs full reload.
 const loadedModules = new Set<string>();
 
+// MF containers with a descriptor load currently IN FLIGHT. A container is
+// committed to its entry from the moment its load STARTS, not when it
+// resolves: forced re-registration drops the runtime's cached promise but
+// does NOT cancel the running operation, so replacing the entry mid-load
+// races two initializations of one container name. The dev takeover treats
+// pending like loaded. A Set suffices — loadDescriptor dedups concurrent
+// loads per app, so at most one load per container is in flight.
+const pendingModules = new Set<string>();
+
 /**
  * Whether an MF container's remote has successfully loaded this document.
  *
@@ -304,33 +313,44 @@ export function unregisterLocalApp(id: string): void {
  * @param entry - The dev server's remoteEntry.js URL.
  */
 export function registerDevRemote(appId: string, moduleId: string, name: string, entry: string): void {
-	// Injection for a container the manifest registered AND that has already
-	// LOADED this document: a loaded container is committed to its version
-	// (repointing it corrupts its consume-shared getters), so only a reboot
-	// can hand the dev entry a clean container. Normally unreachable — the
+	// Injection for a container the manifest registered AND that is LOADED or
+	// mid-load this document: such a container is committed to its entry
+	// (repointing corrupts its consume-shared getters; a forced registration
+	// does not cancel an in-flight load, it races it), so only a reboot can
+	// hand the dev entry a clean container. Normally unreachable — the
 	// dev-preview boot skips the locked app's manifest registration, so the
-	// injection lands first — this covers a lock/injection mismatch. The
-	// reboot is time-bounded per module: without persisted ownership the
-	// next boot may register the module from the manifest again, and an
-	// unbounded reload here would loop. A recurrence inside the guard
-	// window degrades to the force-registration below instead.
-	if (registeredEntries.has(moduleId) && !devRemoteModules.has(moduleId) && loadedModules.has(moduleId)) {
-		const TAKEOVER_GUARD_MS = 60_000;
+	// injection lands first — this covers a lock/injection mismatch and the
+	// late-injection-after-fallback case. The reboot spends from a persisted
+	// per-module BUDGET, not a rate limit: a pure rate limit never bounds the
+	// count (a mismatch recurring once per interval reloads forever), while a
+	// permanent one-shot would strand the legitimate recurrence (an app
+	// fallback-loaded again long after its dev server revived). Budget
+	// exhausted → degrade to the force-registration below instead.
+	if (registeredEntries.has(moduleId) && !devRemoteModules.has(moduleId) && (loadedModules.has(moduleId) || pendingModules.has(moduleId))) {
+		const TAKEOVER_WINDOW_MS = 30 * 60_000;
+		const TAKEOVER_MAX_RELOADS = 2;
 		let reboot = false;
 		try {
-			const key = `rr:devTakeoverAt:${moduleId}`;
-			const last = Number(sessionStorage.getItem(key) ?? 0);
-			if (Date.now() - last > TAKEOVER_GUARD_MS) {
-				sessionStorage.setItem(key, String(Date.now()));
+			const key = `rr:devTakeover:${moduleId}`;
+			// Budget window anchors at the FIRST reload of a burst; it resets
+			// only once the window has fully elapsed since that first attempt.
+			let guard = { n: 0, at: Date.now() };
+			const raw = sessionStorage.getItem(key);
+			if (raw) {
+				const parsed = JSON.parse(raw) as { n: number; at: number };
+				if (Number.isFinite(parsed.n) && Number.isFinite(parsed.at) && Date.now() - parsed.at <= TAKEOVER_WINDOW_MS) guard = parsed;
+			}
+			if (guard.n < TAKEOVER_MAX_RELOADS) {
+				sessionStorage.setItem(key, JSON.stringify({ n: guard.n + 1, at: guard.at }));
 				reboot = true;
 			}
 		} catch { /* storage unavailable — cannot bound a reload loop, so never reload */ }
 		if (reboot) {
-			console.log(`[appLoader] dev registration for loaded container "${moduleId}" — rebooting once for a clean container`);
+			console.log(`[appLoader] dev registration for active container "${moduleId}" — rebooting for a clean container`);
 			window.location.reload();
 			return;
 		}
-		console.error(`[appLoader] dev takeover of loaded container "${moduleId}" recurred within the guard window — force-registering in place; its shared getters may be stale`);
+		console.error(`[appLoader] dev takeover of active container "${moduleId}" exhausted its reload budget — force-registering in place; its shared getters may be stale`);
 	}
 
 	devRemoteModules.add(moduleId);
@@ -663,13 +683,17 @@ export function registerAndMapApps(serverApps: ServerAppEntry[]): AppManifestEnt
 			// removal restores the remote) without re-mapping the manifest.
 			const local = localOverrides.get(a.id);
 			if (local) return local();
+			// Pending marks the container committed for the WHOLE load — the
+			// dev takeover must not force-register it mid-flight.
+			pendingModules.add(a.moduleId);
 			return (loadRemote(`${a.moduleId}/AppDescriptor`) as Promise<{ default: AppDescriptor }>)
 				.then((m) => {
 					// A resolved remote commits this container to its version
 					// for the document's lifetime (see isRemoteLoaded).
 					loadedModules.add(a.moduleId);
 					return m.default;
-				});
+				})
+				.finally(() => pendingModules.delete(a.moduleId));
 		},
 	}));
 }

--- a/packages/shell/src/util/appLoader.ts
+++ b/packages/shell/src/util/appLoader.ts
@@ -163,28 +163,21 @@ let localAppsListener: (() => void) | null = null;
 // (older) published bundle mid-session — the dev preview then loads THAT
 // and dies on platform mismatch (RUNTIME-012).
 //
-// Ownership is PERSISTED per tab (sessionStorage) and loaded at module init:
-// the probe registers manifest remotes at boot, BEFORE any dev injection can
-// arrive — and force-overriding an already-initialized container corrupts
-// its consume-shared getters (MF's "overriding may cause unexpected errors"
-// → "getter for the shared module is not a function"). With persisted
-// ownership, every boot after the first skips the manifest registration
-// entirely and the dev entry is the container's ONLY registration.
-const DEV_OWNED_KEY = 'rr:devOwnedModules';
-const devRemoteModules = new Set<string>(((): string[] => {
-	try {
-		return JSON.parse(sessionStorage.getItem(DEV_OWNED_KEY) ?? '[]') as string[];
-	} catch {
-		return [];
-	}
-})());
+// PAGE-LIFETIME ONLY, never persisted. Ownership used to be persisted in
+// sessionStorage on a per-browser-tab assumption, but a VS Code window is
+// ONE browsing context: every App Builder preview iframe against the same
+// engine origin shares a single sessionStorage (which also survives
+// workspace switches), so ownership accumulated across every app ever
+// designed and stranded them all as mapped-but-unregistered (RUNTIME-004
+// on launch). The boot-time "keep the container clean for the dev entry"
+// job is DERIVED instead: a dev-preview page skips the manifest
+// registration of its session-locked app (see registerAndMapApps), so the
+// injection is the container's first registration without any stored state.
+const devRemoteModules = new Set<string>();
 
-/** Persists the current dev-owned module set for this tab. */
-function persistDevOwned(): void {
-	try {
-		sessionStorage.setItem(DEV_OWNED_KEY, JSON.stringify([...devRemoteModules]));
-	} catch { /* storage unavailable — ownership lasts this page only */ }
-}
+// One-time migration: drop the legacy persisted ownership set so windows
+// poisoned by the old accumulate-forever behavior heal on their next boot.
+try { sessionStorage.removeItem('rr:devOwnedModules'); } catch { /* storage unavailable */ }
 
 /**
  * Whether an MF container is currently dev-owned (see devRemoteModules).
@@ -290,10 +283,7 @@ export function registerLocalApp(id: string, load: () => Promise<AppDescriptor>,
 export function unregisterLocalApp(id: string): void {
 	const hadOverride = localOverrides.delete(id);
 	const meta = localAppMetas.get(id);
-	if (meta) {
-		devRemoteModules.delete(meta.moduleId);
-		persistDevOwned();
-	}
+	if (meta) devRemoteModules.delete(meta.moduleId);
 	if (localAppMetas.delete(id)) localAppsListener?.();
 	if (hadOverride) {
 		console.log(`[appLoader] Local override removed for "${id}"`);
@@ -314,21 +304,36 @@ export function unregisterLocalApp(id: string): void {
  * @param entry - The dev server's remoteEntry.js URL.
  */
 export function registerDevRemote(appId: string, moduleId: string, name: string, entry: string): void {
-	// First takeover of a module the MANIFEST already registered this boot:
-	// the container may be half-initialized and force-overriding it corrupts
-	// its shared getters. Persist ownership and reboot — the next boot skips
-	// the manifest registration, making the dev entry the FIRST and ONLY
-	// registration this container ever sees.
-	if (registeredEntries.has(moduleId) && !devRemoteModules.has(moduleId)) {
-		devRemoteModules.add(moduleId);
-		persistDevOwned();
-		console.log(`[appLoader] taking dev ownership of manifest-registered "${moduleId}" — rebooting for a clean container`);
-		window.location.reload();
-		return;
+	// Injection for a container the manifest registered AND that has already
+	// LOADED this document: a loaded container is committed to its version
+	// (repointing it corrupts its consume-shared getters), so only a reboot
+	// can hand the dev entry a clean container. Normally unreachable — the
+	// dev-preview boot skips the locked app's manifest registration, so the
+	// injection lands first — this covers a lock/injection mismatch. The
+	// reboot is time-bounded per module: without persisted ownership the
+	// next boot may register the module from the manifest again, and an
+	// unbounded reload here would loop. A recurrence inside the guard
+	// window degrades to the force-registration below instead.
+	if (registeredEntries.has(moduleId) && !devRemoteModules.has(moduleId) && loadedModules.has(moduleId)) {
+		const TAKEOVER_GUARD_MS = 60_000;
+		let reboot = false;
+		try {
+			const key = `rr:devTakeoverAt:${moduleId}`;
+			const last = Number(sessionStorage.getItem(key) ?? 0);
+			if (Date.now() - last > TAKEOVER_GUARD_MS) {
+				sessionStorage.setItem(key, String(Date.now()));
+				reboot = true;
+			}
+		} catch { /* storage unavailable — cannot bound a reload loop, so never reload */ }
+		if (reboot) {
+			console.log(`[appLoader] dev registration for loaded container "${moduleId}" — rebooting once for a clean container`);
+			window.location.reload();
+			return;
+		}
+		console.error(`[appLoader] dev takeover of loaded container "${moduleId}" recurred within the guard window — force-registering in place; its shared getters may be stale`);
 	}
 
 	devRemoteModules.add(moduleId);
-	persistDevOwned();
 	registerRemotes([{ name: moduleId, entry }], { force: true });
 	registeredEntries.set(moduleId, entry);
 	registerLocalApp(
@@ -361,6 +366,32 @@ export function registerDevRemote(appId: string, moduleId: string, name: string,
 const devRegisteredApps = new Set<string>();
 /** Pending load releases per app id, resolved by registerDevRemote. */
 const devRemoteWaiters = new Map<string, Array<() => void>>();
+/**
+ * Manifest entries the dev-preview boot skipped for the session-locked app
+ * (appId → container + URL), stashed so the dev-remote wait can fall back
+ * to the published bundle when no injection ever arrives.
+ */
+const skippedManifestEntries = new Map<string, { moduleId: string; url: string }>();
+
+/**
+ * Last-resort registration of a dev-skipped app from its stashed manifest
+ * entry. The boot skip assumes the embedder's injection will arrive; when
+ * it never does (dev server dead, lock mismatch), registering the published
+ * bundle beats a permanently dead app. No-op once a real dev registration
+ * has arrived, or when nothing was skipped.
+ *
+ * @param appId - The preview-locked app id whose dev-remote wait timed out.
+ * @returns True when the manifest fallback was registered.
+ */
+export function fallbackSkippedRemote(appId: string): boolean {
+	if (devRegisteredApps.has(appId)) return false;
+	const stash = skippedManifestEntries.get(appId);
+	if (!stash) return false;
+	registerRemotes([{ name: stash.moduleId, entry: stash.url }], { force: true });
+	registeredEntries.set(stash.moduleId, stash.url);
+	console.warn(`[appLoader] dev remote for "${appId}" never registered — falling back to the published bundle at ${stash.url}`);
+	return true;
+}
 
 /**
  * Whether this page is an embedded dev preview (`rrdev=1`, or the session
@@ -585,7 +616,21 @@ export function registerAndMapApps(serverApps: ServerAppEntry[]): AppManifestEnt
 	// force: true overwrites any previously registered remotes (e.g. from
 	// the pre-auth probe) with the post-auth set. Dev-owned containers are
 	// NEVER (re)registered from the manifest — the dev entry stays live.
-	const registrable = resolved.filter(({ app }) => !devRemoteModules.has(app.moduleId));
+	//
+	// A dev-preview page additionally skips its SESSION-LOCKED app: the
+	// embedder's injection must be that container's FIRST registration
+	// (force-overriding an initialized container corrupts its consume-shared
+	// getters). Derived fresh per call from the URL/session lock — never
+	// persisted — so the skip cannot leak to other apps or outlive the
+	// preview. The skipped entry is stashed for the dev-remote wait's
+	// manifest fallback (fallbackSkippedRemote).
+	const lockedAppId = isDevPreviewPage() ? previewLockedAppId() : '';
+	const registrable = resolved.filter(({ app }) => !devRemoteModules.has(app.moduleId) && app.id !== lockedAppId);
+	for (const { app, url } of resolved) {
+		if (app.id === lockedAppId && !devRemoteModules.has(app.moduleId)) {
+			skippedManifestEntries.set(app.id, { moduleId: app.moduleId, url });
+		}
+	}
 	registerRemotes(
 		registrable.map(({ app, url }) => ({ name: app.moduleId, entry: url })),
 		{ force: true },


### PR DESCRIPTION
## Problem

Apps previously opened in the App Builder could no longer be launched in any dev preview: clicking their tile died with Module Federation `RUNTIME-004 "Failed to locate remote"`, and the only recovery was clearing sessionStorage by hand in DevTools.

Root cause: dev-owned container ownership was persisted in `sessionStorage['rr:devOwnedModules']` on a per-browser-tab assumption. A VS Code window is one browsing context, so every App Builder preview iframe against the same engine origin shares a single sessionStorage (it survives editor tabs closing and even workspace switches). The set therefore accumulated every app ever designed in the window; `registerAndMapApps` skipped manifest registration for all of them, while only the currently-designed app receives a dev injection - leaving the rest listed in the manifest with no registered container.

Diagnosed live: the poisoned set read `["rocketride_hello","rocketride_monitor","rocketride_explorer","rocketride_home","rocketride_admin","rocketride_benchmark","rocketride_appAdmin"]` while the host instance carried registrations for everything else.

## Fix

The persisted state was redundant - the shell can derive everything it was trying to remember:

- **Dev ownership is page-lifetime, in-memory only.** The legacy sessionStorage key is deleted at module init, so already-poisoned windows heal on their next boot with no user action and nothing to document.
- **The boot skip is derived, not stored:** a dev-preview page skips the manifest registration of exactly its session-locked app (`previewLockedAppId()`), computed fresh on every `registerAndMapApps` call. The injection stays the container's first registration - the original goal of the persistence - and the take-ownership-and-reload cycle disappears from the normal design flow.
- **Takeover reload bounded:** it now fires only for containers that have actually loaded (an unloaded container is safe to repoint in place, the rule `repointRemote`/`resetRemote` already encode) and is time-bounded per module, so a lock/injection mismatch degrades to an in-place force registration instead of a reload loop.
- **Self-heal fallback:** the skipped manifest entry is stashed; if the dev-remote wait times out, `fallbackSkippedRemote()` registers the published bundle so the app loads a stale build instead of nothing. The error only surfaces when there is no fallback.

Production pages are untouched: outside a dev preview the locked-app id is empty and registration follows the exact old path.

## Verification

- `builder shell:clean shell:build` passes (type check + both flavors + stitch + pack).
- Failure signature and mechanism confirmed at runtime before the fix: one healthy `rocketride_shell` host instance, failing apps present in the manifest but absent from its remotes, exactly matching the persisted dev-owned set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev-preview startup reliability when a development remote does not register in time.
  * Automatically loads the available published version when the development version cannot be reached, instead of leaving the app unavailable.
  * Reduced unnecessary page reloads during development remote updates and prevented repeated reload loops.
  * Cleared outdated development-remote state between page sessions to avoid stale registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->