### PR TITLE
feat(nodes): node distribution — publish, pin and resolve a node at run time

### DIFF
--- a/packages/ai/src/ai/account/deploy_common.py
+++ b/packages/ai/src/ai/account/deploy_common.py
@@ -1,0 +1,43 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+# =============================================================================
+# DEPLOY COMMON — the ground the deploy rails share
+#
+# Publishing an app and publishing a node ask the same four questions: who is
+# the caller, which org does this write land in, which audience does this
+# target name, and is this zip safe to open. app_deploy answered them first,
+# so the answers live there.
+#
+# This module is the ONE place that reaches into them. The coupling is real
+# either way; keeping it in a single import means a rename breaks one line
+# with a clear message, instead of six scattered call sites.
+#
+# Lifting the implementations here outright is the right end state and is a
+# separate piece of work: it moves ~180 lines out of a file that shipped days
+# ago, and the file's author should have the say on when that churn is worth
+# it. Nothing else has to change when it happens — callers already use the
+# public names they will keep.
+# =============================================================================
+
+"""Identity, audience and archive helpers shared by the deploy rails."""
+
+from __future__ import annotations
+
+from ai.account.app_deploy import _actor_of as actor_of
+from ai.account.app_deploy import _developer_id_of as developer_id_of
+from ai.account.app_deploy import _org_of as org_of
+from ai.account.app_deploy import _resolve_target as resolve_target
+from ai.account.app_deploy import _zip_guard as zip_guard
+from ai.account.app_deploy import _ZIP_MAX_ZIPPED as ZIP_MAX_ZIPPED
+
+__all__ = [
+    'ZIP_MAX_ZIPPED',
+    'actor_of',
+    'developer_id_of',
+    'org_of',
+    'resolve_target',
+    'zip_guard',
+]

--- a/packages/ai/src/ai/account/deploy_common.py
+++ b/packages/ai/src/ai/account/deploy_common.py
@@ -26,6 +26,7 @@
 
 from __future__ import annotations
 
+from ai.account.app_deploy import _RUNG_RANK as RUNG_RANK
 from ai.account.app_deploy import _actor_of as actor_of
 from ai.account.app_deploy import _developer_id_of as developer_id_of
 from ai.account.app_deploy import _org_of as org_of
@@ -34,6 +35,7 @@ from ai.account.app_deploy import _zip_guard as zip_guard
 from ai.account.app_deploy import _ZIP_MAX_ZIPPED as ZIP_MAX_ZIPPED
 
 __all__ = [
+    'RUNG_RANK',
     'ZIP_MAX_ZIPPED',
     'actor_of',
     'developer_id_of',

--- a/packages/ai/src/ai/account/deploy_common.py
+++ b/packages/ai/src/ai/account/deploy_common.py
@@ -31,6 +31,7 @@ from ai.account.app_deploy import _actor_of as actor_of
 from ai.account.app_deploy import _developer_id_of as developer_id_of
 from ai.account.app_deploy import _org_of as org_of
 from ai.account.app_deploy import _resolve_target as resolve_target
+from ai.account.app_deploy import _team_ids_of as team_ids_of
 from ai.account.app_deploy import _zip_guard as zip_guard
 from ai.account.app_deploy import _ZIP_MAX_ZIPPED as ZIP_MAX_ZIPPED
 
@@ -41,5 +42,6 @@ __all__ = [
     'developer_id_of',
     'org_of',
     'resolve_target',
+    'team_ids_of',
     'zip_guard',
 ]

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -1,0 +1,238 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Node deployments — the node branch of the generic ``rrext_deploy add`` rail.
+
+Nodes ride the SAME registry apps and pipes use (``deployment_backend``:
+immutable versioned artifacts under ``orgs/<org>/files/.deployments/<key>/``).
+Nothing here is a parallel mechanism; this module is the ``kind:'node'``
+adapter, the way ``app_deploy`` is the ``kind:'app'`` one.
+
+What a node deployment is:
+
+- The ARTIFACT is a small ``kind:'node'`` JSON record — node id, display name,
+  version, runtime, and the digest of the bundle. The registry pins metadata
+  and treats the record as opaque, exactly as it pins pipeline JSON.
+- The CONTENT is the node directory as a zip, retained at
+  ``<artifact sibling>/bundle/`` for provenance and unpacked into
+  ``.../source/`` — the tree the engine materializes from at run time.
+
+Unlike an app, a Python node needs no server-side build: the source IS what
+runs. The lifecycle field is still recorded, because native nodes (#1577) will
+ship compiled libraries built against one engine toolchain and will need one.
+``runtime`` is carried from the first version for the same reason — a native
+node's content is per-platform, so the schema has to admit more than one
+artifact per version before such a node exists, not after.
+
+Shared platform infrastructure: works on the OSS local engine (single implicit
+org/user 'local') and SaaS alike.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any, Dict, List
+
+from rocketlib import debug
+
+# The zip guards live with the app rail and are shared verbatim: the threat is
+# the archive, not what it carries, and one implementation is one place to fix.
+from ai.account.app_deploy import _ZIP_MAX_ZIPPED, _actor_of, _org_of, _zip_guard
+from ai.account.deployment_backend import artifact_content_dir
+
+#: Node runtimes. 'python' is a source tree the engine imports as-is. 'native'
+#: is reserved for the compiled nodes of #1577, whose content is per-platform
+#: and tied to the engine build it was compiled against.
+RUNTIME_PYTHON = 'python'
+RUNTIME_NATIVE = 'native'
+
+#: The manifest a node zip must carry at its root — the node's own declaration,
+#: read for the id and name rather than trusting what the caller says it sent.
+NODE_MANIFEST = 'services.json'
+
+#: Cap on the manifest read before the archive guard has run.
+_MANIFEST_MAX = 512 * 1024
+
+
+def _safe_node_id(value: str) -> str:
+    """A node id is a path segment in the store, so it is validated like one."""
+    node_id = str(value or '').strip()
+    if not node_id:
+        raise ValueError('the node manifest carries no id')
+    if len(node_id) > 128:
+        raise ValueError(f'node id is too long: {node_id[:32]!r}...')
+    for bad in ('/', '\\', ':', '..'):
+        if bad in node_id:
+            raise ValueError(f'node id has an unsafe character ({bad!r}): {node_id!r}')
+    if node_id.startswith('.'):
+        raise ValueError(f'node id may not start with a dot: {node_id!r}')
+    return node_id
+
+
+def _manifest_of_zip(archive: Any) -> Dict[str, Any]:
+    """Read the node's own ``services.json`` from the zip root.
+
+    The declaration inside the archive is the truth: taking the id from the
+    request would let a caller publish under a name the zip does not carry.
+    """
+    import json
+
+    names = [n for n in archive.namelist() if n.replace('\\', '/') == NODE_MANIFEST]
+    if not names:
+        raise ValueError(f'the zip has no {NODE_MANIFEST} at its root')
+    try:
+        with archive.open(names[0]) as handle:
+            raw = handle.read(_MANIFEST_MAX + 1)
+    except Exception:
+        raise ValueError(f'{NODE_MANIFEST} could not be read')
+    if len(raw) > _MANIFEST_MAX:
+        raise ValueError(f'{NODE_MANIFEST} exceeds the {_MANIFEST_MAX}-byte cap')
+    try:
+        manifest = json.loads(raw)
+    except Exception as exc:
+        raise ValueError(f'{NODE_MANIFEST} is not valid JSON: {exc}')
+    if not isinstance(manifest, dict):
+        raise ValueError(f'{NODE_MANIFEST} must be an object')
+    return manifest
+
+
+async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
+    """The node branch of ``rrext_deploy add``: publish a node version.
+
+    Receives ONE zip of the node directory via the binary ``arguments.data``
+    frame, checks it, registers an immutable version, and lays the content
+    down beside the artifact:
+
+        <artifact sibling>/bundle/<nodeId>-v<NNNNNN>.zip   retained transport
+        <artifact sibling>/source/...                      unpacked tree
+
+    Publishing does NOT make the node reachable: the version is inert until a
+    rung is pinned to it, the same rule apps follow.
+    """
+    from ai.account import account
+
+    info = getattr(conn, '_account_info', None)
+    if not info or not getattr(info, 'userId', None):
+        return conn.build_error(request, 'deploying a node requires an authenticated connection')
+
+    args = request.get('arguments', {}) or {}
+    org_id = _org_of(conn)
+    comment = str(args.get('comment', '') or '')
+
+    data = args.get('data')
+    if not data:
+        return conn.build_error(request, 'data (the node directory zip) is required')
+    # A str here would make zipfile raise TypeError and escape as a 500 rather
+    # than a clean DAP error, so bytes-like inputs are normalised and the rest
+    # refused outright.
+    if isinstance(data, (bytearray, memoryview)):
+        data = bytes(data)
+    elif not isinstance(data, bytes):
+        return conn.build_error(request, 'data must be a binary zip frame (bytes), not text')
+    # Measured on the zipped bytes and refused before any parsing: a node
+    # directory is small, and the unpacked guard below still applies.
+    if len(data) > _ZIP_MAX_ZIPPED:
+        return conn.build_error(
+            request,
+            f'node zip is {len(data) // (1024 * 1024)} MB — the upload cap is '
+            f'{_ZIP_MAX_ZIPPED // (1024 * 1024)} MB zipped',
+        )
+
+    import io
+    import zipfile
+
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        return conn.build_error(request, 'data is not a valid zip archive')
+
+    try:
+        manifest = _manifest_of_zip(archive)
+        node_id = _safe_node_id(manifest.get('protocol', '').replace('://', '') or manifest.get('id', ''))
+    except ValueError as exc:
+        return conn.build_error(request, str(exc))
+
+    # Traversal and bombs are refused BEFORE a registry row exists, so a bad
+    # archive never leaves a version behind.
+    guard_error = _zip_guard(archive)
+    if guard_error:
+        return conn.build_error(request, guard_error)
+
+    node_version = str(manifest.get('version') or '0.0.0')
+    artifact = {
+        'kind': 'node',
+        'nodeId': node_id,
+        'name': str(manifest.get('title') or node_id),
+        'nodeVersion': node_version,
+        # Carried from the first version: a native node's content is
+        # per-platform, and a resolver has to know what it is fetching before
+        # it fetches it.
+        'runtime': RUNTIME_PYTHON,
+        'bundleSha256': hashlib.sha256(data).hexdigest(),
+    }
+    caller_meta = args.get('metadata') if isinstance(args.get('metadata'), dict) else {}
+    metadata = {
+        **caller_meta,
+        'manifest': manifest,
+        # A python node's source IS what runs, so it is born ready. The field
+        # exists because native nodes will not be.
+        'build': {'status': 'ready', 'readyAt': time.time()},
+    }
+
+    entry = await account.deployments_publish(
+        org_id, node_id, artifact, _actor_of(conn), comment=comment, metadata=metadata
+    )
+    version = int(entry.get('version', 0))
+
+    # ── Content beside the artifact, through the Store interface ──────────
+    from ai.account.models import RequestContext
+    from ai.account.store import Store
+
+    fs = Store.file_store(RequestContext.internal('node-deploy'), client_id=info.userId)
+    written: List[str] = []
+    try:
+        content_root = artifact_content_dir(str(entry.get('artifactPath') or ''))
+        org_prefix = f'orgs/{org_id}/files/'
+        if not content_root.startswith(org_prefix):
+            raise ValueError(f'registry entry carries no usable artifactPath ({content_root!r})')
+        home = f'@/Org/={org_id}/{content_root[len(org_prefix) :]}'
+
+        path = f'{home}/bundle/{node_id}-v{version:06d}.zip'
+        # Recorded BEFORE the write: a write that fails partway still leaves
+        # bytes behind, and the compensation loop only deletes what it knows.
+        written.append(path)
+        await fs.write(path, bytes(data))
+
+        for item in archive.infolist():
+            if item.is_dir():
+                continue
+            path = f'{home}/source/{item.filename}'
+            written.append(path)
+            await fs.write(path, archive.read(item))
+    except Exception as exc:
+        # The registry row is allocated before the content writes, because
+        # version allocation is what names these paths. A failure here would
+        # otherwise strand a version with no bytes behind it.
+        for path in written:
+            try:
+                await fs.delete(path)
+            except Exception:
+                pass  # best-effort; the 'failed' state is what gates serving
+        try:
+            await account.set_artifact_state(org_id, node_id, version, 'failed', _actor_of(conn))
+        except Exception:
+            pass
+        return conn.build_error(request, f'node content could not be stored: {exc}')
+
+    debug(f'[node_deploy] published {node_id} v{node_version} as registry v{version}')
+    await account.audit(
+        info.userId,
+        'deploy',
+        'node_add',
+        request_data={'nodeId': node_id, 'version': version},
+        org_id=org_id,
+    )
+    return conn.build_response(request, body={'artifact': entry, 'orgId': org_id})

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -61,6 +61,20 @@ NODE_MANIFEST = 'services.json'
 #: Cap on the manifest read before the archive guard has run.
 _MANIFEST_MAX = 512 * 1024
 
+#: A node declares its Python dependencies the way every in-tree node does —
+#: one requirements.txt at the root of its directory. 116 of the 139 nodes in
+#: the tree carry one, so a node WITH dependencies is the normal case.
+NODE_REQUIREMENTS = 'requirements.txt'
+
+#: An overrides.txt does not add a dependency, it REPLACES what packages
+#: themselves declare, and the engine sweeps it engine-wide. A published node
+#: carrying one would rewrite dependency resolution for everything else in the
+#: process, so it is refused rather than published.
+NODE_OVERRIDES = 'overrides.txt'
+
+#: Cap on the requirements read, same reasoning as the manifest cap.
+_REQUIREMENTS_MAX = 64 * 1024
+
 
 def _safe_node_id(value: str) -> str:
     """A node id is a path segment in the store, so it is validated like one."""
@@ -102,6 +116,31 @@ def _manifest_of_zip(archive: Any) -> Dict[str, Any]:
     if not isinstance(manifest, dict):
         raise ValueError(f'{NODE_MANIFEST} must be an object')
     return manifest
+
+
+def _requirements_of_zip(archive: Any) -> List[str]:
+    """The node's own ``requirements.txt`` at the zip root, as declared lines.
+
+    Recorded on the artifact so anything resolving the node knows what it needs
+    BEFORE fetching the bundle. Comments and blank lines are dropped; nothing
+    else is interpreted here — pinning policy belongs to whoever installs.
+    """
+    names = [n for n in archive.namelist() if n.replace('\\', '/') == NODE_REQUIREMENTS]
+    if not names:
+        return []
+    try:
+        with archive.open(names[0]) as handle:
+            raw = handle.read(_REQUIREMENTS_MAX + 1)
+    except Exception:
+        raise ValueError(f'{NODE_REQUIREMENTS} could not be read')
+    if len(raw) > _REQUIREMENTS_MAX:
+        raise ValueError(f'{NODE_REQUIREMENTS} exceeds the {_REQUIREMENTS_MAX}-byte cap')
+    lines: List[str] = []
+    for line in raw.decode('utf-8', 'replace').splitlines():
+        entry = line.strip()
+        if entry and not entry.startswith('#'):
+            lines.append(entry)
+    return lines
 
 
 async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
@@ -157,8 +196,19 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
     try:
         manifest = _manifest_of_zip(archive)
         node_id = _safe_node_id(manifest.get('protocol', '').replace('://', '') or manifest.get('id', ''))
+        requirements = _requirements_of_zip(archive)
     except ValueError as exc:
         return conn.build_error(request, str(exc))
+
+    # Refused before anything is registered: an overrides file replaces what
+    # other packages declare, engine-wide, so one published node could rewrite
+    # dependency resolution for every other node in the process.
+    if any(name.replace('\\', '/') == NODE_OVERRIDES for name in archive.namelist()):
+        return conn.build_error(
+            request,
+            f'a node may not publish a {NODE_OVERRIDES}: it would replace dependency '
+            f'resolution engine-wide. Declare what the node needs in {NODE_REQUIREMENTS}.',
+        )
 
     # Traversal and bombs are refused BEFORE a registry row exists, so a bad
     # archive never leaves a version behind.
@@ -177,6 +227,10 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
         # it fetches it.
         'runtime': RUNTIME_PYTHON,
         'bundleSha256': hashlib.sha256(data).hexdigest(),
+        # What the node needs installed, from its own requirements.txt. On the
+        # artifact rather than only inside the bundle so a resolver can decide
+        # whether it can run this node before it downloads it.
+        'requirements': requirements,
     }
     caller_meta = args.get('metadata') if isinstance(args.get('metadata'), dict) else {}
     metadata = {

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -41,7 +41,15 @@ from rocketlib import debug
 # Identity, audiences and the zip guards are shared verbatim with the app rail
 # through deploy_common — the threat is the archive, not what it carries, and
 # an audience means the same thing whichever kind is being published.
-from ai.account.deploy_common import ZIP_MAX_ZIPPED, actor_of, developer_id_of, org_of, resolve_target, zip_guard
+from ai.account.deploy_common import (
+    RUNG_RANK,
+    ZIP_MAX_ZIPPED,
+    actor_of,
+    developer_id_of,
+    org_of,
+    resolve_target,
+    zip_guard,
+)
 from ai.account.deployment_backend import artifact_content_dir
 
 #: Node runtimes. 'python' is a source tree the engine imports as-is. 'native'
@@ -512,3 +520,83 @@ def _snapshot(entry: Dict[str, Any], artifact: Dict[str, Any]) -> Dict[str, Any]
         'runtime': artifact.get('runtime', RUNTIME_PYTHON),
         'sha256': entry.get('sha256', ''),
     }
+
+
+# =============================================================================
+# AVAILABILITY — which nodes a caller has, and at which version
+# =============================================================================
+#
+# The scope walk apps take, over node bindings. This is the ONE answer to
+# "which nodes can this caller use": the picker offers what it returns, and the
+# run-time resolver fetches what it names. Two implementations would eventually
+# disagree, and a designer offering a node the run then refuses is worse than
+# not offering it at all.
+
+
+async def resolve_node_pins(org_id: str, user_id: str | None, team_ids: List[str]) -> List[Dict[str, Any]]:
+    """Every node the caller can use, newest binding per node id.
+
+    Walks public, then each team, then the user. On a node-id collision the
+    MORE SPECIFIC rung wins (user > team > public); a same-rung tie breaks on
+    the lowest org id, so a stray public row can never displace a lower org's
+    claim on a name.
+
+    A binding only serves when it is enabled AND its version is serveable:
+    public reach demands a 'ready' version, internal reach accepts anything
+    that did not fail. That gate matters more later than now — a Python node
+    is born ready, a compiled one will not be.
+    """
+    from ai.account import account
+
+    audiences: List[Dict[str, str]] = [{'type': 'public', 'id': ''}]
+    audiences += [{'type': 'team', 'id': tid} for tid in team_ids]
+    if user_id:
+        audiences.append({'type': 'user', 'id': user_id})
+    try:
+        rows = await account.publish_list(org_id, KIND_NODE, audiences)
+    except Exception as exc:
+        debug(f'[node_deploy] publish_list failed: {exc}')
+        return []
+
+    # Sort so the winner lands LAST and the dict write below keeps it: rung
+    # ascending, org id DESCENDING within a rung.
+    rows = sorted(rows or [], key=lambda r: str(r.get('orgId') or ''), reverse=True)
+    rows.sort(key=lambda r: RUNG_RANK.get((r.get('audience') or {}).get('type', ''), 0))
+
+    resolved: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        if row.get('state') != 'enabled':
+            continue
+        audience_type = (row.get('audience') or {}).get('type', '')
+        artifact_state = row.get('artifactState') or ''
+        if audience_type == 'public':
+            if artifact_state != 'ready':
+                continue
+        elif artifact_state == 'failed':
+            continue
+        node_id = row.get('nodeId') or ''
+        version = row.get('version')
+        if not node_id or not isinstance(version, int):
+            continue
+        row_org = str(row.get('orgId') or org_id)
+        try:
+            artifact = await account.deployments_artifact(row_org, node_id, version)
+        except Exception:
+            continue
+        if not isinstance(artifact, dict) or artifact.get('kind') != KIND_NODE:
+            continue
+        snapshot = row.get('snapshot') or {}
+        resolved[node_id] = {
+            'id': node_id,
+            'name': snapshot.get('name') or artifact.get('name') or node_id,
+            'version': version,
+            'nodeVersion': artifact.get('nodeVersion', ''),
+            'runtime': artifact.get('runtime', RUNTIME_PYTHON),
+            # Carried so a caller can tell whether it can run this node before
+            # it fetches a single byte of it.
+            'requirements': artifact.get('requirements') or [],
+            'bundleSha256': artifact.get('bundleSha256', ''),
+            'orgId': row_org,
+            'rung': 'personal' if audience_type == 'user' else audience_type,
+        }
+    return list(resolved.values())

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -40,7 +40,7 @@ from rocketlib import debug
 
 # The zip guards live with the app rail and are shared verbatim: the threat is
 # the archive, not what it carries, and one implementation is one place to fix.
-from ai.account.app_deploy import _ZIP_MAX_ZIPPED, _actor_of, _org_of, _zip_guard
+from ai.account.app_deploy import _ZIP_MAX_ZIPPED, _actor_of, _org_of, _resolve_target, _zip_guard
 from ai.account.deployment_backend import artifact_content_dir
 
 #: Node runtimes. 'python' is a source tree the engine imports as-is. 'native'
@@ -48,6 +48,10 @@ from ai.account.deployment_backend import artifact_content_dir
 #: and tied to the engine build it was compiled against.
 RUNTIME_PYTHON = 'python'
 RUNTIME_NATIVE = 'native'
+
+#: The registry kind these artifacts carry — the discriminator every
+#: publish_* call takes, so node bindings never mix with app ones.
+KIND_NODE = 'node'
 
 #: The manifest a node zip must carry at its root — the node's own declaration,
 #: read for the id and name rather than trusting what the caller says it sent.
@@ -163,7 +167,7 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
 
     node_version = str(manifest.get('version') or '0.0.0')
     artifact = {
-        'kind': 'node',
+        'kind': KIND_NODE,
         'nodeId': node_id,
         'name': str(manifest.get('title') or node_id),
         'nodeVersion': node_version,
@@ -264,6 +268,44 @@ def _node_rail_entry(entry: Dict[str, Any], artifact: Dict[str, Any] | None) -> 
     }
 
 
+def _assert_may_expose(conn: Any, node_id: str, audience: Dict[str, Any]) -> None:
+    """Check the caller may expose this node at this reach.
+
+    Reach is what decides the bar, and ``_resolve_target`` has already applied
+    most of it: ``@me`` is your own id, ``@team/<x>`` refuses a team you do not
+    belong to, and ``@public`` refuses an org with no registered developer id.
+
+    What is added here is OWNERSHIP at the public rung. Private reach needs no
+    namespace: the registry is partitioned by org, so two orgs holding a node
+    called ``csv_split`` never see each other's. Public reach is one shared
+    space, so a node offered there must sit in the org's own developer
+    namespace — otherwise the first org to publish ``csv_split`` would own the
+    name for everyone.
+
+    Nodes are NOT namespaced like apps in general: they are named by their
+    protocol (``store_chroma``, ``llm_openai``), and requiring
+    ``<developerId>.<name>`` everywhere would break that convention for a
+    problem that only exists in public.
+
+    Raises:
+        ValueError: public reach for a node outside the org's namespace.
+    """
+    if audience.get('type') != 'public':
+        return
+    from ai.account.app_deploy import _developer_id_of
+
+    dev = _developer_id_of(conn)
+    if not dev:
+        # _resolve_target refuses this first; kept so the guard holds alone.
+        raise ValueError('Publishing a node publicly requires the organization to be registered as a developer')
+    if node_id != dev and not node_id.startswith(f'{dev}.'):
+        raise ValueError(
+            f'{node_id!r} is outside your developer namespace — a node offered publicly must be '
+            f'named {dev!r} or {dev}.<name>, so two organizations can never contend for the same '
+            'public node id. Private reach (@me, @team) has no such requirement.'
+        )
+
+
 async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
     """Handle ``rrext_deploy_node`` — node publish control on the registry.
 
@@ -275,6 +317,12 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
       update, and rollback are all this one verb; pinning is what makes a
       published version reachable at all.
     - ``where``    — the reverse index: which audience holds which version.
+    - ``disable``  — stop serving one binding; reversible by binding again.
+    - ``remove``   — take the binding out of the listing.
+
+    Withdrawal acts on the BINDING, never on the version: a published version
+    is immutable and stays available to bind again, which is what keeps
+    rollback possible.
 
     Requires an authenticated connection; the org comes from the session.
     """
@@ -306,22 +354,70 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
         if not isinstance(version, int):
             return conn.build_error(request, 'version (the registry version number) is required')
         try:
-            from ai.account.app_deploy import _resolve_target
-
             audience = _resolve_target(conn, str(args.get('target') or '@me'))
         except ValueError as exc:
             return conn.build_error(request, str(exc))
-        record = await account.deployments_deploy(org_id, audience['id'], node_id, version, _actor_of(conn))
-        debug(f'[node_deploy] pinned {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
-        return conn.build_response(request, body={'deployment': record, 'audience': audience})
+        try:
+            _assert_may_expose(conn, node_id, audience)
+        except ValueError as exc:
+            return conn.build_error(request, str(exc))
+        entry = await _entry_of(account, org_id, node_id, version)
+        if not entry:
+            return conn.build_error(request, f'{node_id} has no registry version {version}')
+        artifact = await account.deployments_artifact(org_id, node_id, version)
+        if not isinstance(artifact, dict) or artifact.get('kind') != KIND_NODE:
+            return conn.build_error(request, f'Registry version {version} of {node_id} is not a node artifact')
+        # A pure pointer, born enabled — the same publish row shape apps bind.
+        row = await account.publish_set(
+            org_id, KIND_NODE, node_id, audience, version, _snapshot(entry, artifact), _actor_of(conn)
+        )
+        debug(f'[node_deploy] bound {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
+        return conn.build_response(request, body={'publish': row, 'audience': audience})
 
     if sub == 'where':
-        deployments = await account.deployments_list(org_id, '')
-        pins = [
-            {'audience': dep.get('teamId') or dep.get('team_id') or '', 'version': dep.get('version')}
-            for dep in deployments or []
-            if (dep.get('projectId') or dep.get('project_id')) == node_id
-        ]
-        return conn.build_response(request, body={'pins': pins})
+        rows = await account.publish_of_app(org_id, KIND_NODE, node_id)
+        return conn.build_response(request, body={'pins': rows or []})
+
+    # ── disable / remove — stop serving a binding ─────────────────────────
+    #
+    # A published VERSION is immutable and never disappears: what is withdrawn
+    # is the binding that points an audience at it. 'disable' is reversible by
+    # binding again; 'remove' takes the row out of the listing. Neither
+    # touches the artifact, so a rollback to that version stays possible.
+    if sub in ('disable', 'remove'):
+        try:
+            audience = _resolve_target(conn, str(args.get('target') or '@me'))
+        except ValueError as exc:
+            return conn.build_error(request, str(exc))
+        try:
+            _assert_may_expose(conn, node_id, audience)
+        except ValueError as exc:
+            return conn.build_error(request, str(exc))
+        state = 'disabled' if sub == 'disable' else 'removed'
+        try:
+            row = await account.publish_set_state(org_id, KIND_NODE, node_id, audience, state, _actor_of(conn))
+        except Exception as exc:
+            return conn.build_error(request, str(exc))
+        debug(f'[node_deploy] {state} {node_id} for {audience.get("type")}:{audience.get("id")}')
+        return conn.build_response(request, body={'publish': row, 'audience': audience})
 
     return conn.build_error(request, f'Unknown subcommand: {sub!r}')
+
+
+async def _entry_of(account: Any, org_id: str, node_id: str, version: int) -> Dict[str, Any] | None:
+    """One registry row of a node by version, or None."""
+    for entry in await account.deployments_versions(org_id, node_id) or []:
+        if int(entry.get('version', 0)) == version:
+            return entry
+    return None
+
+
+def _snapshot(entry: Dict[str, Any], artifact: Dict[str, Any]) -> Dict[str, Any]:
+    """The display facts a binding carries so a listing needs no second read."""
+    return {
+        'nodeId': artifact.get('nodeId', ''),
+        'name': artifact.get('name', ''),
+        'nodeVersion': artifact.get('nodeVersion', ''),
+        'runtime': artifact.get('runtime', RUNTIME_PYTHON),
+        'sha256': entry.get('sha256', ''),
+    }

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -48,6 +48,7 @@ from ai.account.deploy_common import (
     developer_id_of,
     org_of,
     resolve_target,
+    team_ids_of,
     zip_guard,
 )
 from ai.account.deployment_backend import artifact_content_dir
@@ -382,6 +383,27 @@ def _assert_may_expose(conn: Any, node_id: str, audience: Dict[str, Any]) -> Non
         )
 
 
+#: Withdraw from every audience at once, rather than one call per binding.
+TARGET_ALL = '@all'
+
+
+def _assert_may_withdraw(conn: Any, node_id: str, audience: Dict[str, Any]) -> None:
+    """Check the caller may withdraw a binding that already exists.
+
+    Same bar as granting it. The single-audience path gets this for free —
+    ``resolve_target`` refuses a team you are not in before an audience is even
+    built — but ``@all`` reads its audiences back from the registry, where they
+    arrive already resolved, so membership has to be re-checked here.
+
+    Raises:
+        ValueError: a team the caller is not in, or public reach they may not
+                    grant.
+    """
+    if audience.get('type') == 'team' and str(audience.get('id') or '') not in set(team_ids_of(conn).values()):
+        raise ValueError(f'{node_id} is bound to a team you are not a member of')
+    _assert_may_expose(conn, node_id, audience)
+
+
 def _deploy_target_of(raw: str) -> str:
     """The wire target behind ``deployTo``: a bare team name or id means a team.
 
@@ -484,15 +506,38 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
     # binding again; 'remove' takes the row out of the listing. Neither
     # touches the artifact, so a rollback to that version stays possible.
     if sub in ('disable', 'remove'):
+        state = 'disabled' if sub == 'disable' else 'removed'
+        target = str(args.get('target') or '@me')
+
+        if target == TARGET_ALL:
+            rows = await account.publish_of_app(org_id, KIND_NODE, node_id) or []
+            audiences = [row.get('audience') or {} for row in rows if row.get('state') != 'removed']
+            if not audiences:
+                return conn.build_response(request, body={'publish': [], 'audiences': []})
+            # EVERY audience is checked before ANY is touched. Withdrawing half
+            # of them and stopping would leave the node reachable exactly where
+            # the caller wanted it gone — the worst outcome available here.
+            try:
+                for audience in audiences:
+                    _assert_may_withdraw(conn, node_id, audience)
+            except ValueError as exc:
+                return conn.build_error(request, str(exc))
+            withdrawn: List[Dict[str, Any]] = []
+            for audience in audiences:
+                withdrawn.append(
+                    await account.publish_set_state(org_id, KIND_NODE, node_id, audience, state, actor_of(conn))
+                )
+            debug(f'[node_deploy] {state} {node_id} for all {len(withdrawn)} audience(s)')
+            return conn.build_response(request, body={'publish': withdrawn, 'audiences': audiences})
+
         try:
-            audience = resolve_target(conn, str(args.get('target') or '@me'))
+            audience = resolve_target(conn, target)
         except ValueError as exc:
             return conn.build_error(request, str(exc))
         try:
             _assert_may_expose(conn, node_id, audience)
         except ValueError as exc:
             return conn.build_error(request, str(exc))
-        state = 'disabled' if sub == 'disable' else 'removed'
         try:
             row = await account.publish_set_state(org_id, KIND_NODE, node_id, audience, state, actor_of(conn))
         except Exception as exc:

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -236,3 +236,92 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
         org_id=org_id,
     )
     return conn.build_response(request, body={'artifact': entry, 'orgId': org_id})
+
+
+# =============================================================================
+# CONTROL — the rail for a published node: see it, pin it, find it
+# =============================================================================
+#
+# Publishing leaves an inert version. These are the verbs that make one
+# reachable, and they mirror the app control surface: targets are '@me',
+# '@team/<name-or-id>' and '@public'. There is no org rung — org is the
+# governance container, and org-wide distribution is a team an org admin
+# maintains.
+
+
+def _node_rail_entry(entry: Dict[str, Any], artifact: Dict[str, Any] | None) -> Dict[str, Any]:
+    """One row of a node's version rail: registry facts plus the node's own version."""
+    who = entry.get('publishedBy') or {}
+    return {
+        'registryVersion': entry.get('version'),
+        'nodeVersion': (artifact or {}).get('nodeVersion') or '',
+        'runtime': (artifact or {}).get('runtime') or RUNTIME_PYTHON,
+        'state': entry.get('state') or '',
+        'sha256': entry.get('sha256', ''),
+        'publishedAt': entry.get('publishedAt'),
+        'author': who.get('display') or who.get('email') or who.get('userId') or '',
+        'message': entry.get('comment', ''),
+    }
+
+
+async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle ``rrext_deploy_node`` — node publish control on the registry.
+
+    Subcommands:
+
+    - ``versions`` — the version rail for one node, newest first, with the
+      audiences currently pinned to each.
+    - ``deploy``   — pin an audience to a registry version. First release,
+      update, and rollback are all this one verb; pinning is what makes a
+      published version reachable at all.
+    - ``where``    — the reverse index: which audience holds which version.
+
+    Requires an authenticated connection; the org comes from the session.
+    """
+    from ai.account import account
+
+    info = getattr(conn, '_account_info', None)
+    if not info or not getattr(info, 'userId', None):
+        return conn.build_error(request, 'rrext_deploy_node requires an authenticated connection')
+
+    args = request.get('arguments', {}) or {}
+    sub = str(args.get('subcommand') or '')
+    node_id = str(args.get('nodeId') or '')
+    if not node_id:
+        return conn.build_error(request, 'nodeId is required')
+    org_id = _org_of(conn)
+
+    if sub == 'versions':
+        entries = await account.deployments_versions(org_id, node_id)
+        rail: List[Dict[str, Any]] = []
+        for entry in sorted(entries or [], key=lambda e: -int(e.get('version', 0))):
+            artifact = await account.deployments_artifact(org_id, node_id, int(entry.get('version', 0)))
+            rail.append(_node_rail_entry(entry, artifact))
+        return conn.build_response(request, body={'versions': rail})
+
+    if sub == 'deploy':
+        version = args.get('version')
+        # The registry version, not the node's own semver: two published
+        # versions can carry the same nodeVersion, and only one is this row.
+        if not isinstance(version, int):
+            return conn.build_error(request, 'version (the registry version number) is required')
+        try:
+            from ai.account.app_deploy import _resolve_target
+
+            audience = _resolve_target(conn, str(args.get('target') or '@me'))
+        except ValueError as exc:
+            return conn.build_error(request, str(exc))
+        record = await account.deployments_deploy(org_id, audience['id'], node_id, version, _actor_of(conn))
+        debug(f'[node_deploy] pinned {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
+        return conn.build_response(request, body={'deployment': record, 'audience': audience})
+
+    if sub == 'where':
+        deployments = await account.deployments_list(org_id, '')
+        pins = [
+            {'audience': dep.get('teamId') or dep.get('team_id') or '', 'version': dep.get('version')}
+            for dep in deployments or []
+            if (dep.get('projectId') or dep.get('project_id')) == node_id
+        ]
+        return conn.build_response(request, body={'pins': pins})
+
+    return conn.build_error(request, f'Unknown subcommand: {sub!r}')

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -38,9 +38,10 @@ from typing import Any, Dict, List, Tuple
 
 from rocketlib import debug
 
-# The zip guards live with the app rail and are shared verbatim: the threat is
-# the archive, not what it carries, and one implementation is one place to fix.
-from ai.account.app_deploy import _ZIP_MAX_ZIPPED, _actor_of, _org_of, _resolve_target, _zip_guard
+# Identity, audiences and the zip guards are shared verbatim with the app rail
+# through deploy_common — the threat is the archive, not what it carries, and
+# an audience means the same thing whichever kind is being published.
+from ai.account.deploy_common import ZIP_MAX_ZIPPED, actor_of, developer_id_of, org_of, resolve_target, zip_guard
 from ai.account.deployment_backend import artifact_content_dir
 
 #: Node runtimes. 'python' is a source tree the engine imports as-is. 'native'
@@ -123,7 +124,7 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
         return conn.build_error(request, 'deploying a node requires an authenticated connection')
 
     args = request.get('arguments', {}) or {}
-    org_id = _org_of(conn)
+    org_id = org_of(conn)
     comment = str(args.get('comment', '') or '')
 
     data = args.get('data')
@@ -138,11 +139,11 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
         return conn.build_error(request, 'data must be a binary zip frame (bytes), not text')
     # Measured on the zipped bytes and refused before any parsing: a node
     # directory is small, and the unpacked guard below still applies.
-    if len(data) > _ZIP_MAX_ZIPPED:
+    if len(data) > ZIP_MAX_ZIPPED:
         return conn.build_error(
             request,
             f'node zip is {len(data) // (1024 * 1024)} MB — the upload cap is '
-            f'{_ZIP_MAX_ZIPPED // (1024 * 1024)} MB zipped',
+            f'{ZIP_MAX_ZIPPED // (1024 * 1024)} MB zipped',
         )
 
     import io
@@ -161,7 +162,7 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
 
     # Traversal and bombs are refused BEFORE a registry row exists, so a bad
     # archive never leaves a version behind.
-    guard_error = _zip_guard(archive)
+    guard_error = zip_guard(archive)
     if guard_error:
         return conn.build_error(request, guard_error)
 
@@ -187,7 +188,7 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     entry = await account.deployments_publish(
-        org_id, node_id, artifact, _actor_of(conn), comment=comment, metadata=metadata
+        org_id, node_id, artifact, actor_of(conn), comment=comment, metadata=metadata
     )
     version = int(entry.get('version', 0))
 
@@ -226,7 +227,7 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
             except Exception:
                 pass  # best-effort; the 'failed' state is what gates serving
         try:
-            await account.set_artifact_state(org_id, node_id, version, 'failed', _actor_of(conn))
+            await account.set_artifact_state(org_id, node_id, version, 'failed', actor_of(conn))
         except Exception:
             pass
         return conn.build_error(request, f'node content could not be stored: {exc}')
@@ -286,7 +287,7 @@ def _node_rail_entry(entry: Dict[str, Any], artifact: Dict[str, Any] | None) -> 
 def _assert_may_expose(conn: Any, node_id: str, audience: Dict[str, Any]) -> None:
     """Check the caller may expose this node at this reach.
 
-    Reach is what decides the bar, and ``_resolve_target`` has already applied
+    Reach is what decides the bar, and ``resolve_target`` has already applied
     most of it: ``@me`` is your own id, ``@team/<x>`` refuses a team you do not
     belong to, and ``@public`` refuses an org with no registered developer id.
 
@@ -307,11 +308,9 @@ def _assert_may_expose(conn: Any, node_id: str, audience: Dict[str, Any]) -> Non
     """
     if audience.get('type') != 'public':
         return
-    from ai.account.app_deploy import _developer_id_of
-
-    dev = _developer_id_of(conn)
+    dev = developer_id_of(conn)
     if not dev:
-        # _resolve_target refuses this first; kept so the guard holds alone.
+        # resolve_target refuses this first; kept so the guard holds alone.
         raise ValueError('Publishing a node publicly requires the organization to be registered as a developer')
     if node_id != dev and not node_id.startswith(f'{dev}.'):
         raise ValueError(
@@ -343,7 +342,7 @@ async def _bind(
         ValueError: unusable target, reach the caller may not grant, or a
                     version that is missing or is not a node artifact.
     """
-    audience = _resolve_target(conn, target)
+    audience = resolve_target(conn, target)
     _assert_may_expose(conn, node_id, audience)
     entry = await _entry_of(account, org_id, node_id, version)
     if not entry:
@@ -353,7 +352,7 @@ async def _bind(
         raise ValueError(f'Registry version {version} of {node_id} is not a node artifact')
     # A pure pointer, born enabled — the same publish row shape apps bind.
     row = await account.publish_set(
-        org_id, KIND_NODE, node_id, audience, version, _snapshot(entry, artifact), _actor_of(conn)
+        org_id, KIND_NODE, node_id, audience, version, _snapshot(entry, artifact), actor_of(conn)
     )
     debug(f'[node_deploy] bound {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
     return row, audience
@@ -390,7 +389,7 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
     node_id = str(args.get('nodeId') or '')
     if not node_id:
         return conn.build_error(request, 'nodeId is required')
-    org_id = _org_of(conn)
+    org_id = org_of(conn)
 
     if sub == 'versions':
         entries = await account.deployments_versions(org_id, node_id)
@@ -424,7 +423,7 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
     # touches the artifact, so a rollback to that version stays possible.
     if sub in ('disable', 'remove'):
         try:
-            audience = _resolve_target(conn, str(args.get('target') or '@me'))
+            audience = resolve_target(conn, str(args.get('target') or '@me'))
         except ValueError as exc:
             return conn.build_error(request, str(exc))
         try:
@@ -433,7 +432,7 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
             return conn.build_error(request, str(exc))
         state = 'disabled' if sub == 'disable' else 'removed'
         try:
-            row = await account.publish_set_state(org_id, KIND_NODE, node_id, audience, state, _actor_of(conn))
+            row = await account.publish_set_state(org_id, KIND_NODE, node_id, audience, state, actor_of(conn))
         except Exception as exc:
             return conn.build_error(request, str(exc))
         debug(f'[node_deploy] {state} {node_id} for {audience.get("type")}:{audience.get("id")}')

--- a/packages/ai/src/ai/account/node_deploy.py
+++ b/packages/ai/src/ai/account/node_deploy.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import hashlib
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from rocketlib import debug
 
@@ -239,7 +239,22 @@ async def handle_node_add(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
         request_data={'nodeId': node_id, 'version': version},
         org_id=org_id,
     )
-    return conn.build_response(request, body={'artifact': entry, 'orgId': org_id})
+    body: Dict[str, Any] = {'artifact': entry, 'orgId': org_id}
+    if args.get('deployTo'):
+        # One-step publish+bind, the same convenience the pipe rail offers —
+        # and what the CLI already sends alongside kind='node'. Binding runs
+        # through the shared helper, so nothing is reachable here that the
+        # deploy verb would have refused.
+        try:
+            _, audience = await _bind(
+                conn, account, org_id, node_id, int(entry['version']), _deploy_target_of(str(args['deployTo']))
+            )
+        except ValueError as exc:
+            # The version stands: it published fine, only the pointer failed,
+            # and a caller can bind it afterwards without publishing again.
+            return conn.build_error(request, f'{node_id} v{entry["version"]} published, but not bound: {exc}')
+        body['audience'] = audience
+    return conn.build_response(request, body=body)
 
 
 # =============================================================================
@@ -306,6 +321,44 @@ def _assert_may_expose(conn: Any, node_id: str, audience: Dict[str, Any]) -> Non
         )
 
 
+def _deploy_target_of(raw: str) -> str:
+    """The wire target behind ``deployTo``: a bare team name or id means a team.
+
+    The CLI has always spelled ``--deploy-to`` as a plain team, so a value
+    with no '@' is read as one; '@'-targets pass through untouched.
+    """
+    return raw if raw.startswith('@') else f'@team/{raw}'
+
+
+async def _bind(
+    conn: Any, account: Any, org_id: str, node_id: str, version: int, target: str
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    """Pin one audience to a registry version — the whole of "make it reachable".
+
+    Shared by the ``deploy`` verb and by ``add``'s ``deployTo``, so the one
+    authorization rule covers both doors rather than one door growing a
+    weaker copy of it.
+
+    Raises:
+        ValueError: unusable target, reach the caller may not grant, or a
+                    version that is missing or is not a node artifact.
+    """
+    audience = _resolve_target(conn, target)
+    _assert_may_expose(conn, node_id, audience)
+    entry = await _entry_of(account, org_id, node_id, version)
+    if not entry:
+        raise ValueError(f'{node_id} has no registry version {version}')
+    artifact = await account.deployments_artifact(org_id, node_id, version)
+    if not isinstance(artifact, dict) or artifact.get('kind') != KIND_NODE:
+        raise ValueError(f'Registry version {version} of {node_id} is not a node artifact')
+    # A pure pointer, born enabled — the same publish row shape apps bind.
+    row = await account.publish_set(
+        org_id, KIND_NODE, node_id, audience, version, _snapshot(entry, artifact), _actor_of(conn)
+    )
+    debug(f'[node_deploy] bound {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
+    return row, audience
+
+
 async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, Any]:
     """Handle ``rrext_deploy_node`` — node publish control on the registry.
 
@@ -354,24 +407,9 @@ async def handle_node_deploy(conn: Any, request: Dict[str, Any]) -> Dict[str, An
         if not isinstance(version, int):
             return conn.build_error(request, 'version (the registry version number) is required')
         try:
-            audience = _resolve_target(conn, str(args.get('target') or '@me'))
+            row, audience = await _bind(conn, account, org_id, node_id, version, str(args.get('target') or '@me'))
         except ValueError as exc:
             return conn.build_error(request, str(exc))
-        try:
-            _assert_may_expose(conn, node_id, audience)
-        except ValueError as exc:
-            return conn.build_error(request, str(exc))
-        entry = await _entry_of(account, org_id, node_id, version)
-        if not entry:
-            return conn.build_error(request, f'{node_id} has no registry version {version}')
-        artifact = await account.deployments_artifact(org_id, node_id, version)
-        if not isinstance(artifact, dict) or artifact.get('kind') != KIND_NODE:
-            return conn.build_error(request, f'Registry version {version} of {node_id} is not a node artifact')
-        # A pure pointer, born enabled — the same publish row shape apps bind.
-        row = await account.publish_set(
-            org_id, KIND_NODE, node_id, audience, version, _snapshot(entry, artifact), _actor_of(conn)
-        )
-        debug(f'[node_deploy] bound {node_id} v{version} to {audience.get("type")}:{audience.get("id")}')
         return conn.build_response(request, body={'publish': row, 'audience': audience})
 
     if sub == 'where':

--- a/packages/ai/src/ai/account/node_resolve.py
+++ b/packages/ai/src/ai/account/node_resolve.py
@@ -16,15 +16,29 @@
 # answer "will this run work?" without touching the network or the disk.
 # =============================================================================
 
-"""Deciding which published nodes a pipeline run has to resolve."""
+"""Deciding which published nodes a pipeline run has to resolve, and getting them."""
 
 from __future__ import annotations
 
+import hashlib
+import io
+import os
+import shutil
+import zipfile
 from typing import Any, Dict, List, Set
 
 from rocketlib import debug
 
+from ai.account.deploy_common import ZIP_MAX_ZIPPED, zip_guard
+from ai.account.deployment_backend import artifact_content_dir
 from ai.account.node_deploy import resolve_node_pins
+
+#: The package folder the engine imports external nodes from. Its __init__ is
+#: the PARENT of each node directory, so it never travels inside a bundle —
+#: the resolver writes it.
+RUN_PACKAGE = 'local_nodes'
+
+_PACKAGE_INIT = b'# Marks local_nodes as a package so the engine can import local_nodes.<name>.\n'
 
 
 def providers_of(pipeline: Dict[str, Any]) -> Set[str]:
@@ -104,3 +118,179 @@ async def plan_for(
     plan = [available[name] for name in sorted(wanted)]
     debug(f'[node_resolve] {len(plan)} node(s) to resolve: {", ".join(entry["id"] for entry in plan)}')
     return plan
+
+
+# =============================================================================
+# FETCHING — bytes, proven, then on disk
+# =============================================================================
+#
+# The order below is the design: a bundle is proven to be what the registry
+# said it was BEFORE it is opened, and the archive is checked again before it
+# is written out. Publishing checked the same things, but that was a different
+# moment and a different copy of the bytes.
+
+
+class BundleMismatch(Exception):
+    """Fetched bytes are not what the registry recorded for that version."""
+
+
+async def _bundle_of(org_id: str, node_id: str, version: int, actor: str) -> bytes:
+    """The stored bundle for one registry version, through the same Store.
+
+    Filesystem when self-hosted, S3 or Azure on cloud — the resolver never
+    knows which, the same way publishing does not.
+
+    Raises:
+        ValueError: the version is gone, or its entry carries no usable path.
+    """
+    from ai.account import account
+    from ai.account.models import RequestContext
+    from ai.account.store import Store
+
+    entries = await account.deployments_versions(org_id, node_id) or []
+    entry = next((e for e in entries if int(e.get('version', 0)) == version), None)
+    if not entry:
+        raise ValueError(f'{node_id} has no registry version {version} in {org_id!r}')
+
+    content_root = artifact_content_dir(str(entry.get('artifactPath') or ''))
+    org_prefix = f'orgs/{org_id}/files/'
+    if not content_root.startswith(org_prefix):
+        raise ValueError(f'registry entry for {node_id} carries no usable artifactPath')
+
+    fs = Store.file_store(RequestContext.internal('node-resolve'), client_id=actor)
+    home = f'@/Org/={org_id}/{content_root[len(org_prefix) :]}'
+    # Read cap tied to the publish cap rather than the store's larger default:
+    # nothing bigger than that could have been published in the first place.
+    return await fs.read(f'{home}/bundle/{node_id}-v{version:06d}.zip', ZIP_MAX_ZIPPED)
+
+
+def _verified(data: bytes, expected: str, node_id: str) -> bytes:
+    """The bundle, or nothing.
+
+    Checked before the archive is opened at all: a mismatch means the bytes
+    are not the version that was reviewed and pinned, and the cheapest place
+    to stop is before a zip reader has seen them.
+
+    Raises:
+        BundleMismatch: digest does not match what the artifact recorded.
+    """
+    if not expected:
+        raise BundleMismatch(f'{node_id} has no recorded digest to verify against')
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise BundleMismatch(f'{node_id} bundle digest is {actual[:12]}…, expected {expected[:12]}…')
+    return data
+
+
+def _unpack_into(data: bytes, destination: str, node_id: str) -> None:
+    """Write the node directory out, guarded first.
+
+    Raises:
+        ValueError: the archive is unsafe to unpack.
+    """
+    archive = zipfile.ZipFile(io.BytesIO(data))
+    guard_error = zip_guard(archive)
+    if guard_error:
+        raise ValueError(f'{node_id} bundle refused: {guard_error}')
+    os.makedirs(destination, exist_ok=True)
+    archive.extractall(destination)
+
+
+# =============================================================================
+# CACHE — keyed by content, so it is never stale
+# =============================================================================
+
+
+def cache_root() -> str:
+    """Where unpacked nodes are kept between runs."""
+    from depends import engine_cache_dir
+
+    return os.path.join(engine_cache_dir(create=True), 'nodes')
+
+
+def cache_slot(node_id: str, digest: str) -> str:
+    """This exact node at this exact content, and nothing else.
+
+    Keyed by digest rather than by version: two versions never collide, a slot
+    can never hold the wrong bytes, and nothing ever has to be invalidated.
+    """
+    return os.path.join(cache_root(), node_id, digest)
+
+
+async def _ensure_cached(entry: Dict[str, Any], org_id: str, actor: str) -> str:
+    """The cache slot for one node, populated if it was not already.
+
+    Concurrency is handled by building somewhere else and moving into place:
+    a second run either finds the slot already there, or loses the rename and
+    uses the winner's copy. No lock, and no half-written slot is ever visible
+    under the real name.
+    """
+    node_id = str(entry['id'])
+    digest = str(entry.get('bundleSha256') or '')
+    slot = cache_slot(node_id, digest)
+    if os.path.isdir(slot):
+        debug(f'[node_resolve] {node_id} already cached')
+        return slot
+
+    data = _verified(await _bundle_of(org_id, node_id, int(entry['version']), actor), digest, node_id)
+    staging = f'{slot}.{os.getpid()}.partial'
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        _unpack_into(data, staging, node_id)
+        os.makedirs(os.path.dirname(slot), exist_ok=True)
+        try:
+            os.rename(staging, slot)
+        except OSError:
+            # Another run got there first. Its copy has the same digest, so it
+            # is the same bytes — use it and drop ours.
+            if not os.path.isdir(slot):
+                raise
+            shutil.rmtree(staging, ignore_errors=True)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return slot
+
+
+# =============================================================================
+# MATERIALISE — the layout the engine imports from
+# =============================================================================
+
+
+def _place(slot: str, run_root: str, node_id: str) -> str:
+    """Put one cached node where this run's engine will import it from."""
+    package = os.path.join(run_root, RUN_PACKAGE)
+    os.makedirs(package, exist_ok=True)
+    init_py = os.path.join(package, '__init__.py')
+    if not os.path.exists(init_py):
+        with open(init_py, 'wb') as handle:
+            handle.write(_PACKAGE_INIT)
+    destination = os.path.join(package, node_id)
+    if os.path.exists(destination):
+        shutil.rmtree(destination, ignore_errors=True)
+    shutil.copytree(slot, destination)
+    return destination
+
+
+async def materialise(plan: List[Dict[str, Any]], run_root: str, org_id: str, actor: str) -> List[str]:
+    """Bring every planned node onto this machine, ready to import.
+
+    Returns the directory written for each. A node placed this way is
+    indistinguishable from one sitting in a developer's workspace, which is
+    why nothing downstream — including the node's own manifest — has to know
+    it arrived seconds ago.
+
+    The engine still has to be told to look again; that is the one piece this
+    cannot do from Python yet.
+    """
+    written: List[str] = []
+    for entry in plan:
+        slot = await _ensure_cached(entry, org_id, actor)
+        written.append(_place(slot, run_root, str(entry['id'])))
+        debug(f'[node_resolve] materialised {entry["id"]} v{entry["version"]}')
+    return written
+
+
+def clean(run_root: str) -> None:
+    """Drop what this run unpacked. The cache is untouched and stays warm."""
+    shutil.rmtree(os.path.join(run_root, RUN_PACKAGE), ignore_errors=True)

--- a/packages/ai/src/ai/account/node_resolve.py
+++ b/packages/ai/src/ai/account/node_resolve.py
@@ -31,7 +31,12 @@ from rocketlib import debug
 
 from ai.account.deploy_common import ZIP_MAX_ZIPPED, zip_guard
 from ai.account.deployment_backend import artifact_content_dir
-from ai.account.node_deploy import resolve_node_pins
+from ai.account.node_deploy import NODE_REQUIREMENTS, resolve_node_pins
+
+# The engine's own installer. It resolves AGAINST the constraints lock, which
+# is the whole reason a run may install at all: a conflict is refused rather
+# than settled by downgrading a package another node is relying on.
+from depends import depends as _install
 
 #: The package folder the engine imports external nodes from. Its __init__ is
 #: the PARENT of each node directory, so it never travels inside a bundle —
@@ -132,6 +137,10 @@ async def plan_for(
 
 class BundleMismatch(Exception):
     """Fetched bytes are not what the registry recorded for that version."""
+
+
+class DependencyFailure(Exception):
+    """A node's declared dependencies cannot be satisfied on this machine."""
 
 
 async def _bundle_of(org_id: str, node_id: str, version: int, actor: str) -> bytes:
@@ -272,6 +281,38 @@ def _place(slot: str, run_root: str, node_id: str) -> str:
     return destination
 
 
+async def _satisfy_requirements(placed: str, node_id: str) -> bool:
+    """Install what the node declares, if it declares anything.
+
+    The engine sweeps its own dependencies once at startup, from a glob a
+    node materialised for a run falls outside of — so a published node's
+    requirements would otherwise never be installed and its import would fail
+    for a reason that looks nothing like the cause.
+
+    Installing happens against the constraints lock, so a node that cannot fit
+    the environment is refused instead of quietly downgrading a package
+    another node in the same run depends on.
+
+    Returns:
+        True if the node declared requirements and they were installed.
+
+    Raises:
+        DependencyFailure: the node's requirements cannot be satisfied.
+    """
+    import asyncio
+
+    path = os.path.join(placed, NODE_REQUIREMENTS)
+    if not os.path.exists(path):
+        return False
+    try:
+        # Off the event loop: this can reach the network and take a while.
+        await asyncio.get_running_loop().run_in_executor(None, _install, path)
+    except Exception as exc:
+        raise DependencyFailure(f'{node_id} declares dependencies that cannot be satisfied here: {exc}') from exc
+    debug(f'[node_resolve] installed requirements for {node_id}')
+    return True
+
+
 async def materialise(plan: List[Dict[str, Any]], run_root: str, org_id: str, actor: str) -> List[str]:
     """Bring every planned node onto this machine, ready to import.
 
@@ -285,9 +326,12 @@ async def materialise(plan: List[Dict[str, Any]], run_root: str, org_id: str, ac
     """
     written: List[str] = []
     for entry in plan:
+        node_id = str(entry['id'])
         slot = await _ensure_cached(entry, org_id, actor)
-        written.append(_place(slot, run_root, str(entry['id'])))
-        debug(f'[node_resolve] materialised {entry["id"]} v{entry["version"]}')
+        placed = _place(slot, run_root, node_id)
+        await _satisfy_requirements(placed, node_id)
+        written.append(placed)
+        debug(f'[node_resolve] materialised {node_id} v{entry["version"]}')
     return written
 
 

--- a/packages/ai/src/ai/account/node_resolve.py
+++ b/packages/ai/src/ai/account/node_resolve.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import io
 import os
+import re
 import shutil
 import zipfile
 from typing import Any, Dict, List, Set
@@ -44,6 +45,11 @@ from depends import depends as _install
 RUN_PACKAGE = 'local_nodes'
 
 _PACKAGE_INIT = b'# Marks local_nodes as a package so the engine can import local_nodes.<name>.\n'
+
+#: How long one node's dependency install may take before the run gives up.
+#: Generous, because a cold resolve can genuinely be slow; finite, because a
+#: stalled resolver would otherwise hang the run with nothing to show for it.
+INSTALL_TIMEOUT = 900.0
 
 
 def providers_of(pipeline: Dict[str, Any]) -> Set[str]:
@@ -217,12 +223,25 @@ def cache_root() -> str:
     return os.path.join(engine_cache_dir(create=True), 'nodes')
 
 
+#: A digest is a path segment in the cache, so it is validated as one. This
+#: also rejects anything that could climb out of the cache root.
+_DIGEST = re.compile(r'[0-9a-f]{64}')
+
+
 def cache_slot(node_id: str, digest: str) -> str:
     """This exact node at this exact content, and nothing else.
 
     Keyed by digest rather than by version: two versions never collide, a slot
     can never hold the wrong bytes, and nothing ever has to be invalidated.
+
+    Raises:
+        BundleMismatch: the digest is not a usable sha256. An empty one would
+                        otherwise resolve to the node's own directory — which
+                        on a warm cache exists, holding the digest slots, and
+                        would be copied out as though it were the node.
     """
+    if not _DIGEST.fullmatch(digest):
+        raise BundleMismatch(f'{node_id} carries no usable content digest ({digest!r})')
     return os.path.join(cache_root(), node_id, digest)
 
 
@@ -305,8 +324,19 @@ async def _satisfy_requirements(placed: str, node_id: str) -> bool:
     if not os.path.exists(path):
         return False
     try:
-        # Off the event loop: this can reach the network and take a while.
-        await asyncio.get_running_loop().run_in_executor(None, _install, path)
+        # Off the event loop: this reaches the network and takes a while.
+        await asyncio.wait_for(
+            asyncio.get_running_loop().run_in_executor(None, _install, path),
+            timeout=INSTALL_TIMEOUT,
+        )
+    except asyncio.TimeoutError as exc:
+        # The run stops with something a person can act on. The installer
+        # process itself is NOT killed here — `depends` drives uv through
+        # subprocess calls that take no timeout, so the deadline it needs is
+        # its own to add. Worth doing; it is not this module's to reach into.
+        raise DependencyFailure(
+            f'{node_id} dependency install exceeded {INSTALL_TIMEOUT:.0f}s and the run gave up'
+        ) from exc
     except Exception as exc:
         raise DependencyFailure(f'{node_id} declares dependencies that cannot be satisfied here: {exc}') from exc
     debug(f'[node_resolve] installed requirements for {node_id}')

--- a/packages/ai/src/ai/account/node_resolve.py
+++ b/packages/ai/src/ai/account/node_resolve.py
@@ -1,0 +1,106 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+# =============================================================================
+# NODE RESOLVE — what a pipeline needs that this machine does not have
+#
+# A published node is never installed. When a pipeline names one the engine
+# does not carry, the run fetches it, uses it, and drops it. This module is
+# the first half of that: deciding WHICH nodes a run has to go and get, and
+# at which version, before anything is downloaded or written.
+#
+# Kept separate from the fetching on purpose. Detection is pure — a pipeline
+# dict, the names the engine already knows, and the caller's pins — so it can
+# answer "will this run work?" without touching the network or the disk.
+# =============================================================================
+
+"""Deciding which published nodes a pipeline run has to resolve."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+from rocketlib import debug
+
+from ai.account.node_deploy import resolve_node_pins
+
+
+def providers_of(pipeline: Dict[str, Any]) -> Set[str]:
+    """Every node type a pipeline names, once each.
+
+    A component's ``provider`` IS the node's protocol id, which is the same id
+    a node publishes under — so nothing has to be translated between what a
+    pipeline asks for and what the registry holds.
+    """
+    providers: Set[str] = set()
+    for component in pipeline.get('components') or []:
+        if not isinstance(component, dict):
+            continue
+        provider = component.get('provider')
+        if isinstance(provider, str) and provider:
+            providers.add(provider)
+    return providers
+
+
+def missing_from(providers: Set[str], known: Set[str]) -> Set[str]:
+    """The named nodes this engine does not already carry.
+
+    Everything a normal pipeline names is built in, so this is empty for
+    almost every run — which is the point. A pipeline of stock nodes must not
+    pay for this feature existing.
+    """
+    return {name for name in providers if name not in known}
+
+
+class UnresolvedNodes(Exception):
+    """A run named nodes it has no way to get.
+
+    Carries the names and the org they were looked for in: "node not found" is
+    a dead end, while "not published to you in <org>" tells someone what to do
+    about it.
+    """
+
+    def __init__(self, names: List[str], org_id: str):
+        self.names = names
+        self.org_id = org_id
+        listed = ', '.join(sorted(names))
+        super().__init__(
+            f'this pipeline uses {listed}, which this engine does not have and '
+            f'which is not published to you in {org_id!r}'
+        )
+
+
+async def plan_for(
+    pipeline: Dict[str, Any],
+    known: Set[str],
+    org_id: str,
+    user_id: str | None,
+    team_ids: List[str],
+) -> List[Dict[str, Any]]:
+    """What this run has to fetch, resolved to exact versions.
+
+    Returns one availability entry per node that has to be brought in —
+    empty when the engine already carries everything, which is the common
+    case and costs one set difference.
+
+    Nothing is fetched or written here. A pin that does not exist stops the
+    run BEFORE any bytes move, rather than downloading what it can and
+    failing halfway through.
+
+    Raises:
+        UnresolvedNodes: a named node with no pin for this caller.
+    """
+    wanted = missing_from(providers_of(pipeline), known)
+    if not wanted:
+        return []
+
+    available = {entry['id']: entry for entry in await resolve_node_pins(org_id, user_id, team_ids)}
+    unresolved = sorted(name for name in wanted if name not in available)
+    if unresolved:
+        raise UnresolvedNodes(unresolved, org_id)
+
+    plan = [available[name] for name in sorted(wanted)]
+    debug(f'[node_resolve] {len(plan)} node(s) to resolve: {", ".join(entry["id"] for entry in plan)}')
+    return plan

--- a/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
@@ -297,15 +297,21 @@ class DeployCommands(_DeployBase):
 
         Kind dispatch: ``kind='pipe'`` (default — v0 clients send none) takes
         the pipeline-dict path below; ``kind='app'`` routes to the app branch
-        (zip transport, unpacked at receipt) in ``ai.account.app_deploy``.
+        (zip transport, unpacked at receipt) in ``ai.account.app_deploy``;
+        ``kind='node'`` to the node branch in ``ai.account.node_deploy``, which
+        carries the same zip transport.
         """
         kind = str(args.get('kind') or 'pipe')
         if kind == 'app':
             from ai.account.app_deploy import handle_app_add
 
             return await handle_app_add(self, request)
+        if kind == 'node':
+            from ai.account.node_deploy import handle_node_add
+
+            return await handle_node_add(self, request)
         if kind != 'pipe':
-            raise ValueError(f"Unknown deploy kind: {kind!r} (use 'pipe' or 'app')")
+            raise ValueError(f"Unknown deploy kind: {kind!r} (use 'pipe', 'app' or 'node')")
         return await self._deploy_add_pipe(request, args)
 
     async def _deploy_add_pipe(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:

--- a/packages/ai/src/ai/modules/task/commands/cmd_node.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node.py
@@ -17,18 +17,16 @@
 Exposes one command to the DAP dispatcher:
 
   - ``rrext_deploy_node`` — node publish control on the deployments registry
-                            (``versions`` / ``deploy`` / ``where``)
+                            (``versions`` / ``deploy`` / ``where`` /
+                            ``disable`` / ``remove``)
 
 Publishing a version is NOT here: it arrives on the generic rail as
 ``rrext_deploy add`` with ``kind='node'``, which carries the zip.
 """
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Dict
 
 from ai.common.dap import DAPConn
-
-if TYPE_CHECKING:
-    pass
 
 
 # =============================================================================

--- a/packages/ai/src/ai/modules/task/commands/cmd_node.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_node.py
@@ -1,0 +1,46 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+# =============================================================================
+# CMD NODE — thin DAP router for node publish control
+#
+# One command (rrext_deploy_node, grouped subcommands) delegating to
+# node_deploy.handle_node_deploy. Uploading a node version goes through the
+# generic rail instead (rrext_deploy add, kind='node'), the same split apps
+# use: one door to put code on the server, one surface to control it.
+# =============================================================================
+
+"""NodeCommands: thin DAP router for node publish control.
+
+Exposes one command to the DAP dispatcher:
+
+  - ``rrext_deploy_node`` — node publish control on the deployments registry
+                            (``versions`` / ``deploy`` / ``where``)
+
+Publishing a version is NOT here: it arrives on the generic rail as
+``rrext_deploy add`` with ``kind='node'``, which carries the zip.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from ai.common.dap import DAPConn
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# NODE COMMANDS MIXIN
+# =============================================================================
+
+
+class NodeCommands(DAPConn):
+    """DAP handlers for the node command family."""
+
+    async def on_rrext_deploy_node(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Delegate ``rrext_deploy_node`` (node publish control) to the node handler."""
+        from ai.account.node_deploy import handle_node_deploy
+
+        return await handle_node_deploy(self, request)

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -208,7 +208,6 @@ class TaskConn(
         AppCommands.__init__(self, connection_id, server, transport, **kwargs)
         DeployCommands.__init__(self, connection_id, server, transport, **kwargs)
         DeployPipeCommands.__init__(self, connection_id, server, transport, **kwargs)
-        NodeCommands.__init__(self, connection_id, server, transport, **kwargs)
         LogCommands.__init__(self, connection_id, server, transport, **kwargs)
         StoreCommands.__init__(self, connection_id, server, transport, **kwargs)
 

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -74,6 +74,7 @@ from .commands.cmd_account import AccountCommands
 from .commands.cmd_app import AppCommands
 from .commands.cmd_public import PublicCommands
 from .commands.cmd_deploy import DeployCommands
+from .commands.cmd_node import NodeCommands
 from .commands.cmd_pipe import DeployPipeCommands
 from .commands.cmd_log import LogCommands
 from .commands.cmd_store import StoreCommands
@@ -113,6 +114,7 @@ class TaskConn(
     PublicCommands,
     DeployCommands,
     DeployPipeCommands,
+    NodeCommands,
     LogCommands,
     StoreCommands,
     DAPConn,
@@ -149,6 +151,7 @@ class TaskConn(
     - CProfileCommands: cProfile process profiling (start, stop, status, report)
     - AccountCommands: Account management (profile, keys, organizations, teams, billing)
     - AppCommands: App marketplace (developer, submission, catalog, admin, pricing)
+    - NodeCommands: Node publish control (versions, deploy, where)
     - DAPConn: Base DAP protocol implementation and transport handling
 
     Attributes:
@@ -205,6 +208,7 @@ class TaskConn(
         AppCommands.__init__(self, connection_id, server, transport, **kwargs)
         DeployCommands.__init__(self, connection_id, server, transport, **kwargs)
         DeployPipeCommands.__init__(self, connection_id, server, transport, **kwargs)
+        NodeCommands.__init__(self, connection_id, server, transport, **kwargs)
         LogCommands.__init__(self, connection_id, server, transport, **kwargs)
         StoreCommands.__init__(self, connection_id, server, transport, **kwargs)
 

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -294,6 +294,7 @@ class _ControlRegistry:
         self.versions = {}
         self.artifacts = {}
         self.deployed = []
+        self.states = []
         self.listed = []
 
     def add_version(self, node_id, version, node_version, runtime='python'):
@@ -323,18 +324,24 @@ class _ControlRegistry:
         async def deployments_artifact(org_id, project_id, version):
             return self.artifacts.get((project_id, version))
 
-        async def deployments_deploy(org_id, team_id, project_id, version, actor):
-            record = {'projectId': project_id, 'teamId': team_id, 'version': version}
-            self.deployed.append(record)
-            return record
+        async def publish_set(org_id, kind, node_id, audience, version, snapshot, actor):
+            row = {'kind': kind, 'nodeId': node_id, 'audience': audience, 'version': version, 'state': 'enabled'}
+            self.deployed.append(row)
+            return row
 
-        async def deployments_list(org_id, team_id):
-            return self.listed
+        async def publish_of_app(org_id, kind, node_id):
+            return [r for r in self.listed if r.get('nodeId') == node_id]
+
+        async def publish_set_state(org_id, kind, node_id, audience, state, actor):
+            row = {'kind': kind, 'nodeId': node_id, 'audience': audience, 'state': state}
+            self.states.append(row)
+            return row
 
         monkeypatch.setattr(account, 'deployments_versions', deployments_versions)
         monkeypatch.setattr(account, 'deployments_artifact', deployments_artifact)
-        monkeypatch.setattr(account, 'deployments_deploy', deployments_deploy)
-        monkeypatch.setattr(account, 'deployments_list', deployments_list)
+        monkeypatch.setattr(account, 'publish_set', publish_set)
+        monkeypatch.setattr(account, 'publish_of_app', publish_of_app)
+        monkeypatch.setattr(account, 'publish_set_state', publish_set_state)
 
 
 @pytest.fixture
@@ -381,10 +388,17 @@ class TestDeploy:
 
     @pytest.mark.asyncio
     async def test_pinning_defaults_to_the_caller(self, control):
+        control.add_version('my_node', 1, '1.0.0')
         result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1))
         assert result['success'] is True
         assert control.deployed[0]['version'] == 1
         assert result['body']['audience']['type'] == 'user'
+
+    @pytest.mark.asyncio
+    async def test_a_version_that_does_not_exist_is_refused(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=99))
+        assert result['success'] is False
+        assert not control.deployed
 
     @pytest.mark.asyncio
     async def test_the_registry_version_is_required_as_an_int(self, control):
@@ -405,6 +419,8 @@ class TestDeploy:
 
     @pytest.mark.asyncio
     async def test_rollback_is_the_same_verb(self, control):
+        control.add_version('my_node', 1, '1.0.0')
+        control.add_version('my_node', 2, '1.1.0')
         await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=2))
         await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1))
         assert [d['version'] for d in control.deployed] == [2, 1]
@@ -416,11 +432,11 @@ class TestWhere:
     @pytest.mark.asyncio
     async def test_only_this_nodes_pins_are_returned(self, control):
         control.listed = [
-            {'projectId': 'my_node', 'teamId': 'u1', 'version': 3},
-            {'projectId': 'other_node', 'teamId': 'u1', 'version': 9},
+            {'nodeId': 'my_node', 'audience': {'type': 'user', 'id': 'u1'}, 'version': 3},
+            {'nodeId': 'other_node', 'audience': {'type': 'user', 'id': 'u1'}, 'version': 9},
         ]
         result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('where'))
-        assert result['body']['pins'] == [{'audience': 'u1', 'version': 3}]
+        assert [row['nodeId'] for row in result['body']['pins']] == ['my_node']
 
 
 class TestControlRefusals:
@@ -441,3 +457,96 @@ class TestControlRefusals:
         result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('teleport'))
         assert result['success'] is False
         assert 'teleport' in result['message']
+
+
+class TestWithdrawal:
+    """Stopping a binding — the version itself is immutable and stays put."""
+
+    @pytest.mark.asyncio
+    async def test_disable_stops_serving_one_binding(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('disable'))
+        assert result['success'] is True
+        assert control.states[0]['state'] == 'disabled'
+
+    @pytest.mark.asyncio
+    async def test_remove_takes_the_row_out(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('remove'))
+        assert result['success'] is True
+        assert control.states[0]['state'] == 'removed'
+
+    @pytest.mark.asyncio
+    async def test_withdrawal_names_the_audience_it_acted_on(self, control):
+        # Disabling for one team must not touch what another team sees.
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('disable', target='@me'))
+        assert result['body']['audience']['type'] == 'user'
+
+    @pytest.mark.asyncio
+    async def test_the_version_survives_a_withdrawal(self, control):
+        # Nothing about the artifact is touched, which is what keeps a later
+        # rollback to that same version possible.
+        control.add_version('my_node', 1, '1.0.0')
+        await node_deploy.handle_node_deploy(_FakeConn(), _control_request('remove'))
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('versions'))
+        assert [row['registryVersion'] for row in result['body']['versions']] == [1]
+
+
+class TestReachControls:
+    """What a caller may expose, and how far.
+
+    Most of the bar lives in the shared target resolver; what is checked here
+    is that the node surface applies it, plus the ownership rule the public
+    rung adds.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_team_you_do_not_belong_to_is_refused(self, control):
+        control.add_version('my_node', 1, '1.0.0')
+        result = await node_deploy.handle_node_deploy(
+            _FakeConn(), _control_request('deploy', version=1, target='@team/strangers')
+        )
+        assert result['success'] is False
+        assert not control.deployed
+
+    @pytest.mark.asyncio
+    async def test_the_org_target_is_refused_with_the_alternative(self, control):
+        control.add_version('my_node', 1, '1.0.0')
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1, target='@org'))
+        assert result['success'] is False
+        assert 'team' in result['message'], 'the error should point at the team that replaces it'
+
+    @pytest.mark.asyncio
+    async def test_public_reach_requires_the_node_to_be_in_your_namespace(self, control):
+        # Private reach is partitioned by org, so 'my_node' is fine there.
+        # Public reach is one shared space: first-come would own the name.
+        control.add_version('my_node', 1, '1.0.0')
+        result = await node_deploy.handle_node_deploy(
+            _FakeConn(), _control_request('deploy', version=1, target='@public')
+        )
+        assert result['success'] is False
+        assert 'namespace' in result['message']
+        assert not control.deployed
+
+    @pytest.mark.asyncio
+    async def test_a_namespaced_node_may_go_public(self, control):
+        control.add_version('acme.my_node', 1, '1.0.0')
+        request = {
+            'command': 'rrext_deploy_node',
+            'arguments': {'subcommand': 'deploy', 'nodeId': 'acme.my_node', 'version': 1, 'target': '@public'},
+        }
+        result = await node_deploy.handle_node_deploy(_FakeConn(), request)
+        assert result['success'] is True, result.get('message')
+        assert control.deployed[0]['audience']['type'] == 'public'
+
+    @pytest.mark.asyncio
+    async def test_private_reach_needs_no_namespace(self, control):
+        control.add_version('my_node', 1, '1.0.0')
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1, target='@me'))
+        assert result['success'] is True, result.get('message')
+
+    @pytest.mark.asyncio
+    async def test_withdrawing_publicly_is_gated_the_same_way(self, control):
+        # The reach check applies to taking something down, not only to
+        # putting it up: the bar is the audience, not the direction.
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('disable', target='@public'))
+        assert result['success'] is False
+        assert not control.states

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -280,3 +280,164 @@ class TestRefusals:
         )
         assert result['success'] is False
         assert not registry.published
+
+
+# =============================================================================
+# CONTROL — publishing leaves a version inert; these verbs make it reachable
+# =============================================================================
+
+
+class _ControlRegistry:
+    """Registry stand-in for the control verbs (rail, pins)."""
+
+    def __init__(self):
+        self.versions = {}
+        self.artifacts = {}
+        self.deployed = []
+        self.listed = []
+
+    def add_version(self, node_id, version, node_version, runtime='python'):
+        self.versions.setdefault(node_id, []).append(
+            {
+                'version': version,
+                'sha256': f'sha-{version}',
+                'state': 'ready',
+                'publishedAt': 1000 + version,
+                'publishedBy': {'display': 'Dev'},
+                'comment': f'v{node_version}',
+            }
+        )
+        self.artifacts[(node_id, version)] = {
+            'kind': 'node',
+            'nodeId': node_id,
+            'nodeVersion': node_version,
+            'runtime': runtime,
+        }
+
+    def install(self, monkeypatch):
+        from ai.account import account
+
+        async def deployments_versions(org_id, project_id):
+            return self.versions.get(project_id, [])
+
+        async def deployments_artifact(org_id, project_id, version):
+            return self.artifacts.get((project_id, version))
+
+        async def deployments_deploy(org_id, team_id, project_id, version, actor):
+            record = {'projectId': project_id, 'teamId': team_id, 'version': version}
+            self.deployed.append(record)
+            return record
+
+        async def deployments_list(org_id, team_id):
+            return self.listed
+
+        monkeypatch.setattr(account, 'deployments_versions', deployments_versions)
+        monkeypatch.setattr(account, 'deployments_artifact', deployments_artifact)
+        monkeypatch.setattr(account, 'deployments_deploy', deployments_deploy)
+        monkeypatch.setattr(account, 'deployments_list', deployments_list)
+
+
+@pytest.fixture
+def control(monkeypatch):
+    reg = _ControlRegistry()
+    reg.install(monkeypatch)
+    return reg
+
+
+def _control_request(subcommand, **args):
+    return {
+        'command': 'rrext_deploy_node',
+        'arguments': {'subcommand': subcommand, 'nodeId': 'my_node', **args},
+    }
+
+
+class TestVersions:
+    """The rail: what has been published, newest first."""
+
+    @pytest.mark.asyncio
+    async def test_newest_version_comes_first(self, control):
+        control.add_version('my_node', 1, '1.0.0')
+        control.add_version('my_node', 2, '1.1.0')
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('versions'))
+        rail = result['body']['versions']
+        assert [row['registryVersion'] for row in rail] == [2, 1]
+
+    @pytest.mark.asyncio
+    async def test_the_row_carries_the_nodes_own_version_and_runtime(self, control):
+        control.add_version('my_node', 1, '1.2.0')
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('versions'))
+        row = result['body']['versions'][0]
+        assert row['nodeVersion'] == '1.2.0'
+        assert row['runtime'] == 'python'
+
+    @pytest.mark.asyncio
+    async def test_a_node_with_no_versions_is_an_empty_rail(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('versions'))
+        assert result['body']['versions'] == []
+
+
+class TestDeploy:
+    """Pinning: first release, update and rollback are all this one verb."""
+
+    @pytest.mark.asyncio
+    async def test_pinning_defaults_to_the_caller(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1))
+        assert result['success'] is True
+        assert control.deployed[0]['version'] == 1
+        assert result['body']['audience']['type'] == 'user'
+
+    @pytest.mark.asyncio
+    async def test_the_registry_version_is_required_as_an_int(self, control):
+        # The node's own semver is not it: two versions can carry the same
+        # nodeVersion, and only one of them is this registry row.
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version='1.2.0'))
+        assert result['success'] is False
+        assert 'registry version' in result['message']
+        assert not control.deployed
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_target_is_refused(self, control):
+        result = await node_deploy.handle_node_deploy(
+            _FakeConn(), _control_request('deploy', version=1, target='@nowhere')
+        )
+        assert result['success'] is False
+        assert not control.deployed
+
+    @pytest.mark.asyncio
+    async def test_rollback_is_the_same_verb(self, control):
+        await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=2))
+        await node_deploy.handle_node_deploy(_FakeConn(), _control_request('deploy', version=1))
+        assert [d['version'] for d in control.deployed] == [2, 1]
+
+
+class TestWhere:
+    """The reverse index — which audience holds which version."""
+
+    @pytest.mark.asyncio
+    async def test_only_this_nodes_pins_are_returned(self, control):
+        control.listed = [
+            {'projectId': 'my_node', 'teamId': 'u1', 'version': 3},
+            {'projectId': 'other_node', 'teamId': 'u1', 'version': 9},
+        ]
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('where'))
+        assert result['body']['pins'] == [{'audience': 'u1', 'version': 3}]
+
+
+class TestControlRefusals:
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_connection_is_refused(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(authenticated=False), _control_request('versions'))
+        assert result['success'] is False
+
+    @pytest.mark.asyncio
+    async def test_a_missing_node_id_is_refused(self, control):
+        request = {'command': 'rrext_deploy_node', 'arguments': {'subcommand': 'versions'}}
+        result = await node_deploy.handle_node_deploy(_FakeConn(), request)
+        assert result['success'] is False
+        assert 'nodeId' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_subcommand_is_named_in_the_error(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('teleport'))
+        assert result['success'] is False
+        assert 'teleport' in result['message']

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -606,6 +606,46 @@ class TestWithdrawal:
         assert result['body']['audience']['type'] == 'user'
 
     @pytest.mark.asyncio
+    async def test_at_all_withdraws_every_binding(self, control):
+        # Unpublishing everywhere is one call, not one call per audience.
+        control.listed = [
+            {'nodeId': 'my_node', 'audience': {'type': 'user', 'id': 'u1'}, 'state': 'enabled'},
+            {'nodeId': 'my_node', 'audience': {'type': 'team', 'id': 't1'}, 'state': 'enabled'},
+        ]
+        conn = _FakeConn(teams=[{'id': 't1', 'name': 'Platform'}])
+        result = await node_deploy.handle_node_deploy(conn, _control_request('remove', target='@all'))
+        assert result['success'] is True
+        assert [row['audience']['id'] for row in control.states] == ['u1', 't1']
+
+    @pytest.mark.asyncio
+    async def test_at_all_checks_every_audience_before_touching_any(self, control):
+        # A team the caller is not in makes the WHOLE call fail: withdrawing
+        # half and stopping would leave the node reachable where it was meant
+        # to be gone.
+        control.listed = [
+            {'nodeId': 'my_node', 'audience': {'type': 'user', 'id': 'u1'}, 'state': 'enabled'},
+            {'nodeId': 'my_node', 'audience': {'type': 'team', 'id': 'strangers'}, 'state': 'enabled'},
+        ]
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('remove', target='@all'))
+        assert result['success'] is False
+        assert not control.states
+
+    @pytest.mark.asyncio
+    async def test_at_all_skips_bindings_already_removed(self, control):
+        control.listed = [
+            {'nodeId': 'my_node', 'audience': {'type': 'user', 'id': 'u1'}, 'state': 'removed'},
+            {'nodeId': 'my_node', 'audience': {'type': 'user', 'id': 'u1'}, 'state': 'enabled'},
+        ]
+        await node_deploy.handle_node_deploy(_FakeConn(), _control_request('disable', target='@all'))
+        assert len(control.states) == 1
+
+    @pytest.mark.asyncio
+    async def test_at_all_on_a_node_with_no_bindings_is_not_an_error(self, control):
+        result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('remove', target='@all'))
+        assert result['success'] is True
+        assert result['body']['publish'] == []
+
+    @pytest.mark.asyncio
     async def test_the_version_survives_a_withdrawal(self, control):
         # Nothing about the artifact is touched, which is what keeps a later
         # rollback to that same version possible.

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -675,3 +675,137 @@ class TestReachControls:
         result = await node_deploy.handle_node_deploy(_FakeConn(), _control_request('disable', target='@public'))
         assert result['success'] is False
         assert not control.states
+
+
+# =============================================================================
+# AVAILABILITY — the scope walk that answers "which nodes do I have"
+# =============================================================================
+
+
+class _PinRegistry:
+    """Binding rows plus the artifacts they point at."""
+
+    def __init__(self):
+        self.rows = []
+        self.artifacts = {}
+
+    def pin(
+        self,
+        node_id,
+        version,
+        audience_type,
+        audience_id='',
+        org_id='org1',
+        state='enabled',
+        artifact_state='ready',
+        name=None,
+    ):
+        self.rows.append(
+            {
+                'nodeId': node_id,
+                'version': version,
+                'audience': {'type': audience_type, 'id': audience_id},
+                'orgId': org_id,
+                'state': state,
+                'artifactState': artifact_state,
+                'snapshot': {'name': name} if name else {},
+            }
+        )
+        self.artifacts[(org_id, node_id, version)] = {
+            'kind': 'node',
+            'nodeId': node_id,
+            'name': name or node_id,
+            'nodeVersion': f'{version}.0.0',
+            'runtime': 'python',
+            'requirements': ['httpx'],
+            'bundleSha256': f'sha-{version}',
+        }
+
+    def install(self, monkeypatch):
+        from ai.account import account
+
+        async def publish_list(org_id, kind, audiences):
+            wanted = {(a['type'], a.get('id', '')) for a in audiences}
+            return [r for r in self.rows if (r['audience']['type'], r['audience']['id']) in wanted]
+
+        async def deployments_artifact(org_id, node_id, version):
+            return self.artifacts.get((org_id, node_id, version))
+
+        monkeypatch.setattr(account, 'publish_list', publish_list)
+        monkeypatch.setattr(account, 'deployments_artifact', deployments_artifact)
+
+
+@pytest.fixture
+def pins(monkeypatch):
+    reg = _PinRegistry()
+    reg.install(monkeypatch)
+    return reg
+
+
+class TestAvailability:
+    """resolve_node_pins — the one answer the picker and the resolver share."""
+
+    @pytest.mark.asyncio
+    async def test_a_personal_pin_is_available(self, pins):
+        pins.pin('my_node', 3, 'user', 'u1')
+        entries = await node_deploy.resolve_node_pins('org1', 'u1', [])
+        assert [(e['id'], e['version'], e['rung']) for e in entries] == [('my_node', 3, 'personal')]
+
+    @pytest.mark.asyncio
+    async def test_the_more_specific_rung_wins(self, pins):
+        # Same node pinned three ways; the user's own pin is what runs.
+        pins.pin('my_node', 1, 'public')
+        pins.pin('my_node', 2, 'team', 't1')
+        pins.pin('my_node', 3, 'user', 'u1')
+        entries = await node_deploy.resolve_node_pins('org1', 'u1', ['t1'])
+        assert len(entries) == 1
+        assert entries[0]['version'] == 3
+
+    @pytest.mark.asyncio
+    async def test_a_team_pin_beats_a_public_one(self, pins):
+        pins.pin('my_node', 1, 'public')
+        pins.pin('my_node', 2, 'team', 't1')
+        entries = await node_deploy.resolve_node_pins('org1', 'u1', ['t1'])
+        assert entries[0]['version'] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_binding_never_serves(self, pins):
+        pins.pin('my_node', 3, 'user', 'u1', state='disabled')
+        assert await node_deploy.resolve_node_pins('org1', 'u1', []) == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_version_never_serves(self, pins):
+        pins.pin('my_node', 3, 'user', 'u1', artifact_state='failed')
+        assert await node_deploy.resolve_node_pins('org1', 'u1', []) == []
+
+    @pytest.mark.asyncio
+    async def test_public_reach_demands_a_ready_version(self, pins):
+        # Internal reach tolerates a version still settling; public does not.
+        pins.pin('my_node', 3, 'public', artifact_state='building')
+        assert await node_deploy.resolve_node_pins('org1', 'u1', []) == []
+
+    @pytest.mark.asyncio
+    async def test_requirements_ride_on_the_entry(self, pins):
+        # So a caller knows what the node needs before fetching it.
+        pins.pin('my_node', 3, 'user', 'u1')
+        entries = await node_deploy.resolve_node_pins('org1', 'u1', [])
+        assert entries[0]['requirements'] == ['httpx']
+        assert entries[0]['bundleSha256'] == 'sha-3'
+
+    @pytest.mark.asyncio
+    async def test_a_team_the_caller_is_not_in_is_not_walked(self, pins):
+        pins.pin('other_node', 1, 'team', 't9')
+        assert await node_deploy.resolve_node_pins('org1', 'u1', ['t1']) == []
+
+    @pytest.mark.asyncio
+    async def test_distinct_nodes_all_come_back(self, pins):
+        pins.pin('node_a', 1, 'user', 'u1')
+        pins.pin('node_b', 2, 'team', 't1')
+        entries = await node_deploy.resolve_node_pins('org1', 'u1', ['t1'])
+        assert sorted(e['id'] for e in entries) == ['node_a', 'node_b']
+
+    @pytest.mark.asyncio
+    async def test_a_binding_without_its_artifact_is_skipped(self, pins):
+        pins.pin('my_node', 3, 'user', 'u1')
+        pins.artifacts.clear()
+        assert await node_deploy.resolve_node_pins('org1', 'u1', []) == []

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -36,13 +36,13 @@ from ai.account.store import Store
 class _FakeConn:
     """Minimal TaskConn stand-in: account info + response builders."""
 
-    def __init__(self, user_id='u1', org_id='org1', authenticated=True):
+    def __init__(self, user_id='u1', org_id='org1', authenticated=True, teams=None):
         self._account_info = (
             SimpleNamespace(
                 userId=user_id,
                 displayName='User One',
                 email='u1@example.com',
-                organization={'id': org_id, 'teams': [], 'developerId': 'acme'},
+                organization={'id': org_id, 'teams': teams or [], 'developerId': 'acme'},
             )
             if authenticated
             else None
@@ -63,6 +63,7 @@ class _FakeRegistry:
         self.published = []
         self.states = []
         self.audits = []
+        self.bound = []
         self.next_version = 1
 
     def install(self, monkeypatch):
@@ -88,9 +89,29 @@ class _FakeRegistry:
         async def audit(user_id, area, action, request_data=None, org_id=None):
             self.audits.append({'action': action, 'data': request_data})
 
+        # The bind side, reading back exactly what the publish above wrote —
+        # deployTo binds the version it just created, so a fake that invented
+        # its own rows would not be testing the seam that matters.
+        async def deployments_versions(org_id, project_id):
+            return [p['entry'] for p in self.published if p['projectId'] == project_id]
+
+        async def deployments_artifact(org_id, project_id, version):
+            for pub in self.published:
+                if pub['projectId'] == project_id and pub['entry']['version'] == version:
+                    return pub['artifact']
+            return None
+
+        async def publish_set(org_id, kind, node_id, audience, version, snapshot, actor):
+            row = {'kind': kind, 'nodeId': node_id, 'audience': audience, 'version': version, 'state': 'enabled'}
+            self.bound.append(row)
+            return row
+
         monkeypatch.setattr(account, 'deployments_publish', deployments_publish)
         monkeypatch.setattr(account, 'set_artifact_state', set_artifact_state)
         monkeypatch.setattr(account, 'audit', audit)
+        monkeypatch.setattr(account, 'deployments_versions', deployments_versions)
+        monkeypatch.setattr(account, 'deployments_artifact', deployments_artifact)
+        monkeypatch.setattr(account, 'publish_set', publish_set)
 
 
 @pytest.fixture
@@ -280,6 +301,65 @@ class TestRefusals:
         )
         assert result['success'] is False
         assert not registry.published
+
+
+# =============================================================================
+# ONE-STEP PUBLISH + BIND — the CLI's --deploy-to
+# =============================================================================
+
+
+class TestDeployTo:
+    """Publishing and binding in one call, the way the CLI already sends it."""
+
+    @staticmethod
+    def _member_of(team_id='t1', name='Platform'):
+        """A caller who belongs to one team, so @team targets can resolve."""
+        return _FakeConn(teams=[{'id': team_id, 'name': name}])
+
+    @pytest.mark.asyncio
+    async def test_a_bare_team_binds_in_one_step(self, registry, content_store):
+        # The CLI spells --deploy-to as a plain team, with no '@'.
+        result = await node_deploy.handle_node_add(
+            self._member_of(), _add_request(data=_node_zip(), deployTo='Platform')
+        )
+        assert result['success'] is True
+        assert registry.bound[0]['audience']['type'] == 'team'
+        assert registry.bound[0]['audience']['id'] == 't1'
+
+    @pytest.mark.asyncio
+    async def test_it_binds_the_version_it_just_published(self, registry, content_store):
+        await node_deploy.handle_node_add(self._member_of(), _add_request(data=_node_zip(), deployTo='Platform'))
+        await node_deploy.handle_node_add(self._member_of(), _add_request(data=_node_zip(), deployTo='Platform'))
+        # The second call pins v2, not the version that happened to be first.
+        assert [row['version'] for row in registry.bound] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_an_at_target_passes_through(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip(), deployTo='@me'))
+        assert result['success'] is True
+        assert registry.bound[0]['audience']['type'] == 'user'
+
+    @pytest.mark.asyncio
+    async def test_without_deploy_to_the_version_stays_inert(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        assert result['success'] is True
+        assert registry.published
+        assert not registry.bound
+
+    @pytest.mark.asyncio
+    async def test_a_team_the_caller_is_not_in_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip(), deployTo='Strangers'))
+        assert result['success'] is False
+        assert not registry.bound
+
+    @pytest.mark.asyncio
+    async def test_a_failed_bind_leaves_the_version_published(self, registry, content_store):
+        # The bytes landed and the version is real — only the pointer failed,
+        # so the error says so and the caller can bind without re-uploading.
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip(), deployTo='Strangers'))
+        assert 'published' in result['message']
+        assert registry.published[0]['entry']['version'] == 1
+        assert registry.states == []
 
 
 # =============================================================================

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -1,0 +1,282 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""The node branch of ``rrext_deploy add``.
+
+Nodes ride the registry apps and pipes already use, so what these tests pin is
+the adapter: that a node zip becomes a ``kind:'node'`` artifact, that its
+content lands beside that artifact, that the node's own manifest — not the
+caller — decides the id, and that a bad archive leaves nothing behind.
+
+The fakes and fixtures follow ``test_app_deploy.py``: an in-memory registry
+over the account singleton, and the REAL Store over a temp filesystem, so a
+call against a method the store does not have fails here as it would live.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from ai.account import node_deploy
+from ai.account.store import Store
+
+
+# =============================================================================
+# FAKES
+# =============================================================================
+
+
+class _FakeConn:
+    """Minimal TaskConn stand-in: account info + response builders."""
+
+    def __init__(self, user_id='u1', org_id='org1', authenticated=True):
+        self._account_info = (
+            SimpleNamespace(
+                userId=user_id,
+                displayName='User One',
+                email='u1@example.com',
+                organization={'id': org_id, 'teams': [], 'developerId': 'acme'},
+            )
+            if authenticated
+            else None
+        )
+        self._server = SimpleNamespace()
+
+    def build_response(self, request, body=None):
+        return {'success': True, 'body': body or {}}
+
+    def build_error(self, request, message):
+        return {'success': False, 'message': message}
+
+
+class _FakeRegistry:
+    """In-memory registry patched over the account singleton."""
+
+    def __init__(self):
+        self.published = []
+        self.states = []
+        self.audits = []
+        self.next_version = 1
+
+    def install(self, monkeypatch):
+        from ai.account import account
+
+        async def deployments_publish(org_id, project_id, artifact, actor, comment='', metadata=None, **kwargs):
+            version = self.next_version
+            self.next_version += 1
+            entry = {
+                'version': version,
+                'sha256': f'sha-{version}',
+                'metadata': metadata or {},
+                'artifactPath': f'orgs/{org_id}/files/.deployments/{project_id}/v{version:06d}-fake.json',
+            }
+            self.published.append(
+                {'orgId': org_id, 'projectId': project_id, 'artifact': artifact, 'comment': comment, 'entry': entry}
+            )
+            return entry
+
+        async def set_artifact_state(org_id, project_id, version, state, actor):
+            self.states.append({'projectId': project_id, 'version': version, 'state': state})
+
+        async def audit(user_id, area, action, request_data=None, org_id=None):
+            self.audits.append({'action': action, 'data': request_data})
+
+        monkeypatch.setattr(account, 'deployments_publish', deployments_publish)
+        monkeypatch.setattr(account, 'set_artifact_state', set_artifact_state)
+        monkeypatch.setattr(account, 'audit', audit)
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = _FakeRegistry()
+    reg.install(monkeypatch)
+    return reg
+
+
+@pytest.fixture
+def content_store(monkeypatch, tmp_path):
+    """The REAL Store over a temp filesystem backend."""
+    monkeypatch.setenv('RR_STORE_URL', f'filesystem://{tmp_path}')
+    Store.reset()
+    yield tmp_path
+    Store.reset()
+
+
+def _written(root):
+    """Physical files under the temp store root: relative posix path -> bytes."""
+    return {p.relative_to(root).as_posix(): p.read_bytes() for p in root.rglob('*') if p.is_file()}
+
+
+def _node_zip(manifest=None, files=None):
+    """An in-memory node directory zip: services.json at the root + sources."""
+    manifest = (
+        manifest
+        if manifest is not None
+        else {'protocol': 'my_node://', 'title': 'My Node', 'version': '1.2.0', 'classType': ['transform']}
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as archive:
+        archive.writestr('services.json', json.dumps(manifest))
+        archive.writestr('IInstance.py', 'class IInstance:\n    pass\n')
+        for name, content in (files or {}).items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _add_request(**args):
+    """A raw rrext_deploy add request dict, node branch."""
+    return {'command': 'rrext_deploy', 'arguments': {'subcommand': 'add', 'kind': 'node', **args}}
+
+
+# =============================================================================
+# THE ARTIFACT
+# =============================================================================
+
+
+class TestArtifact:
+    """What the registry ends up holding for a node version."""
+
+    @pytest.mark.asyncio
+    async def test_the_artifact_is_kind_node(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        assert registry.published[0]['artifact']['kind'] == 'node'
+
+    @pytest.mark.asyncio
+    async def test_the_id_comes_from_the_manifest_not_the_caller(self, registry, content_store):
+        # A caller naming a different node must not decide where it publishes.
+        await node_deploy.handle_node_add(
+            _FakeConn(), _add_request(data=_node_zip(), nodeId='something_else', name='Impostor')
+        )
+        assert registry.published[0]['artifact']['nodeId'] == 'my_node'
+        assert registry.published[0]['projectId'] == 'my_node'
+
+    @pytest.mark.asyncio
+    async def test_the_display_name_and_version_ride_along(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        artifact = registry.published[0]['artifact']
+        assert artifact['name'] == 'My Node'
+        assert artifact['nodeVersion'] == '1.2.0'
+
+    @pytest.mark.asyncio
+    async def test_the_runtime_is_recorded_from_the_first_version(self, registry, content_store):
+        # Native nodes (#1577) ship per-platform content; a resolver has to
+        # know what it is fetching before it fetches it.
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        assert registry.published[0]['artifact']['runtime'] == node_deploy.RUNTIME_PYTHON
+
+    @pytest.mark.asyncio
+    async def test_the_bundle_digest_is_recorded(self, registry, content_store):
+        data = _node_zip()
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=data))
+        import hashlib
+
+        assert registry.published[0]['artifact']['bundleSha256'] == hashlib.sha256(data).hexdigest()
+
+
+# =============================================================================
+# THE CONTENT
+# =============================================================================
+
+
+class TestContent:
+    """Where the bytes land, and in what shape."""
+
+    @pytest.mark.asyncio
+    async def test_the_transport_zip_is_retained(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        paths = _written(content_store)
+        assert any('/bundle/my_node-v000001.zip' in p for p in paths), sorted(paths)
+
+    @pytest.mark.asyncio
+    async def test_the_source_tree_is_unpacked(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        paths = _written(content_store)
+        assert any(p.endswith('/source/services.json') for p in paths), sorted(paths)
+        assert any(p.endswith('/source/IInstance.py') for p in paths), sorted(paths)
+
+    @pytest.mark.asyncio
+    async def test_content_sits_beside_its_artifact(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        # The version number names the directory, so two versions never mix.
+        assert any('v000001' in p for p in _written(content_store))
+
+
+# =============================================================================
+# REFUSALS — nothing is registered when the input is bad
+# =============================================================================
+
+
+class TestRefusals:
+    """A refused deploy must leave no version behind."""
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_connection_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(authenticated=False), _add_request(data=_node_zip()))
+        assert result['success'] is False
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_missing_data_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request())
+        assert result['success'] is False
+        assert 'required' in result['message']
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_text_instead_of_a_binary_frame_is_refused(self, registry, content_store):
+        # A str would make zipfile raise TypeError and escape as a 500.
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data='not bytes'))
+        assert result['success'] is False
+        assert 'binary' in result['message']
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_a_non_zip_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=b'not a zip at all'))
+        assert result['success'] is False
+        assert 'zip' in result['message']
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_a_zip_without_a_manifest_is_refused(self, registry, content_store):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as archive:
+            archive.writestr('IInstance.py', 'pass')
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=buffer.getvalue()))
+        assert result['success'] is False
+        assert 'services.json' in result['message']
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_a_manifest_without_an_id_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(
+            _FakeConn(), _add_request(data=_node_zip(manifest={'title': 'Nameless'}))
+        )
+        assert result['success'] is False
+        assert not registry.published
+
+    @pytest.mark.asyncio
+    async def test_a_traversal_entry_is_refused_before_publishing(self, registry, content_store):
+        # The archive guard runs BEFORE the registry row, so a hostile zip
+        # never leaves a version with no bytes behind it.
+        result = await node_deploy.handle_node_add(
+            _FakeConn(), _add_request(data=_node_zip(files={'../escape.py': 'pass'}))
+        )
+        assert result['success'] is False
+        assert not registry.published
+        assert not _written(content_store)
+
+    @pytest.mark.asyncio
+    async def test_an_unsafe_node_id_is_refused(self, registry, content_store):
+        result = await node_deploy.handle_node_add(
+            _FakeConn(), _add_request(data=_node_zip(manifest={'protocol': '../../etc://', 'title': 'Bad'}))
+        )
+        assert result['success'] is False
+        assert not registry.published

--- a/packages/ai/tests/ai/account/test_node_deploy.py
+++ b/packages/ai/tests/ai/account/test_node_deploy.py
@@ -304,6 +304,51 @@ class TestRefusals:
 
 
 # =============================================================================
+# DEPENDENCIES — what the node needs, and what it may not bring
+# =============================================================================
+
+
+class TestRequirements:
+    """A node's own requirements.txt, and the file it may not carry."""
+
+    @pytest.mark.asyncio
+    async def test_requirements_ride_on_the_artifact(self, registry, content_store):
+        # On the artifact, not only inside the bundle: a resolver decides
+        # whether it can run the node before it downloads it.
+        zip_bytes = _node_zip(files={'requirements.txt': 'httpx\npydantic\n'})
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=zip_bytes))
+        assert registry.published[0]['artifact']['requirements'] == ['httpx', 'pydantic']
+
+    @pytest.mark.asyncio
+    async def test_comments_and_blank_lines_are_dropped(self, registry, content_store):
+        zip_bytes = _node_zip(files={'requirements.txt': '# needed for the API\n\nhttpx\n\n# and this\nrich\n'})
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=zip_bytes))
+        assert registry.published[0]['artifact']['requirements'] == ['httpx', 'rich']
+
+    @pytest.mark.asyncio
+    async def test_a_node_without_requirements_declares_none(self, registry, content_store):
+        await node_deploy.handle_node_add(_FakeConn(), _add_request(data=_node_zip()))
+        assert registry.published[0]['artifact']['requirements'] == []
+
+    @pytest.mark.asyncio
+    async def test_an_overrides_file_is_refused(self, registry, content_store):
+        # overrides.txt REPLACES what other packages declare, engine-wide.
+        zip_bytes = _node_zip(files={'overrides.txt': 'urllib3==1.0\n'})
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=zip_bytes))
+        assert result['success'] is False
+        assert 'overrides.txt' in result['message']
+        assert not registry.published
+        assert not _written(content_store)
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_requirements_file_is_refused(self, registry, content_store):
+        zip_bytes = _node_zip(files={'requirements.txt': 'x\n' * 40000})
+        result = await node_deploy.handle_node_add(_FakeConn(), _add_request(data=zip_bytes))
+        assert result['success'] is False
+        assert not registry.published
+
+
+# =============================================================================
 # ONE-STEP PUBLISH + BIND — the CLI's --deploy-to
 # =============================================================================
 

--- a/packages/ai/tests/ai/account/test_node_resolve.py
+++ b/packages/ai/tests/ai/account/test_node_resolve.py
@@ -278,6 +278,29 @@ class TestMaterialise:
             await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
 
     @pytest.mark.asyncio
+    async def test_a_missing_digest_cannot_borrow_a_warm_cache(self, live):
+        # An empty digest would otherwise join to the node's OWN directory,
+        # which on a warm cache exists and holds the digest slots — copied
+        # out, that is a folder of hashes pretending to be a node, and it
+        # would happen before the digest check ever ran.
+        entry = await live.publish()
+        await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert Path(node_resolve.cache_root(), 'ticket_feed').is_dir()
+
+        second = dict(entry, bundleSha256='')
+        with pytest.raises(node_resolve.BundleMismatch):
+            await node_resolve.materialise([second], str(Path(live.run_root) / 'second'), 'org1', 'u1')
+        assert not (Path(live.run_root) / 'second' / 'local_nodes').exists()
+
+    @pytest.mark.asyncio
+    async def test_a_digest_that_is_not_a_digest_is_refused(self, live):
+        # Also closes the path it would otherwise be joined into.
+        entry = await live.publish()
+        for bad in ('../../etc', 'NOTHEX' * 10, 'abc'):
+            with pytest.raises(node_resolve.BundleMismatch):
+                await node_resolve.materialise([dict(entry, bundleSha256=bad)], live.run_root, 'org1', 'u1')
+
+    @pytest.mark.asyncio
     async def test_the_second_run_reuses_the_cache(self, live):
         entry = await live.publish()
         await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')

--- a/packages/ai/tests/ai/account/test_node_resolve.py
+++ b/packages/ai/tests/ai/account/test_node_resolve.py
@@ -1,0 +1,124 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Deciding which published nodes a run has to fetch.
+
+What these pin is the decision, not the fetching: that a pipeline of stock
+nodes resolves to nothing at all, that a node with no pin stops the run before
+any bytes move, and that the failure names what is missing and where it looked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.account import node_resolve
+
+
+def _pipeline(*providers):
+    """A pipeline shell carrying one component per provider named."""
+    return {'components': [{'provider': name, 'config': {}} for name in providers]}
+
+
+@pytest.fixture
+def published(monkeypatch):
+    """Whatever the caller has pins for, keyed by node id."""
+    entries = {}
+
+    async def resolve_node_pins(org_id, user_id, team_ids):
+        return list(entries.values())
+
+    monkeypatch.setattr(node_resolve, 'resolve_node_pins', resolve_node_pins)
+
+    def add(node_id, version=1, **extra):
+        entries[node_id] = {'id': node_id, 'version': version, 'requirements': [], **extra}
+
+    return add
+
+
+# =============================================================================
+# DETECTION
+# =============================================================================
+
+
+class TestProviders:
+    """Reading what a pipeline asks for."""
+
+    def test_every_provider_is_named(self):
+        assert node_resolve.providers_of(_pipeline('llm_openai', 'store_chroma')) == {'llm_openai', 'store_chroma'}
+
+    def test_a_provider_used_twice_counts_once(self):
+        assert node_resolve.providers_of(_pipeline('llm_openai', 'llm_openai')) == {'llm_openai'}
+
+    def test_a_pipeline_with_no_components_asks_for_nothing(self):
+        assert node_resolve.providers_of({}) == set()
+
+    def test_malformed_components_are_skipped_not_fatal(self):
+        # A pipeline is user input; a stray null must not take the run down
+        # before it starts.
+        pipeline = {'components': [None, 'nonsense', {'provider': 'llm_openai'}, {'no_provider': 1}]}
+        assert node_resolve.providers_of(pipeline) == {'llm_openai'}
+
+    def test_missing_is_what_the_engine_lacks(self):
+        assert node_resolve.missing_from({'a', 'b'}, {'b'}) == {'a'}
+
+
+# =============================================================================
+# THE PLAN
+# =============================================================================
+
+
+class TestPlan:
+    """What a run has to go and get, before anything moves."""
+
+    @pytest.mark.asyncio
+    async def test_a_pipeline_of_stock_nodes_resolves_nothing(self, published):
+        # The common case: no lookup, no fetch, no cost.
+        plan = await node_resolve.plan_for(_pipeline('llm_openai'), {'llm_openai'}, 'org1', 'u1', [])
+        assert plan == []
+
+    @pytest.mark.asyncio
+    async def test_a_published_node_is_planned_with_its_version(self, published):
+        published('ticket_feed', version=3)
+        plan = await node_resolve.plan_for(_pipeline('llm_openai', 'ticket_feed'), {'llm_openai'}, 'org1', 'u1', [])
+        assert [(entry['id'], entry['version']) for entry in plan] == [('ticket_feed', 3)]
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_node_stops_the_run(self, published):
+        with pytest.raises(node_resolve.UnresolvedNodes) as caught:
+            await node_resolve.plan_for(_pipeline('ticket_feed'), set(), 'org1', 'u1', [])
+        assert caught.value.names == ['ticket_feed']
+
+    @pytest.mark.asyncio
+    async def test_the_failure_names_the_node_and_the_org(self, published):
+        # "not found" is a dead end; naming the org tells someone what to do.
+        with pytest.raises(node_resolve.UnresolvedNodes) as caught:
+            await node_resolve.plan_for(_pipeline('ticket_feed'), set(), 'acme', 'u1', [])
+        assert 'ticket_feed' in str(caught.value)
+        assert 'acme' in str(caught.value)
+
+    @pytest.mark.asyncio
+    async def test_one_unresolvable_node_stops_the_whole_run(self, published):
+        # Not "fetch what we can": a run missing one of its nodes cannot work,
+        # so it fails before downloading the others.
+        published('ticket_feed')
+        with pytest.raises(node_resolve.UnresolvedNodes) as caught:
+            await node_resolve.plan_for(_pipeline('ticket_feed', 'sentiment'), set(), 'org1', 'u1', [])
+        assert caught.value.names == ['sentiment']
+
+    @pytest.mark.asyncio
+    async def test_every_missing_node_is_reported_at_once(self, published):
+        # Fixing them one run at a time would be miserable.
+        with pytest.raises(node_resolve.UnresolvedNodes) as caught:
+            await node_resolve.plan_for(_pipeline('b_node', 'a_node'), set(), 'org1', 'u1', [])
+        assert caught.value.names == ['a_node', 'b_node']
+
+    @pytest.mark.asyncio
+    async def test_a_node_the_engine_carries_is_never_looked_up(self, published):
+        # A published node sharing a name with a built-in must not shadow it:
+        # what the engine has already wins, and nothing is fetched.
+        published('llm_openai', version=9)
+        plan = await node_resolve.plan_for(_pipeline('llm_openai'), {'llm_openai'}, 'org1', 'u1', [])
+        assert plan == []

--- a/packages/ai/tests/ai/account/test_node_resolve.py
+++ b/packages/ai/tests/ai/account/test_node_resolve.py
@@ -122,3 +122,193 @@ class TestPlan:
         published('llm_openai', version=9)
         plan = await node_resolve.plan_for(_pipeline('llm_openai'), {'llm_openai'}, 'org1', 'u1', [])
         assert plan == []
+
+
+# =============================================================================
+# FETCH AND MATERIALISE
+# =============================================================================
+#
+# These publish a node for real through handle_node_add and then resolve it
+# back, over the REAL Store on a temp filesystem. That is deliberate: publish
+# and resolve agree on where a bundle lives only by convention, and a fake
+# store on both sides would let those two drift apart without a test noticing.
+
+
+import io  # noqa: E402
+import json  # noqa: E402
+import zipfile  # noqa: E402
+from pathlib import Path  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+from ai.account import node_deploy  # noqa: E402
+from ai.account.store import Store  # noqa: E402
+
+
+class _Conn:
+    def __init__(self, org_id='org1'):
+        self._account_info = SimpleNamespace(
+            userId='u1',
+            displayName='User One',
+            email='u1@example.com',
+            organization={'id': org_id, 'teams': [], 'developerId': 'acme'},
+        )
+        self._server = SimpleNamespace()
+
+    def build_response(self, request, body=None):
+        return {'success': True, 'body': body or {}}
+
+    def build_error(self, request, message):
+        return {'success': False, 'message': message}
+
+
+def _zip(files=None, manifest=None):
+    manifest = manifest or {'protocol': 'ticket_feed://', 'title': 'Ticket Feed', 'version': '1.2.0'}
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as archive:
+        archive.writestr('services.json', json.dumps(manifest))
+        archive.writestr('IInstance.py', 'class IInstance:\n    pass\n')
+        for name, content in (files or {}).items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def live(monkeypatch, tmp_path):
+    """A real Store plus a registry that remembers what was published."""
+    from ai.account import account
+
+    monkeypatch.setenv('RR_STORE_URL', f'filesystem://{tmp_path / "store"}')
+    Store.reset()
+    published = []
+    reads = {'count': 0}
+
+    async def deployments_publish(org_id, project_id, artifact, actor, comment='', metadata=None, **kwargs):
+        version = len(published) + 1
+        entry = {
+            'version': version,
+            'sha256': f'sha-{version}',
+            'metadata': metadata or {},
+            'artifactPath': f'orgs/{org_id}/files/.deployments/{project_id}/v{version:06d}-abcd1234.json',
+        }
+        published.append({'projectId': project_id, 'artifact': artifact, 'entry': entry})
+        return entry
+
+    async def deployments_versions(org_id, project_id):
+        return [p['entry'] for p in published if p['projectId'] == project_id]
+
+    async def set_artifact_state(org_id, project_id, version, state, actor):
+        pass
+
+    async def audit(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(account, 'deployments_publish', deployments_publish)
+    monkeypatch.setattr(account, 'deployments_versions', deployments_versions)
+    monkeypatch.setattr(account, 'set_artifact_state', set_artifact_state)
+    monkeypatch.setattr(account, 'audit', audit)
+    monkeypatch.setattr(node_resolve, 'cache_root', lambda: str(tmp_path / 'cache'))
+
+    real_read = None
+
+    async def counted_read(self, filename):
+        reads['count'] += 1
+        return await real_read(self, filename)
+
+    async def publish(files=None, manifest=None):
+        """Publish a node and hand back the entry a resolver would plan."""
+        result = await node_deploy.handle_node_add(
+            _Conn(),
+            {
+                'command': 'rrext_deploy',
+                'arguments': {'subcommand': 'add', 'kind': 'node', 'data': _zip(files, manifest)},
+            },
+        )
+        assert result['success'] is True, result
+        artifact = published[-1]['artifact']
+        return {
+            'id': artifact['nodeId'],
+            'version': result['body']['artifact']['version'],
+            'bundleSha256': artifact['bundleSha256'],
+            'requirements': artifact['requirements'],
+        }
+
+    yield SimpleNamespace(publish=publish, reads=reads, run_root=str(tmp_path / 'run'), published=published)
+    Store.reset()
+
+
+class TestMaterialise:
+    """Bringing a published node onto a machine that does not have it."""
+
+    @pytest.mark.asyncio
+    async def test_the_node_directory_is_restored(self, live):
+        entry = await live.publish()
+        written = await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        placed = Path(written[0])
+        assert placed.name == 'ticket_feed'
+        assert (placed / 'services.json').exists()
+        assert (placed / 'IInstance.py').read_text().startswith('class IInstance')
+
+    @pytest.mark.asyncio
+    async def test_the_package_marker_is_written_by_the_resolver(self, live):
+        # It is the PARENT of the node directory, so it is not in the bundle.
+        entry = await live.publish()
+        await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert (Path(live.run_root) / 'local_nodes' / '__init__.py').exists()
+
+    @pytest.mark.asyncio
+    async def test_it_lands_where_the_engine_imports_from(self, live):
+        # local_nodes/<id>/ — so the manifest's own path resolves untouched.
+        entry = await live.publish()
+        written = await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert Path(written[0]) == Path(live.run_root) / 'local_nodes' / 'ticket_feed'
+
+    @pytest.mark.asyncio
+    async def test_a_digest_mismatch_refuses_before_unpacking(self, live):
+        entry = await live.publish()
+        entry['bundleSha256'] = 'f' * 64
+        with pytest.raises(node_resolve.BundleMismatch):
+            await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert not (Path(live.run_root) / 'local_nodes').exists()
+
+    @pytest.mark.asyncio
+    async def test_a_version_with_no_digest_is_refused(self, live):
+        entry = await live.publish()
+        entry['bundleSha256'] = ''
+        with pytest.raises(node_resolve.BundleMismatch):
+            await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+
+    @pytest.mark.asyncio
+    async def test_the_second_run_reuses_the_cache(self, live):
+        entry = await live.publish()
+        await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        slot = node_resolve.cache_slot('ticket_feed', entry['bundleSha256'])
+        assert Path(slot).is_dir()
+        # A second materialise finds the slot and never touches the store.
+        node_resolve.clean(live.run_root)
+        await node_resolve.materialise([entry], str(Path(live.run_root) / 'second'), 'org1', 'u1')
+        assert (Path(live.run_root) / 'second' / 'local_nodes' / 'ticket_feed' / 'services.json').exists()
+
+    @pytest.mark.asyncio
+    async def test_no_partial_slot_survives_a_failure(self, live):
+        entry = await live.publish()
+        entry['bundleSha256'] = 'f' * 64
+        with pytest.raises(node_resolve.BundleMismatch):
+            await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        leftovers = list(Path(node_resolve.cache_root()).rglob('*.partial'))
+        assert leftovers == []
+
+    @pytest.mark.asyncio
+    async def test_clean_drops_the_run_tree_and_keeps_the_cache(self, live):
+        entry = await live.publish()
+        await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        node_resolve.clean(live.run_root)
+        assert not (Path(live.run_root) / 'local_nodes').exists()
+        assert Path(node_resolve.cache_slot('ticket_feed', entry['bundleSha256'])).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_requirements_travel_with_the_node(self, live):
+        # The resolver has to be able to see them on disk to act on them.
+        entry = await live.publish(files={'requirements.txt': 'httpx\n'})
+        written = await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert (Path(written[0]) / 'requirements.txt').read_text() == 'httpx\n'
+        assert entry['requirements'] == ['httpx']

--- a/packages/ai/tests/ai/account/test_node_resolve.py
+++ b/packages/ai/tests/ai/account/test_node_resolve.py
@@ -312,3 +312,41 @@ class TestMaterialise:
         written = await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
         assert (Path(written[0]) / 'requirements.txt').read_text() == 'httpx\n'
         assert entry['requirements'] == ['httpx']
+
+
+class TestRequirements:
+    """A published node's dependencies, which the engine's startup sweep misses."""
+
+    @pytest.fixture
+    def installs(self, monkeypatch):
+        """Record what the engine installer was asked to install."""
+        calls = []
+        monkeypatch.setattr(node_resolve, '_install', lambda path: calls.append(path))
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_declared_requirements_are_installed(self, live, installs):
+        entry = await live.publish(files={'requirements.txt': 'httpx\n'})
+        written = await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        # Installed from the materialised copy, so the path exists on disk.
+        assert installs == [str(Path(written[0]) / 'requirements.txt')]
+
+    @pytest.mark.asyncio
+    async def test_a_node_without_requirements_installs_nothing(self, live, installs):
+        entry = await live.publish()
+        await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert installs == []
+
+    @pytest.mark.asyncio
+    async def test_an_unsatisfiable_node_fails_the_run_by_name(self, live, monkeypatch):
+        # Against the constraints lock a conflict is refused rather than
+        # settled by downgrading someone else's package — so the run stops,
+        # and it says which node could not fit.
+        def boom(path):
+            raise RuntimeError('httpx==9.9 conflicts with the lock')
+
+        monkeypatch.setattr(node_resolve, '_install', boom)
+        entry = await live.publish(files={'requirements.txt': 'httpx==9.9\n'})
+        with pytest.raises(node_resolve.DependencyFailure) as caught:
+            await node_resolve.materialise([entry], live.run_root, 'org1', 'u1')
+        assert 'ticket_feed' in str(caught.value)

--- a/packages/ai/tests/ai/modules/task/test_task_conn_wiring.py
+++ b/packages/ai/tests/ai/modules/task/test_task_conn_wiring.py
@@ -1,0 +1,79 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""How TaskConn wires its command mixins together.
+
+``TaskConn`` initialises its mixins by hand, calling
+``SomeCommands.__init__(self, connection_id, server, transport, **kwargs)``
+on each. That only works for a mixin that defines its own three-argument
+constructor: one that does not falls through to ``DAPConn.__init__``, which
+takes a single positional, and **every connection then dies with a TypeError
+before it can serve anything**.
+
+Nothing catches that today, because the command tests all use connection
+stand-ins rather than the real class. This pins the invariant instead: a
+mixin is either explicitly initialised AND has its own constructor, or it is
+neither.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from ai.common.dap import DAPConn
+from ai.modules.task import task_conn as task_conn_module
+
+#: `SomeCommands.__init__(self, connection_id, ...)` as TaskConn writes it.
+_EXPLICIT_INIT = re.compile(r'^\s*(\w+Commands)\.__init__\(self,', re.M)
+
+
+def _explicitly_initialised() -> list[str]:
+    """Mixin class names TaskConn initialises by hand, in source order."""
+    source = Path(inspect.getfile(task_conn_module)).read_text(encoding='utf-8')
+    return _EXPLICIT_INIT.findall(source)
+
+
+def test_taskconn_initialises_some_mixins_by_hand():
+    """Guards the guard: if the pattern ever changes, this file must too."""
+    assert len(_explicitly_initialised()) > 3
+
+
+@pytest.mark.parametrize('name', _explicitly_initialised())
+def test_an_explicitly_initialised_mixin_owns_its_constructor(name):
+    mixin = getattr(task_conn_module, name)
+    assert '__init__' in mixin.__dict__, (
+        f'TaskConn calls {name}.__init__(self, connection_id, server, transport), '
+        f'but {name} defines no constructor — that call resolves to '
+        f'DAPConn.__init__, which takes one positional argument, and every '
+        f'connection dies. Either give {name} the three-argument constructor '
+        f'its siblings have, or stop initialising it explicitly.'
+    )
+
+
+@pytest.mark.parametrize('name', _explicitly_initialised())
+def test_that_constructor_takes_the_three_arguments_it_is_handed(name):
+    signature = inspect.signature(getattr(task_conn_module, name).__init__)
+    positional = [
+        parameter.name
+        for parameter in signature.parameters.values()
+        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    assert positional[:4] == ['self', 'connection_id', 'server', 'transport'], (
+        f'{name}.__init__ takes {positional[:4]}, but TaskConn hands it (self, connection_id, server, transport).'
+    )
+
+
+def test_dap_conn_takes_only_module():
+    """The reason the rule above exists — the fallback that swallows the call."""
+    positional = [
+        parameter.name
+        for parameter in inspect.signature(DAPConn.__init__).parameters.values()
+        if parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    assert positional == ['self', 'module']

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -60,6 +60,7 @@ from .mixins.dashboard import DashboardMixin
 from .mixins.cprofile import CProfileMixin
 from .mixins.store import StoreMixin
 from .mixins.apps import AppsMixin
+from .mixins.nodes import NodesMixin
 from typing import Any, Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -87,6 +88,7 @@ class RocketRideClient(
     CProfileMixin,
     StoreMixin,
     AppsMixin,
+    NodesMixin,
     DAPClient,
 ):
     """

--- a/packages/client-python/src/rocketride/mixins/nodes.py
+++ b/packages/client-python/src/rocketride/mixins/nodes.py
@@ -1,0 +1,128 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Node distribution: control a published node on the deployments registry.
+
+Publishing a node version is NOT here — it rides the generic rail as
+``deploy(kind='node')``, which carries the zip. These are the verbs that
+control one afterwards, the same split apps use: one door to put code on the
+server, one surface to control it.
+
+A published version is INERT. Nothing can reach it until an audience is
+pinned to it, and pinning is what first release, update and rollback all are.
+"""
+
+from typing import Any, Dict, List
+
+
+class NodesMixin:
+    """Node publish control over ``rrext_deploy_node``."""
+
+    async def node_versions(self, node_id: str) -> List[Dict[str, Any]]:
+        """
+        The node's version rail, newest first.
+
+        Args:
+            node_id: The node's id — its protocol without the '://'.
+
+        Returns:
+            One row per registry version: ``registryVersion`` (the handle
+            every other verb takes), the node's own ``nodeVersion``,
+            ``runtime``, ``state``, ``sha256``, and who published it.
+        """
+        body = await self.call('rrext_deploy_node', subcommand='versions', nodeId=node_id)
+        return body.get('versions', []) if isinstance(body, dict) else []
+
+    async def deploy_node(self, node_id: str, registry_version: int, target: str = '@me') -> Dict[str, Any]:
+        """
+        Point an audience at one registry version.
+
+        First release, update and rollback are all this one call — rolling
+        back is pinning the older number again.
+
+        Args:
+            node_id:          The node's id.
+            registry_version: The REGISTRY version number from the rail, not
+                              the node's own semver: two versions can carry
+                              the same semver, and only one is that row.
+            target:           '@me', '@team/<name-or-id>' or '@public'.
+                              '@public' needs the org's developer namespace.
+
+        Returns:
+            Dict with the ``publish`` binding row and the ``audience`` it serves.
+        """
+        return await self.call(
+            'rrext_deploy_node',
+            subcommand='deploy',
+            nodeId=node_id,
+            version=registry_version,
+            target=target,
+        )
+
+    async def where_node(self, node_id: str) -> List[Dict[str, Any]]:
+        """
+        Which audience holds which version.
+
+        Args:
+            node_id: The node's id.
+
+        Returns:
+            One row per live binding.
+        """
+        body = await self.call('rrext_deploy_node', subcommand='where', nodeId=node_id)
+        return body.get('pins', []) if isinstance(body, dict) else []
+
+    async def disable_node(self, node_id: str, target: str = '@me') -> Dict[str, Any]:
+        """
+        Stop serving one binding, reversibly.
+
+        The version is untouched — published versions are immutable and stay
+        on the registry, which is what keeps a later rollback possible. Bind
+        again and the node is back.
+
+        Args:
+            node_id: The node's id.
+            target:  The audience to stop serving, or '@all' for every one
+                     the node currently has. '@all' checks permission on all
+                     of them before touching any, so it withdraws all or none.
+
+        Returns:
+            Dict with the withdrawn binding, or all of them for '@all'.
+        """
+        return await self.call('rrext_deploy_node', subcommand='disable', nodeId=node_id, target=target)
+
+    async def remove_node(self, node_id: str, target: str = '@me') -> Dict[str, Any]:
+        """
+        Take a binding out of the listing.
+
+        Like ``disable_node``, this acts on the BINDING and never on the
+        version.
+
+        Args:
+            node_id: The node's id.
+            target:  The audience to remove, or '@all' for every one it has.
+
+        Returns:
+            Dict with the removed binding, or all of them for '@all'.
+        """
+        return await self.call('rrext_deploy_node', subcommand='remove', nodeId=node_id, target=target)

--- a/packages/client-python/tests/test_nodes_mixin.py
+++ b/packages/client-python/tests/test_nodes_mixin.py
@@ -1,0 +1,109 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""The Python SDK's node control surface.
+
+Wire-shape tests: what the server does with these is pinned by the engine
+suite, and what can drift here is the argument names and the unwrapping.
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from rocketride.mixins.nodes import NodesMixin
+
+
+class _Recorder(NodesMixin):
+    """A NodesMixin whose transport records instead of connecting."""
+
+    def __init__(self, reply: Any = None):
+        self.sent: list[Dict[str, Any]] = []
+        self._reply = reply if reply is not None else {}
+
+    async def call(self, command: str, **args: Any) -> Any:
+        self.sent.append({'command': command, **args})
+        return self._reply
+
+
+class TestControl:
+    """Every verb lands on rrext_deploy_node with the right subcommand."""
+
+    @pytest.mark.asyncio
+    async def test_versions_unwraps_the_rail(self):
+        client = _Recorder({'versions': [{'registryVersion': 3}]})
+        rows = await client.node_versions('ticket_feed')
+        assert client.sent[0] == {'command': 'rrext_deploy_node', 'subcommand': 'versions', 'nodeId': 'ticket_feed'}
+        assert rows == [{'registryVersion': 3}]
+
+    @pytest.mark.asyncio
+    async def test_a_node_with_no_versions_is_an_empty_list(self):
+        # Not None: callers iterate this without checking.
+        assert await _Recorder({}).node_versions('ticket_feed') == []
+
+    @pytest.mark.asyncio
+    async def test_deploy_pins_a_registry_version(self):
+        client = _Recorder()
+        await client.deploy_node('ticket_feed', 3, '@team/Platform')
+        assert client.sent[0] == {
+            'command': 'rrext_deploy_node',
+            'subcommand': 'deploy',
+            'nodeId': 'ticket_feed',
+            'version': 3,
+            'target': '@team/Platform',
+        }
+
+    @pytest.mark.asyncio
+    async def test_deploy_defaults_to_the_caller(self):
+        client = _Recorder()
+        await client.deploy_node('ticket_feed', 1)
+        assert client.sent[0]['target'] == '@me'
+
+    @pytest.mark.asyncio
+    async def test_where_unwraps_the_pins(self):
+        client = _Recorder({'pins': [{'audience': {'type': 'user'}, 'version': 3}]})
+        pins = await client.where_node('ticket_feed')
+        assert client.sent[0]['subcommand'] == 'where'
+        assert pins[0]['version'] == 3
+
+    @pytest.mark.asyncio
+    async def test_disable_is_reversible_and_targeted(self):
+        client = _Recorder()
+        await client.disable_node('ticket_feed', '@team/Platform')
+        assert client.sent[0]['subcommand'] == 'disable'
+        assert client.sent[0]['target'] == '@team/Platform'
+
+    @pytest.mark.asyncio
+    async def test_remove_takes_the_row_out(self):
+        client = _Recorder()
+        await client.remove_node('ticket_feed')
+        assert client.sent[0]['subcommand'] == 'remove'
+
+    @pytest.mark.asyncio
+    async def test_withdrawing_everywhere_is_one_call(self):
+        # The alternative is `where` followed by one call per audience, which
+        # is neither atomic nor pleasant from a UI.
+        client = _Recorder()
+        await client.remove_node('ticket_feed', '@all')
+        assert client.sent[0]['target'] == '@all'
+        assert len(client.sent) == 1

--- a/packages/client-typescript/docs/guide/methods/deploy.md
+++ b/packages/client-typescript/docs/guide/methods/deploy.md
@@ -53,6 +53,33 @@ their logs land in the team's run-log continuum, readable by teammates via
 | `deploy.artifact(projectId, version)` | One immutable version's pipeline JSON, sha256-verified server-side |
 | `deploy.preview(schedule, count?)` | THE single cron evaluator: validity + next occurrences |
 
+### Nodes
+
+A custom node is distributed the same way, over the same registry. Publishing takes a **folder** — packing rules live in `rocketride/app-pack`, so a UI, the CLI and CI produce identical bundles — and a published version is **inert** until an audience is pinned to it.
+
+| Method | Description |
+| --- | --- |
+| `deploy.addNode(nodeRoot, options?)` | Pack a node folder and deploy it as the next registry version (`options.deployTo` also pins a team in one step) |
+| `deploy.nodeVersions(nodeId)` | The node's version rail, newest first |
+| `deploy.nodeDeploy(nodeId, version, target?)` | Point an audience at a registry version — first release, update and rollback alike |
+| `deploy.nodeWhere(nodeId)` | Which audience holds which version |
+| `deploy.nodeWithdraw(nodeId, target?, mode?)` | Stop serving a binding (`'disable'`, reversible) or take it out of the listing (`'remove'`); `target: '@all'` withdraws every one |
+
+`target` is `'@me'` (default), `'@team/<name-or-id>'` or `'@public'`. Withdrawal acts on the **binding**, never on the version: published versions are immutable and stay on the registry, which is what keeps rollback possible.
+
+```typescript
+const { artifact } = await client.deploy.addNode('local_nodes/ticket_feed', { comment: 'first cut' });
+await client.deploy.nodeDeploy('ticket_feed', artifact.version!, '@team/Platform');
+await client.deploy.nodeWhere('ticket_feed');
+await client.deploy.nodeWithdraw('ticket_feed', '@all', 'remove');
+```
+
+```python
+entry = await client.deploy_node('ticket_feed', 3, '@team/Platform')
+pins = await client.where_node('ticket_feed')
+await client.remove_node('ticket_feed', '@all')
+```
+
 ### Python (async)
 
 ```python

--- a/packages/client-typescript/src/app-pack/index.ts
+++ b/packages/client-typescript/src/app-pack/index.ts
@@ -536,6 +536,20 @@ export function packNodeSource(nodeRoot: string, onProgress?: PackProgress): Pac
 	if (files.length === 0) {
 		throw new Error(`Nothing to pack under "${nodeRoot}" — is the folder fully ignored?`);
 	}
+	// On disk is not enough: a .gitignore can exclude the manifest, and a
+	// bundle without one is refused by the server for a reason nobody would
+	// connect back to an ignore rule.
+	if (!files.some((file) => file.zipPath === 'services.json')) {
+		throw new Error(`services.json is excluded by an ignore rule in "${nodeRoot}" — the bundle would carry no manifest.`);
+	}
+	// Preflight the uncompressed total. The zip cap below only catches what
+	// compresses badly; a large, highly compressible node would sail past it
+	// while costing the memory anyway.
+	const sourceBytes = files.reduce((total, file) => total + fs.statSync(file.absPath).size, 0);
+	if (sourceBytes > MAX_PACK_BYTES) {
+		onProgress?.(`pack ABORTED — source exceeds ${Math.floor(MAX_PACK_BYTES / (1024 * 1024))} MB`);
+		throw new Error(`Pack exceeds ${Math.floor(MAX_PACK_BYTES / (1024 * 1024))}MB uncompressed — add ignores.`);
+	}
 
 	// Identity is read here only to report it back; the server reads the same
 	// file out of the zip and that copy is the one that decides.

--- a/packages/client-typescript/src/app-pack/index.ts
+++ b/packages/client-typescript/src/app-pack/index.ts
@@ -483,6 +483,86 @@ export function readIncludeEntries(appFolder: string, workspaceRoot: string, onP
  * @throws Error on a missing folder, an invalid include entry, or a
  *   breached size cap.
  */
+/**
+ * The files a node directory carries that never belong in a bundle.
+ *
+ * Python leaves these behind on every run and they are machine-specific, so
+ * shipping them wastes bytes at best and confuses an import at worst. The
+ * app baseline does not cover them because no app produces them.
+ */
+const PYTHON_ARTEFACTS = /(^|\/)(__pycache__\/|\.pytest_cache\/)|\.py[co]$/;
+
+/**
+ * A packed node directory, ready for `deploy.add({ kind: 'node', data })`.
+ */
+export interface PackedNode {
+	/** The zip bytes. */
+	data: Uint8Array;
+	/** The node's id, read from its own manifest. */
+	nodeId: string;
+	/** Number of files packed. */
+	fileCount: number;
+	/** Size of the zip itself. */
+	zippedBytes: number;
+}
+
+/**
+ * Packs a node directory into the bundle the server expects.
+ *
+ * A node is self-contained, so unlike an app there is no workspace to root
+ * against and no include list: **the node folder itself is the zip root**,
+ * which puts `services.json` at the top where the server reads identity from.
+ * What comes out is the directory exactly as the author has it, so the same
+ * tree can be restored on another machine and its manifest's own `path`
+ * resolves unchanged.
+ *
+ * Filtering is the app rules plus Python's own leavings.
+ *
+ * @param nodeRoot - Absolute or cwd-relative path to the node directory.
+ * @param onProgress - Optional narration of each step.
+ * @returns The zip bytes and what went into them.
+ * @throws If the folder has no `services.json`, is empty, or exceeds the
+ *         upload cap.
+ */
+export function packNodeSource(nodeRoot: string, onProgress?: PackProgress): PackedNode {
+	const nodeAbs = path.resolve(nodeRoot);
+	const manifestPath = path.join(nodeAbs, 'services.json');
+	if (!fs.existsSync(manifestPath)) {
+		throw new Error(`No services.json in "${nodeRoot}" — a node directory is identified by its own manifest.`);
+	}
+
+	// The node folder IS the root, so zip paths come out relative to it.
+	const files = collectPackedFiles(nodeAbs, ['']).filter((file) => !PYTHON_ARTEFACTS.test(file.zipPath));
+	if (files.length === 0) {
+		throw new Error(`Nothing to pack under "${nodeRoot}" — is the folder fully ignored?`);
+	}
+
+	// Identity is read here only to report it back; the server reads the same
+	// file out of the zip and that copy is the one that decides.
+	let nodeId = '';
+	try {
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { protocol?: string; id?: string };
+		nodeId = String(manifest.protocol || manifest.id || '').replace('://', '');
+	} catch (err) {
+		throw new Error(`services.json in "${nodeRoot}" is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	onProgress?.(`packing ${files.length} files from ${nodeId || nodeRoot}`);
+
+	const zip = new AdmZip();
+	for (const file of files) {
+		const bytes = fs.readFileSync(file.absPath);
+		zip.addFile(file.zipPath, bytes);
+		onProgress?.(`+ ${file.zipPath} (${bytes.byteLength} bytes)`);
+	}
+	const buffer = zip.toBuffer();
+	if (buffer.byteLength > MAX_ZIP_BYTES) {
+		throw new Error(`Zip exceeds ${Math.floor(MAX_ZIP_BYTES / (1024 * 1024))}MB — the server refuses larger uploads.`);
+	}
+	onProgress?.(`pack complete — ${files.length} files, ${buffer.byteLength} bytes zipped`);
+
+	return { data: new Uint8Array(buffer), nodeId, fileCount: files.length, zippedBytes: buffer.byteLength };
+}
+
 export function packAppSource(workspaceRoot: string, appRoot: string, onProgress?: PackProgress): PackedApp {
 	const { wsAbs, appAbs, appRootRel } = resolveAppRoot(workspaceRoot, appRoot);
 
@@ -874,4 +954,4 @@ function resolveAppRoot(workspaceRoot: string, appRoot: string): { wsAbs: string
 // Arm the client's registry so bundled hosts (which cannot dynamically
 // resolve package specifiers at runtime) get the packer through their own
 // static import of this module.
-registerAppPack({ MAX_PACK_BYTES, MAX_ZIP_BYTES, collectPackedFiles, readIncludeEntries, packAppSource, verifyAppSource, createAppWorkspace } as AppPackModule);
+registerAppPack({ MAX_PACK_BYTES, MAX_ZIP_BYTES, collectPackedFiles, readIncludeEntries, packAppSource, packNodeSource, verifyAppSource, createAppWorkspace } as AppPackModule);

--- a/packages/client-typescript/src/cli/commands/node.ts
+++ b/packages/client-typescript/src/cli/commands/node.ts
@@ -82,6 +82,39 @@ function formatAudience(audience: Record<string, unknown> | undefined): string {
 export function registerNodeCommands(program: Command): void {
 	const nodeCmd = program.command('node').description('Node distribution operations (deployment target)');
 
+	// ── node add ─────────────────────────────────────────────────────────
+	// Packs a node folder and deploys it. The packing rules live in the SDK,
+	// so the CLI and any UI produce byte-identical bundles.
+	const addCmd = nodeCmd
+		.command('add <folder>')
+		.description('Pack a node folder and deploy it as the next registry version')
+		.option('--comment <text>', 'What-changed note kept in the registry')
+		.option('--deploy-to <teamId>', 'Also point this team at the new version in the same call')
+		.option('--verbose', 'Narrate every pack step')
+		.action(async (folder, options) => {
+			await runCliCommand(options, async (out) => {
+				const client = await connectDeploy(options, out);
+				if (!client) return 1;
+				const body = await client.deploy.addNode(folder, {
+					comment: options.comment,
+					deployTo: options.deployTo,
+					onProgress: options.verbose ? (line: string) => out.line(line) : undefined,
+				});
+				const artifact = body.artifact as Record<string, unknown> | undefined;
+				out.line(`deployed v${String(artifact?.version ?? '?')}`);
+				// Publishing alone leaves the version inert, so say so rather than
+				// letting someone assume it is live.
+				if (body.audience) {
+					out.line(`reachable by ${formatAudience(body.audience as Record<string, unknown>)}`);
+				} else {
+					out.line('not reachable by anyone yet — pin it with `node deploy`');
+				}
+				out.result(body);
+				return 0;
+			});
+		});
+	addDeployConnectionOptions(addCmd);
+
 	// ── node versions ────────────────────────────────────────────────────
 	const versionsCmd = nodeCmd
 		.command('versions <nodeId>')

--- a/packages/client-typescript/src/cli/commands/node.ts
+++ b/packages/client-typescript/src/cli/commands/node.ts
@@ -1,0 +1,186 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Node distribution commands: `node versions/deploy/where/disable/remove`.
+ *
+ * Publishing a node version is NOT here — it rides the generic rail as
+ * `deploy add <file> --kind node`, which carries the zip. These are the
+ * verbs that control one once it is on the registry, the same split apps
+ * use: one door to put code on the server, one surface to control it.
+ *
+ * All of them are DEPLOYMENT-TARGET verbs: they read the ROCKETRIDE_DEPLOY_*
+ * pair, and an absent pair is a stop rather than a fall back to the
+ * development connection.
+ */
+
+import { Command } from 'commander';
+import { RocketRideClient } from '../../client/client';
+import { Output } from '../output';
+import { addDeployConnectionOptions, connectClient, runCliCommand, ConnectionOptions } from '../common';
+import { NO_DEPLOY_TARGET_MESSAGE } from '../env';
+
+/**
+ * Connect for a lifecycle verb, or stop.
+ *
+ * An absent deployment target is an explicit stop: these verbs must never
+ * fall back to the development connection as a guess about where a node was
+ * meant to go.
+ *
+ * @param options - Parsed connection options.
+ * @param out - The command's output channel.
+ * @returns A connected client, or null once the failure is reported.
+ */
+async function connectDeploy(options: ConnectionOptions, out: Output): Promise<RocketRideClient | null> {
+	if (!options.uri) {
+		out.fail(NO_DEPLOY_TARGET_MESSAGE);
+		return null;
+	}
+	return connectClient(options);
+}
+
+/**
+ * One audience, rendered the way a person reads it back.
+ *
+ * @param audience - The audience object a binding carries.
+ * @returns '@me', '@team/<id>' or '@public'.
+ */
+function formatAudience(audience: Record<string, unknown> | undefined): string {
+	const type = String(audience?.type || '');
+	if (type === 'user') return '@me';
+	if (type === 'public') return '@public';
+	if (type === 'team') return `@team/${String(audience?.id || '')}`;
+	return type || '?';
+}
+
+/**
+ * Register the `node` command group on the program.
+ *
+ * @param program - The root commander program.
+ */
+export function registerNodeCommands(program: Command): void {
+	const nodeCmd = program.command('node').description('Node distribution operations (deployment target)');
+
+	// ── node versions ────────────────────────────────────────────────────
+	const versionsCmd = nodeCmd
+		.command('versions <nodeId>')
+		.description("List a node's registry versions, newest first")
+		.action(async (nodeId, options) => {
+			await runCliCommand(options, async (out) => {
+				const client = await connectDeploy(options, out);
+				if (!client) return 1;
+				const body = await client.deploy.nodeVersions(nodeId);
+				const rows = body.versions || [];
+				if (rows.length === 0) {
+					out.line(`No versions published for ${nodeId}`);
+				} else {
+					out.line(`${rows.length} version(s) of ${nodeId}:`);
+					for (const row of rows) {
+						// The registry number is the handle every other verb
+						// takes; the node's own version is display only, and
+						// two rows can carry the same one.
+						const own = row.nodeVersion ? `  (${String(row.nodeVersion)})` : '';
+						const who = row.author ? `  by ${String(row.author)}` : '';
+						const note = row.message ? `  ${String(row.message)}` : '';
+						out.line(`v${String(row.registryVersion ?? '?')}${own}  ${String(row.state ?? '')}${who}${note}`);
+					}
+				}
+				out.result({ versions: rows });
+				return 0;
+			});
+		});
+	addDeployConnectionOptions(versionsCmd);
+
+	// ── node deploy ──────────────────────────────────────────────────────
+	const deployCmd = nodeCmd
+		.command('deploy <nodeId> <version>')
+		.description('Point an audience at a registry version (first release, update and rollback are all this)')
+		.option('--target <target>', "'@me', '@team/<name-or-id>' or '@public'", '@me')
+		.action(async (nodeId, version, options) => {
+			await runCliCommand(options, async (out) => {
+				const registryVersion = Number(version);
+				if (!Number.isInteger(registryVersion)) {
+					return out.fail(`'${String(version)}' is not a registry version number`, 'use the number from `node versions`');
+				}
+				const client = await connectDeploy(options, out);
+				if (!client) return 1;
+				const body = await client.deploy.nodeDeploy(nodeId, registryVersion, options.target);
+				out.line(`${nodeId} v${registryVersion} → ${formatAudience(body.audience as Record<string, unknown>)}`);
+				out.result(body);
+				return 0;
+			});
+		});
+	addDeployConnectionOptions(deployCmd);
+
+	// ── node where ───────────────────────────────────────────────────────
+	const whereCmd = nodeCmd
+		.command('where <nodeId>')
+		.description('Show which audience holds which version')
+		.action(async (nodeId, options) => {
+			await runCliCommand(options, async (out) => {
+				const client = await connectDeploy(options, out);
+				if (!client) return 1;
+				const body = await client.deploy.nodeWhere(nodeId);
+				const pins = body.pins || [];
+				if (pins.length === 0) {
+					out.line(`${nodeId} is not reachable by anyone yet`);
+				} else {
+					for (const pin of pins) {
+						out.line(`${formatAudience(pin.audience as Record<string, unknown>)}  v${String(pin.version ?? '?')}  ${String(pin.state ?? '')}`);
+					}
+				}
+				out.result({ pins });
+				return 0;
+			});
+		});
+	addDeployConnectionOptions(whereCmd);
+
+	// ── node disable / node remove ───────────────────────────────────────
+	// Both act on the BINDING, never the version: a published version is
+	// immutable and stays on the registry, which is what keeps rollback
+	// possible after a withdrawal.
+	for (const mode of ['disable', 'remove'] as const) {
+		const withdrawCmd = nodeCmd
+			.command(`${mode} <nodeId>`)
+			.description(mode === 'disable' ? 'Stop serving one binding (reversible — deploy again and it is back)' : 'Take a binding out of the listing')
+			.option('--target <target>', "Audience to withdraw from, or '@all' for every one it has", '@me')
+			.action(async (nodeId, options) => {
+				await runCliCommand(options, async (out) => {
+					const client = await connectDeploy(options, out);
+					if (!client) return 1;
+					const body = await client.deploy.nodeWithdraw(nodeId, options.target, mode);
+					const audiences = body.audiences as Record<string, unknown>[] | undefined;
+					if (audiences) {
+						// '@all' answers with every audience it withdrew from.
+						out.line(audiences.length === 0 ? `${nodeId} had no bindings to withdraw` : `${mode}d ${nodeId} for ${audiences.map(formatAudience).join(', ')}`);
+					} else {
+						out.line(`${mode}d ${nodeId} for ${formatAudience(body.audience as Record<string, unknown>)}`);
+					}
+					out.result(body);
+					return 0;
+				});
+			});
+		addDeployConnectionOptions(withdrawCmd);
+	}
+}

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -58,6 +58,7 @@ import { registerStoreCommands } from './commands/store';
 import { registerValidateCommands } from './commands/validate';
 import { registerAppCommands } from './commands/app';
 import { registerDeployCommands } from './commands/deploy';
+import { registerNodeCommands } from './commands/node';
 import { disconnectAll } from './common';
 
 // The workspace .env must be in process.env before the command groups
@@ -107,6 +108,7 @@ function createProgram(): Command {
 	registerStoreCommands(program);
 	registerAppCommands(program);
 	registerDeployCommands(program);
+	registerNodeCommands(program);
 	return program;
 }
 

--- a/packages/client-typescript/src/client/deploy.ts
+++ b/packages/client-typescript/src/client/deploy.ts
@@ -365,6 +365,81 @@ export class DeployApi {
 	}
 
 	/**
+	 * A published node's version rail, newest first.
+	 *
+	 * Uploading a node version is not here — it arrives on the generic rail as
+	 * `add({ kind: 'node' })`, which carries the zip. These are the verbs that
+	 * control one afterwards, the same split apps use.
+	 *
+	 * @param nodeId - The node's id, which is its protocol without the '://'.
+	 * @returns One row per registry version, with the node's own version and
+	 *          who published it.
+	 */
+	async nodeVersions(nodeId: string): Promise<{ versions: Record<string, unknown>[] }> {
+		return this.client.call<{ versions: Record<string, unknown>[] }>('rrext_deploy_node', {
+			subcommand: 'versions',
+			nodeId,
+		});
+	}
+
+	/**
+	 * Points an audience at one registry version of a node.
+	 *
+	 * A published version is inert until something is pinned to it. First
+	 * release, update and rollback are all this one call — rolling back is
+	 * pinning the older number again.
+	 *
+	 * @param nodeId - The node's id.
+	 * @param version - The REGISTRY version number, not the node's own semver:
+	 *                  two versions can carry the same semver.
+	 * @param target - '@me' (default), '@team/<name-or-id>' or '@public'.
+	 * @returns The binding that now serves, and the audience it serves.
+	 */
+	async nodeDeploy(nodeId: string, version: number, target = '@me'): Promise<Record<string, unknown>> {
+		return this.client.call<Record<string, unknown>>('rrext_deploy_node', {
+			subcommand: 'deploy',
+			nodeId,
+			version,
+			target,
+		});
+	}
+
+	/**
+	 * Which audiences hold which version of a node.
+	 *
+	 * @param nodeId - The node's id.
+	 * @returns One row per live binding.
+	 */
+	async nodeWhere(nodeId: string): Promise<{ pins: Record<string, unknown>[] }> {
+		return this.client.call<{ pins: Record<string, unknown>[] }>('rrext_deploy_node', {
+			subcommand: 'where',
+			nodeId,
+		});
+	}
+
+	/**
+	 * Stops serving a node binding, or takes it out of the listing.
+	 *
+	 * Neither touches the version: published versions are immutable and stay
+	 * on the registry, which is what keeps a later rollback possible.
+	 * `disable` is reversible — bind again and it is back.
+	 *
+	 * @param nodeId - The node's id.
+	 * @param target - The audience to withdraw from, or '@all' for every one
+	 *                 it currently has. '@all' checks permission on all of
+	 *                 them before touching any, so it withdraws all or none.
+	 * @param mode - 'disable' (reversible) or 'remove' (out of the listing).
+	 * @returns The withdrawn binding, or all of them for '@all'.
+	 */
+	async nodeWithdraw(nodeId: string, target = '@me', mode: 'disable' | 'remove' = 'disable'): Promise<Record<string, unknown>> {
+		return this.client.call<Record<string, unknown>>('rrext_deploy_node', {
+			subcommand: mode,
+			nodeId,
+			target,
+		});
+	}
+
+	/**
 	 * The immutable audit trail of a project, newest first, as the standard
 	 * list envelope.
 	 *

--- a/packages/client-typescript/src/client/deploy.ts
+++ b/packages/client-typescript/src/client/deploy.ts
@@ -365,6 +365,38 @@ export class DeployApi {
 	}
 
 	/**
+	 * Packs a node directory and deploys it as the next registry version.
+	 *
+	 * The node counterpart of {@link addApp}, and the call a UI makes when
+	 * someone presses Deploy on a node. Packing rules live in
+	 * `rocketride/app-pack` and nowhere else: the node folder is the zip root,
+	 * so `services.json` lands at the top where the server reads identity
+	 * from, and the tree comes back out on another machine exactly as the
+	 * author had it.
+	 *
+	 * The id is decided by the manifest inside the zip, never by the caller.
+	 *
+	 * @param nodeRoot - Path to the node directory.
+	 * @param options.comment - "What changed" note kept in the registry.
+	 * @param options.deployTo - Team to point at the new version in the same
+	 *   call; publishing alone leaves the version inert.
+	 * @param options.metadata - Optional metadata blob.
+	 * @param options.onProgress - Narrates each pack step.
+	 * @returns The new registry entry, plus the audience when `deployTo` was given.
+	 */
+	async addNode(nodeRoot: string, options: { comment?: string; deployTo?: string; metadata?: Record<string, unknown>; onProgress?: (line: string) => void } = {}): Promise<PublishResult> {
+		const pack = await this.loadAppPack();
+		const packed = pack.packNodeSource(nodeRoot, options.onProgress);
+		return this.add({
+			kind: 'node',
+			data: packed.data,
+			...(options.metadata !== undefined && { metadata: options.metadata }),
+			...(options.comment !== undefined && { comment: options.comment }),
+			...(options.deployTo !== undefined && { deployTo: options.deployTo }),
+		});
+	}
+
+	/**
 	 * A published node's version rail, newest first.
 	 *
 	 * Uploading a node version is not here — it arrives on the generic rail as

--- a/packages/client-typescript/src/client/types/deploy.ts
+++ b/packages/client-typescript/src/client/types/deploy.ts
@@ -146,6 +146,11 @@ export interface PublishResult {
 	artifact?: DeployArtifact;
 	/** Present only when `deployTo` was given (one-step add+deploy; pipes only). */
 	deployment?: Deployment;
+	/** The audience a node was bound to, when `deployTo` accompanied a node
+	    deploy. Absent means the version published and is inert. */
+	audience?: { type: string; id: string; name?: string };
+	/** The org the registry write landed in. */
+	orgId?: string;
 }
 
 /** The standard list-API request arguments (page/search/filter/sort). */

--- a/packages/client-typescript/tests/node-distribution.test.ts
+++ b/packages/client-typescript/tests/node-distribution.test.ts
@@ -1,0 +1,212 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ */
+
+/**
+ * The client side of node distribution: packing a node folder, and the calls
+ * that control one afterwards.
+ *
+ * Packing runs against a real temp directory rather than a mocked fs — the
+ * whole point of the packer is what it does with files on disk, and the two
+ * rules that matter (the node folder is the zip root, Python leavings never
+ * ship) are only observable there.
+ *
+ * The control calls run against a stub client that records what was sent.
+ * These are wire-shape tests: the server's behaviour is pinned by the Python
+ * suite, and what can drift here is the argument names.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import AdmZip from 'adm-zip';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { packNodeSource } from '../src/app-pack';
+import { DeployApi } from '../src/client/deploy';
+import type { RocketRideClient } from '../src/client/client';
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/** A node directory on disk, with whatever extra files a test needs. */
+function makeNode(root: string, files: Record<string, string> = {}, manifest?: unknown): string {
+	const dir = path.join(root, 'ticket_feed');
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, 'services.json'), JSON.stringify(manifest ?? { protocol: 'ticket_feed://', title: 'Ticket Feed', version: '1.2.0' }));
+	fs.writeFileSync(path.join(dir, 'IInstance.py'), 'class IInstance:\n    pass\n');
+	for (const [name, content] of Object.entries(files)) {
+		const target = path.join(dir, name);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, content);
+	}
+	return dir;
+}
+
+/** Entry names inside a packed zip. */
+function entriesOf(data: Uint8Array): string[] {
+	return new AdmZip(Buffer.from(data))
+		.getEntries()
+		.map((entry) => entry.entryName)
+		.sort();
+}
+
+/** A client that records the calls made through it instead of connecting. */
+function stubClient(): { api: DeployApi; sent: { command: string; args: Record<string, unknown> }[] } {
+	const sent: { command: string; args: Record<string, unknown> }[] = [];
+	const client = {
+		async call(command: string, args: Record<string, unknown>) {
+			sent.push({ command, args });
+			return {};
+		},
+	} as unknown as RocketRideClient;
+	return { api: new DeployApi(client), sent };
+}
+
+// =============================================================================
+// PACKING
+// =============================================================================
+
+describe('packNodeSource', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-node-pack-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('puts the node folder at the zip root', () => {
+		// services.json has to be at the top: it is where the server reads
+		// identity from, and a wrapper folder would hide it.
+		const packed = packNodeSource(makeNode(tmp));
+		expect(entriesOf(packed.data)).toEqual(['IInstance.py', 'services.json']);
+	});
+
+	it('keeps the tree shape below the root', () => {
+		const packed = packNodeSource(makeNode(tmp, { 'lib/helper.py': 'x = 1\n' }));
+		expect(entriesOf(packed.data)).toContain('lib/helper.py');
+	});
+
+	it('never ships Python leavings', () => {
+		// Machine-specific and regenerated on every run; shipping them wastes
+		// bytes at best and confuses an import at worst.
+		const packed = packNodeSource(
+			makeNode(tmp, {
+				'__pycache__/IInstance.cpython-312.pyc': 'bytecode',
+				'lib/__pycache__/helper.pyc': 'bytecode',
+				'IInstance.pyc': 'bytecode',
+			})
+		);
+		expect(entriesOf(packed.data)).toEqual(['IInstance.py', 'services.json']);
+	});
+
+	it('reports the id the manifest declares', () => {
+		expect(packNodeSource(makeNode(tmp)).nodeId).toBe('ticket_feed');
+	});
+
+	it('refuses a folder with no manifest', () => {
+		const bare = path.join(tmp, 'not_a_node');
+		fs.mkdirSync(bare);
+		fs.writeFileSync(path.join(bare, 'IInstance.py'), 'x = 1\n');
+		expect(() => packNodeSource(bare)).toThrow(/services\.json/);
+	});
+
+	it('refuses a manifest that is not valid JSON', () => {
+		const dir = makeNode(tmp);
+		fs.writeFileSync(path.join(dir, 'services.json'), '{ not json');
+		expect(() => packNodeSource(dir)).toThrow(/not valid JSON/);
+	});
+
+	it('honours .gitignore inside the node', () => {
+		const dir = makeNode(tmp, { '.gitignore': 'secrets.env\n', 'secrets.env': 'TOKEN=1\n' });
+		expect(entriesOf(packNodeSource(dir).data)).not.toContain('secrets.env');
+	});
+});
+
+// =============================================================================
+// THE WIRE
+// =============================================================================
+
+describe('node control calls', () => {
+	it('reads the version rail', async () => {
+		const { api, sent } = stubClient();
+		await api.nodeVersions('ticket_feed');
+		expect(sent[0]).toEqual({ command: 'rrext_deploy_node', args: { subcommand: 'versions', nodeId: 'ticket_feed' } });
+	});
+
+	it('pins an audience to a registry version', async () => {
+		const { api, sent } = stubClient();
+		await api.nodeDeploy('ticket_feed', 3, '@team/Platform');
+		expect(sent[0].args).toEqual({ subcommand: 'deploy', nodeId: 'ticket_feed', version: 3, target: '@team/Platform' });
+	});
+
+	it('pins to the caller when no target is given', async () => {
+		const { api, sent } = stubClient();
+		await api.nodeDeploy('ticket_feed', 1);
+		expect(sent[0].args.target).toBe('@me');
+	});
+
+	it('asks where a node is pinned', async () => {
+		const { api, sent } = stubClient();
+		await api.nodeWhere('ticket_feed');
+		expect(sent[0].args).toEqual({ subcommand: 'where', nodeId: 'ticket_feed' });
+	});
+
+	it('withdraws reversibly by default', async () => {
+		// disable, not remove: the destructive one should never be the default.
+		const { api, sent } = stubClient();
+		await api.nodeWithdraw('ticket_feed');
+		expect(sent[0].args).toEqual({ subcommand: 'disable', nodeId: 'ticket_feed', target: '@me' });
+	});
+
+	it('withdraws from every audience when asked', async () => {
+		const { api, sent } = stubClient();
+		await api.nodeWithdraw('ticket_feed', '@all', 'remove');
+		expect(sent[0].args).toEqual({ subcommand: 'remove', nodeId: 'ticket_feed', target: '@all' });
+	});
+});
+
+// =============================================================================
+// PACK AND DEPLOY TOGETHER
+// =============================================================================
+
+describe('addNode', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-node-add-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('sends the packed folder on the generic rail as a node', async () => {
+		const { api, sent } = stubClient();
+		await api.addNode(makeNode(tmp), { comment: 'first cut' });
+		expect(sent[0].command).toBe('rrext_deploy');
+		expect(sent[0].args.subcommand).toBe('add');
+		expect(sent[0].args.kind).toBe('node');
+		expect(sent[0].args.comment).toBe('first cut');
+		expect(entriesOf(sent[0].args.data as Uint8Array)).toEqual(['IInstance.py', 'services.json']);
+	});
+
+	it('passes deployTo through so publish and bind are one call', async () => {
+		const { api, sent } = stubClient();
+		await api.addNode(makeNode(tmp), { deployTo: 'Platform' });
+		expect(sent[0].args.deployTo).toBe('Platform');
+	});
+
+	it('omits deployTo when it was not asked for', async () => {
+		// Its absence is what leaves the version inert, so it must not be
+		// sent as an empty value.
+		const { api, sent } = stubClient();
+		await api.addNode(makeNode(tmp));
+		expect('deployTo' in sent[0].args).toBe(false);
+	});
+});

--- a/packages/client-typescript/tests/node-distribution.test.ts
+++ b/packages/client-typescript/tests/node-distribution.test.ts
@@ -122,6 +122,14 @@ describe('packNodeSource', () => {
 		expect(() => packNodeSource(dir)).toThrow(/not valid JSON/);
 	});
 
+	it('refuses when an ignore rule swallows the manifest', () => {
+		// On disk is not enough. Without this the bundle ships with no
+		// manifest and the server refuses it, for a reason nobody would trace
+		// back to a .gitignore line.
+		const dir = makeNode(tmp, { '.gitignore': 'services.json\n' });
+		expect(() => packNodeSource(dir)).toThrow(/excluded by an ignore rule/);
+	});
+
 	it('honours .gitignore inside the node', () => {
 		const dir = makeNode(tmp, { '.gitignore': 'secrets.env\n', 'secrets.env': 'TOKEN=1\n' });
 		expect(entriesOf(packNodeSource(dir).data)).not.toContain('secrets.env');

--- a/packages/server/docs/index.md
+++ b/packages/server/docs/index.md
@@ -217,6 +217,8 @@ command.
 
 - [Observability](/protocols/websocket/observability): monitoring events and
   metrics over this socket.
+- [Deploying nodes](/protocols/websocket/node-deploy): publishing a custom node
+  and pinning who can reach it.
 - [MCP](/protocols/mcp): pipelines-as-tools for AI assistants, transported over
   this socket.
 - [TypeScript SDK](/develop/typescript) · [Python SDK](/develop/python): the

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -12,10 +12,10 @@ who can reach it.
 
 Two commands cover the whole surface:
 
-| Command                                                 | What it does                                             |
-| ------------------------------------------------------- | -------------------------------------------------------- |
-| `rrext_deploy` with `subcommand: "add"`, `kind: "node"` | Upload a node version (carries the zip)                  |
-| `rrext_deploy_node`                                     | Control what is published: `versions`, `deploy`, `where` |
+| Command                                                 | What it does                                                   |
+| ------------------------------------------------------- | -------------------------------------------------------------- |
+| `rrext_deploy` with `subcommand: "add"`, `kind: "node"` | Upload a node version (carries the zip)                        |
+| `rrext_deploy_node`                                     | Control it: `versions`, `deploy`, `where`, `disable`, `remove` |
 
 That split matches apps exactly: one generic door to put code on the server,
 one surface to control it afterwards.
@@ -131,6 +131,50 @@ is a team an org admin maintains.
 **First release, update and rollback are all this one verb** — pointing an
 audience at a different registry version is the whole operation. Rolling back
 is pinning the older number again.
+
+## Taking a node back
+
+```json
+{
+	"command": "rrext_deploy_node",
+	"arguments": {
+		"subcommand": "disable",
+		"nodeId": "my_node",
+		"target": "@me"
+	}
+}
+```
+
+`disable` stops serving one binding and is reversible — bind again and it is
+back. `remove` takes the row out of the listing.
+
+**Neither touches the version.** A published version is immutable and stays on
+the registry, which is exactly what keeps rollback possible: taking a node back
+from a team today does not stop you pinning that same version tomorrow. What is
+withdrawn is the pointer, never the artifact.
+
+## Who can expose a node, and how far
+
+The bar is the audience, and it applies the same whether you are putting
+something up or taking it down:
+
+| Target               | Requirement                                                             |
+| -------------------- | ----------------------------------------------------------------------- |
+| `@me`                | Nothing beyond an authenticated session                                 |
+| `@team/<name-or-id>` | You must be a member of that team                                       |
+| `@public`            | The org must be a registered developer **and** own the node's namespace |
+| `@org`               | Does not exist — use an org-admin-maintained "All members" team         |
+
+Private reach needs no namespace: the registry is partitioned by organisation,
+so two orgs can both hold a node called `csv_split` and never see each other's.
+Public reach is one shared space, so a node offered there must be named
+`<developerId>` or `<developerId>.<name>` — otherwise the first org to publish
+`csv_split` would own that name for everybody.
+
+Note this is **looser than apps on purpose**: an app id must sit in the
+developer namespace always, while nodes are named after their protocol
+(`store_chroma`, `llm_openai`). Requiring a namespace everywhere would break
+that convention to solve a problem that only exists in public.
 
 ## Finding where a node is pinned
 

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -187,6 +187,20 @@ is pinning the older number again.
 `disable` stops serving one binding and is reversible — bind again and it is
 back. `remove` takes the row out of the listing.
 
+### Withdrawing everywhere
+
+`"target": "@all"` withdraws every binding the node currently has, in one
+call. It is the answer to "unpublish this", which otherwise means reading
+`where` and then issuing one call per audience.
+
+Every audience is checked **before any is touched**, so the call either
+withdraws all of them or none. Withdrawing half and stopping would leave the
+node reachable exactly where the caller wanted it gone.
+
+The bar is the same one that granting the binding needed: a team you are no
+longer a member of, or public reach outside your namespace, fails the whole
+call rather than being skipped.
+
 **Neither touches the version.** A published version is immutable and stays on
 the registry, which is exactly what keeps rollback possible: taking a node back
 from a team today does not stop you pinning that same version tomorrow. What is

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -277,6 +277,39 @@ artifacts are immutable, which makes an absent field expensive to add later.
 Python node is published — its source is what runs, so there is nothing to
 compile. The field exists for the same reason as `runtime`.
 
+## What happens when a pipeline uses one
+
+A published node is never installed. A run brings in only the nodes that run
+names, uses them, and drops them.
+
+**Deciding** comes first and touches nothing. Each component's `provider` is
+the node's id, so what a pipeline asks for needs no translating. Subtract what
+the engine already carries — for a pipeline of stock nodes that is the whole
+of it, one set difference and no lookup. Whatever is left is resolved against
+the caller's pins, and **a node with no pin stops the run before any bytes
+move**, naming every missing node at once and the org they were looked for in.
+
+**Getting** them follows, and the order is deliberate:
+
+1. The bundle's digest is checked against what the artifact recorded, before a
+   zip reader ever sees the bytes.
+2. The archive is guarded again — publishing checked the same things, but that
+   was a different moment and a different copy.
+3. It is unpacked into a cache keyed by **digest**, not by version, so two
+   versions never collide and nothing ever needs invalidating.
+4. Its declared `requirements.txt` is installed through the engine's own
+   installer, which resolves against the constraints lock — a node that cannot
+   fit the environment is refused rather than downgrading a package another
+   node in the same run depends on.
+5. The directory is placed where the engine imports external nodes from, which
+   is why the manifest's own `path` never has to be rewritten.
+
+Two runs resolving the same node do not collide: each unpacks into a staging
+directory and renames into place, so the second either finds the slot already
+there or loses the rename and uses the winner's identical copy.
+
+When the run ends its tree is dropped and the cache stays warm.
+
 ## Related
 
 - [WebSocket protocol](/protocols/websocket): the transport these commands ride.

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -215,6 +215,28 @@ developer namespace always, while nodes are named after their protocol
 (`store_chroma`, `llm_openai`). Requiring a namespace everywhere would break
 that convention to solve a problem that only exists in public.
 
+## Which nodes a caller has
+
+Bindings answer "who can reach this node". The reverse question — "which nodes
+can this caller use" — is one resolution over all of them, the same scope walk
+apps take:
+
+1. Walk `@public`, then each of the caller's teams, then the caller.
+2. On a node-id collision the **more specific rung wins**: user beats team
+   beats public. A same-rung tie breaks on the lowest org id, so a stray public
+   row can never displace a lower org's claim on a name.
+3. A binding serves only when it is `enabled` **and** its version is
+   serveable: public reach demands a `ready` version, internal reach accepts
+   anything that did not fail.
+
+Each resolved entry carries what a caller needs to decide before fetching
+anything — the registry version, the node's own version, its `runtime`, its
+declared `requirements` and the bundle digest.
+
+This is deliberately **one** answer rather than two. The picker offers what it
+returns and the run-time resolver fetches what it names; a designer offering a
+node the run then refuses would be worse than not offering it at all.
+
 ## Finding where a node is pinned
 
 ```json

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -84,7 +84,7 @@ never leaves a version with no bytes behind it:
 
 Only then is the version allocated, and only then does content land:
 
-```
+```text
 <artifact sibling>/bundle/<nodeId>-v<NNNNNN>.zip   the transport zip, kept for provenance
 <artifact sibling>/source/…                        the unpacked tree the engine reads
 ```
@@ -261,7 +261,7 @@ node the run then refuses would be worse than not offering it at all.
 ```
 
 ```json
-{ "pins": [{ "audience": "u1", "version": 3 }] }
+{ "pins": [{ "audience": { "type": "user", "id": "u1" }, "version": 3 }] }
 ```
 
 ## Fields worth knowing about
@@ -315,7 +315,7 @@ When the run ends its tree is dropped and the cache stays warm.
 The same surface, without hand-writing WebSocket frames. Publishing rides the
 generic rail; everything after it is the `node` group:
 
-```
+```bash
 rocketride deploy add ticket_feed.zip --kind node --deploy-to <teamId>
 
 rocketride node versions ticket_feed

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -310,6 +310,28 @@ there or loses the rename and uses the winner's identical copy.
 
 When the run ends its tree is dropped and the cache stays warm.
 
+## From the command line
+
+The same surface, without hand-writing WebSocket frames. Publishing rides the
+generic rail; everything after it is the `node` group:
+
+```
+rocketride deploy add ticket_feed.zip --kind node --deploy-to <teamId>
+
+rocketride node versions ticket_feed
+rocketride node deploy ticket_feed 3 --target @team/Platform
+rocketride node where ticket_feed
+rocketride node disable ticket_feed --target @team/Platform
+rocketride node remove ticket_feed --target @all
+```
+
+These are deployment-target verbs: an absent `ROCKETRIDE_DEPLOY_*` pair stops
+the command rather than falling back to the development connection, so a node
+never lands somewhere it was not aimed at.
+
+The same calls are on the SDK as `client.deploy.nodeVersions`, `nodeDeploy`,
+`nodeWhere` and `nodeWithdraw` — that is what a UI talks to.
+
 ## Related
 
 - [WebSocket protocol](/protocols/websocket): the transport these commands ride.

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -1,0 +1,164 @@
+---
+title: Deploying nodes
+---
+
+# Deploying nodes
+
+A custom node is distributed the way an app is: the node directory is zipped,
+sent to the server over the [WebSocket](/protocols/websocket), and registered as
+an **immutable version** on the deployments registry. Nothing is installed into
+a machine — publishing puts a version on the shelf, and a separate step decides
+who can reach it.
+
+Two commands cover the whole surface:
+
+| Command                                                 | What it does                                             |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| `rrext_deploy` with `subcommand: "add"`, `kind: "node"` | Upload a node version (carries the zip)                  |
+| `rrext_deploy_node`                                     | Control what is published: `versions`, `deploy`, `where` |
+
+That split matches apps exactly: one generic door to put code on the server,
+one surface to control it afterwards.
+
+## Publishing a version
+
+Send the node directory as a zip in the binary `data` frame:
+
+```json
+{
+	"command": "rrext_deploy",
+	"arguments": {
+		"subcommand": "add",
+		"kind": "node",
+		"comment": "first cut of the CSV splitter"
+	}
+}
+```
+
+The zip must carry the node's `services.json` **at its root**. That file is the
+node's own declaration and it decides the identity: the id comes from
+`protocol` (`my_node://` → `my_node`), the display name from `title`, and the
+version from `version`. The request does not get a say — a caller naming a
+different node must not be able to publish under it.
+
+The response body carries the registry `artifact` and the `orgId` the write
+landed in:
+
+```json
+{
+	"artifact": { "version": 3, "sha256": "…", "artifactPath": "…" },
+	"orgId": "acme"
+}
+```
+
+**A published version is inert.** It is on the shelf and nobody can run it yet.
+Making it reachable is `deploy`, below.
+
+### What the server checks, in order
+
+Each of these refuses **before** a registry row exists, so a rejected upload
+never leaves a version with no bytes behind it:
+
+1. The connection is authenticated.
+2. `data` is a binary frame — text is refused rather than left to explode
+   inside the zip reader.
+3. The zip is at most 50 MB **compressed**, measured before anything is parsed.
+4. `services.json` exists at the root, parses, and carries a usable id.
+5. The archive is safe: no `..` segments, no absolute paths, at most 2,000
+   files, and at most 100 MB when unpacked — measured on the bytes that
+   actually come out, not on the sizes the archive claims.
+
+Only then is the version allocated, and only then does content land:
+
+```
+<artifact sibling>/bundle/<nodeId>-v<NNNNNN>.zip   the transport zip, kept for provenance
+<artifact sibling>/source/…                        the unpacked tree the engine reads
+```
+
+If a content write fails partway, what was written is removed and the version
+is flipped to `failed`.
+
+## Seeing what is published
+
+```json
+{
+	"command": "rrext_deploy_node",
+	"arguments": { "subcommand": "versions", "nodeId": "my_node" }
+}
+```
+
+Returns the rail, newest first:
+
+```json
+{
+	"versions": [
+		{
+			"registryVersion": 3,
+			"nodeVersion": "1.2.0",
+			"runtime": "python",
+			"state": "ready",
+			"sha256": "…",
+			"publishedAt": 1757500000,
+			"author": "Ariel Vernaza",
+			"message": "first cut of the CSV splitter"
+		}
+	]
+}
+```
+
+`registryVersion` is the number every other verb takes. `nodeVersion` is what
+the node calls itself, and two rows can carry the same one — which is why the
+registry number is the handle.
+
+## Making a version reachable
+
+```json
+{
+	"command": "rrext_deploy_node",
+	"arguments": {
+		"subcommand": "deploy",
+		"nodeId": "my_node",
+		"version": 3,
+		"target": "@me"
+	}
+}
+```
+
+`target` is `@me` (the default), `@team/<name-or-id>`, or `@public`. There is no
+org-wide target: an organisation is the governance container, and "everyone"
+is a team an org admin maintains.
+
+**First release, update and rollback are all this one verb** — pointing an
+audience at a different registry version is the whole operation. Rolling back
+is pinning the older number again.
+
+## Finding where a node is pinned
+
+```json
+{
+	"command": "rrext_deploy_node",
+	"arguments": { "subcommand": "where", "nodeId": "my_node" }
+}
+```
+
+```json
+{ "pins": [{ "audience": "u1", "version": 3 }] }
+```
+
+## Fields worth knowing about
+
+**`runtime`** is `python` today and rides on every artifact. Python nodes are a
+source tree the engine imports as it stands. It is recorded from the first
+version because native nodes will not be portable: a compiled node ships one
+artifact per platform and is tied to the engine build it was compiled against,
+so anything resolving a node has to know what it is about to fetch. Registry
+artifacts are immutable, which makes an absent field expensive to add later.
+
+**The build lifecycle** on the version's metadata is `ready` the moment a
+Python node is published — its source is what runs, so there is nothing to
+compile. The field exists for the same reason as `runtime`.
+
+## Related
+
+- [WebSocket protocol](/protocols/websocket): the transport these commands ride.
+- [Pipeline JSON Reference](/pipeline-reference): the `.pipe` payload shape.

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -54,6 +54,20 @@ landed in:
 **A published version is inert.** It is on the shelf and nobody can run it yet.
 Making it reachable is `deploy`, below.
 
+### Publishing and binding in one call
+
+`deployTo` on the same request publishes and then binds, which is what the CLI
+sends behind `--deploy-to`. A bare team name or id is read as that team; the
+`@` targets described under [deploy](#making-a-version-reachable) pass through
+unchanged. The response carries the `audience` that was bound alongside the
+artifact.
+
+It is a convenience, not a second door: the binding runs through the same rule
+`deploy` applies, so nothing becomes reachable here that the explicit verb
+would have refused. If the bind fails, **the version still stands** — the
+bytes landed and the version is real, so the error says so and the caller
+binds it afterwards rather than uploading again.
+
 ### What the server checks, in order
 
 Each of these refuses **before** a registry row exists, so a rejected upload

--- a/packages/server/docs/node-deploy.md
+++ b/packages/server/docs/node-deploy.md
@@ -92,6 +92,31 @@ Only then is the version allocated, and only then does content land:
 If a content write fails partway, what was written is removed and the version
 is flipped to `failed`.
 
+## Dependencies
+
+A node declares what it needs the way every in-tree node does: one
+`requirements.txt` at the root of its directory. That is the normal case — 116
+of the 139 nodes in the tree carry one.
+
+Publishing reads it and records the declared lines on the **artifact**, not
+only inside the bundle:
+
+```json
+{ "requirements": ["httpx", "pydantic"] }
+```
+
+Keeping it on the artifact is what lets anything resolving the node decide
+whether it can run it **before** downloading the bundle. Comments and blank
+lines are dropped; nothing else is interpreted, because pinning policy belongs
+to whoever installs.
+
+### What a node may not bring
+
+An `overrides.txt` is refused, and the version is never registered. Overrides
+do not add a dependency — they **replace what other packages declare**, and the
+engine sweeps them process-wide. One published node carrying one would rewrite
+dependency resolution for every other node running alongside it.
+
 ## Seeing what is published
 
 ```json


### PR DESCRIPTION
Makes a node that **one person uploaded** show up and work on **someone else's machine**.

Design and rationale: #2242.

## What it adds

| Piece | Where |
|---|---|
| Publish a node version | `rrext_deploy add` with `kind: 'node'` |
| See, pin, locate, withdraw | `rrext_deploy_node` |
| Which nodes a caller has | `resolve_node_pins` |
| Fetch and place one for a run | `node_resolve` |
| Control from SDK and CLI | `client.deploy.node*`, `rocketride node` |

Nodes ride the registry apps and pipes already use, so this is the `kind:'node'` adapter rather than a parallel mechanism. The package is the node directory zipped as it sits, with `services.json` at its root — that file decides the identity, so a caller naming someone else's node cannot publish under it.

## Modules

**`account/node_deploy.py`** — the `kind:'node'` adapter. Publishing (guards, identity from the manifest, content beside the artifact, compensation on a partial write), the control verbs, and `resolve_node_pins`, which answers *which nodes can this caller use* with the same scope walk apps take.

**`account/node_resolve.py`** — resolution for a run, in two halves. Deciding is pure: a pipeline dict, the names the engine already carries, the caller's pins — so it answers "will this run work?" without touching the network or the disk. Getting checks the digest against what the registry recorded **before a zip reader sees the bytes**, guards the archive again, caches by content, installs declared dependencies, and places the directory where the engine imports from.

**`account/deploy_common.py`** — one seam for what both deploy rails share (identity, audiences, archive guards), so the coupling is a single import rather than six scattered call sites.

**`modules/task/commands/cmd_node.py`** — thin DAP router, additive to `TaskConn`.

**`cli/commands/node.ts`** and four methods on the SDK's deploy namespace — the client surface for everything after publishing, which did not exist.

## Behaviour worth knowing

- **Publishing is inert.** A version is on the shelf until an audience is pinned to it. First release, update and rollback are all `deploy`.
- **Withdrawal never touches the version.** Pulling a node from a team today does not stop pinning that same version tomorrow. `--target @all` withdraws every binding, checking permission on all of them before touching any.
- **Reach is a set, not a level.** A node can hold `@me`, a team and `@public` at once, each on its own version. Public reach needs the developer namespace; private reach does not, because the registry is partitioned by org.
- **Runs never install.** A run materialises only the nodes it names and drops them afterwards. The cache is keyed by digest, so it is never stale and two runs racing on the same node resolve to the same bytes.
- **`overrides.txt` is refused.** It replaces what other packages declare, process-wide — one published node carrying one would rewrite dependency resolution for every other node running alongside it.

## OSS and SaaS

One code path. Every registry and binding call here is declared on `AccountBase` and implemented by both `account/oss/` and `extension/saas/`; storage is the same Store either way. OSS is not a degraded case — it supplies a real identity, so `@me` and `@team/local` resolve normally and `@public` is held to the same namespace rule.

## Testing

```
./dist/server/engine -m pytest packages/ai/tests/ai/account/test_node_deploy.py packages/ai/tests/ai/account/test_node_resolve.py -q
```

87 tests. The resolver's publish a node through the real publish path and resolve it back over the **real** Store rather than a fake on both sides: publish and resolve agree on where a bundle lives only by convention, and that convention needs something watching it. It earned its keep on the first run by catching a read against a method `FileStore` does not have.

By hand:

```
rocketride deploy add ticket_feed.zip --kind node --deploy-to <teamId>
rocketride node versions ticket_feed
rocketride node deploy ticket_feed 3 --target @team/Platform
rocketride node where ticket_feed
rocketride node remove ticket_feed --target @all
```

## Draft, because one piece is missing

A pipeline naming a published node will fetch it, verify it, install its dependencies and place it correctly — and the engine will not know it is there. Service definitions are built once, and reading a node off disk happens in `loadServices()`, a lambda inside `IServices::init()`, which has no Python binding.

Closing it is a method that scans a directory it is handed and then runs the schema rebuild that already follows — no new logic, since `init()` does both today. Taking a directory rather than re-reading `--node_path` is what makes it work on a cloud worker, which has no workspace and no such option.

That lands on this branch, as its own commit, with `init()` untouched and no callers until a further commit wires step 8 to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for publishing, versioning, deploying, disabling, and removing custom nodes.
  - Added node resolution with bundle verification, caching, dependency installation, and runtime materialization.
  - Added CLI commands and TypeScript/Python client APIs for node deployment management.
  - Added personal, team, public, and all-user audience targeting.
  - Added node package validation, manifest handling, progress reporting, and deployment status details.

- **Documentation**
  - Added guidance for node deployment, validation, targeting, and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->