### PR TITLE
feat(shell): app version pins live in the URL with a stale-version notice (RR-456)

### DIFF
--- a/packages/shell/src/api.ts
+++ b/packages/shell/src/api.ts
@@ -512,7 +512,7 @@ export const shellApi = {
 	get BxChevronRight() { return BxChevronRight; },
 	get BxFolderOpen() { return BxFolderOpen; },
 	get AppLayout() { return AppLayout; },
-	// Desktop version selector — session override read + apply/clear
+	// Desktop version selector — version pin read + apply/clear (URL-backed)
 	get getAppVersionOverride() { return getAppVersionOverride; },
 	get applyAppVersionOverride() { return applyAppVersionOverride; },
 	// Stable versioned entry URL (constructed, never minted — the server
@@ -558,7 +558,7 @@ export {
 	BxLockOpen, BxPurchaseTag, BxChevronRight, BxFolderOpen,
 	// The one app-root layout
 	AppLayout,
-	// Desktop version selector — session override read + apply/clear
+	// Desktop version selector — version pin read + apply/clear (URL-backed)
 	getAppVersionOverride, applyAppVersionOverride, versionedEntryUrl,
 };
 

--- a/packages/shell/src/components/layout/Shell.tsx
+++ b/packages/shell/src/components/layout/Shell.tsx
@@ -51,7 +51,7 @@ import { ApiKeyLogin } from './ApiKeyLogin';
 import LoadingScreen from './LoadingScreen';
 import { SS_PENDING_APP_ID, getHomeAppId } from '../../constants';
 import { registerAndMapApps, resolveServerEntry, getRegisteredEntry, invalidateAppDescriptor, getLocalAppEntries, setLocalAppsListener, isDevRemote, repointRemote } from '../../util/appLoader';
-import { getAppVersionOverrides, setAppVersionOverride, versionedEntryUrl } from '../../util/versionOverride';
+import { getAppVersionOverrides, versionedEntryUrl } from '../../util/versionOverride';
 import type { ServerAppEntry } from '../../util/appLoader';
 import { waitForEmbeddedSession } from '../../util/devMode';
 
@@ -216,27 +216,11 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 		return cm.getSessionAppId();
 	});
 
-	// Deep-link version pin (?appid=X&version=7): seed the session override on
-	// mount — NOT in the useState initializer above, which is impure and would
-	// fire the write twice under StrictMode. REGISTRY INTS ONLY (semver is
-	// developer-controlled display, never a wire identity); a value with any
-	// trailing non-digit (?version=7abc) is REJECTED outright rather than
-	// silently pinned to 7 by parseInt's prefix parsing. The int IS the whole
-	// identity — registration constructs the versioned URL from it directly.
-	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		const fromUrl = params.get('appId') || params.get('appid') || '';
-		const raw = params.get('version') ?? '';
-		if (fromUrl && /^\d+$/.test(raw)) {
-			// Number(), not parseInt(): a digit string too long for a safe
-			// integer must be rejected (parseInt rounds, and overlong input
-			// reaches Infinity — which passes a bare `> 0` check).
-			const version = Number(raw);
-			if (Number.isSafeInteger(version) && version > 0) {
-				setAppVersionOverride(fromUrl, { version });
-			}
-		}
-	}, []);
+	// A deep-link version pin (?appid=X&version=7) needs no seeding step: the
+	// URL IS where pins live now, and getAppVersionOverrides reads it straight
+	// (registry ints only — ?version=7abc is rejected, never prefix-parsed).
+	// This used to copy the parameter into sessionStorage, which is how a pin
+	// outlived the address that explained it.
 
 	// Surface a version pin dropped by the PREVIOUS document: the load
 	// failure path clears the override and reloads, so the notice has to

--- a/packages/shell/src/components/layout/ShellLayout.tsx
+++ b/packages/shell/src/components/layout/ShellLayout.tsx
@@ -49,6 +49,7 @@ import { AppFrame } from './AppFrame';
 import RocketRideWordmark from '../../assets/icons/RocketRideWordmark';
 import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
+import VersionPinNotice from './VersionPinNotice';
 import LoadingScreen from './LoadingScreen';
 import DebugPanel from './DebugPanel';
 import { ConnectionErrorBanner } from './ConnectionErrorBanner';
@@ -721,6 +722,11 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 					<DebugPanel onClose={() => setDebugOpen(false)} />
 				)}
 			</div>
+
+			{/* Which version of the app on screen this is, when it is not the
+			    current one. See VersionPinNotice: a pin is silent, survives
+			    every reload, and is the reason a change "will not show". */}
+			<VersionPinNotice appId={activeAppId} />
 
 			{/* Status bar — presence is the app's AppLayout declaration */}
 			{considerStatusBar && (

--- a/packages/shell/src/components/layout/VersionPinNotice.tsx
+++ b/packages/shell/src/components/layout/VersionPinNotice.tsx
@@ -1,0 +1,119 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// =============================================================================
+// "YOU ARE LOOKING AT AN OLD VERSION" — said where it cannot be missed
+// =============================================================================
+// A version pin lives in the ADDRESS BAR: it survives a reload and leaves when
+// you navigate away. A version picked once from a store tile keeps serving that
+// snapshot until then. Bytes are immutable per version, so the pinned app works
+// perfectly — it is simply the app as it was, and no error, no failed request
+// and no rebuild says otherwise. Days of "my change is not showing" come from
+// this, and the only cure is telling the person, on screen, which version they
+// are running.
+//
+// A chip rather than a banner: it must survive alongside whatever the app draws
+// (the bar in the bottom bar exists only when an app declares one), stay out of
+// the way, and still be the first thing found when something looks wrong. One
+// click clears the pin and reloads onto the server's own answer.
+
+import React, { CSSProperties } from 'react';
+
+import { getStalePin } from '../../util/appLoader';
+import { clearAppVersionOverride, getAppVersionOverride } from '../../util/versionOverride';
+
+const styles = {
+	chip: {
+		position: 'fixed',
+		right: 12,
+		bottom: 10,
+		zIndex: 2147483000,
+		display: 'flex',
+		alignItems: 'center',
+		gap: 8,
+		maxWidth: 'min(92vw, 420px)',
+		padding: '6px 10px',
+		borderRadius: 999,
+		border: '1px solid var(--rr-color-warning)',
+		background: 'color-mix(in srgb, var(--rr-color-warning) 10%, var(--rr-bg-paper))',
+		color: 'var(--rr-text-primary)',
+		fontSize: 12,
+		lineHeight: 1.3,
+		boxShadow: '0 2px 10px rgba(0, 0, 0, 0.18)',
+	} as CSSProperties,
+	text: { minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } as CSSProperties,
+	button: {
+		appearance: 'none',
+		flexShrink: 0,
+		border: '1px solid var(--rr-color-warning)',
+		borderRadius: 999,
+		background: 'transparent',
+		color: 'var(--rr-color-warning)',
+		cursor: 'pointer',
+		fontSize: 12,
+		fontWeight: 600,
+		padding: '2px 10px',
+	} as CSSProperties,
+};
+
+/**
+ * The pinned-version chip for the app on screen.
+ *
+ * @param props.appId - The active app, or null when none is mounted.
+ * @returns The chip, or null when this app loads the server's own version.
+ */
+const VersionPinNotice: React.FC<{ appId: string | null }> = ({ appId }) => {
+	const pin = appId ? getStalePin(appId) : null;
+	if (!pin) return null;
+
+	// Clear and RELOAD rather than repoint: a container that has already
+	// loaded is committed to its version for the life of the document (the MF
+	// one-document-one-version rule that repointRemote enforces), and the app
+	// whose chip this is has by definition loaded.
+	const useLatest = () => {
+		clearAppVersionOverride(pin.appId);
+		// VERIFY BEFORE RELOADING. The clear writes through `writeParams`, which
+		// swallows a refused `replaceState` — a SecurityError in a sandboxed frame
+		// without allow-same-origin, or Safari's rate limit after repeated calls.
+		// Reloading onto a pin that never left comes back on the same version and
+		// redraws this chip, so the button appears to do nothing, with no error and
+		// no log. Same shape as WorkspaceContext's dropped-override path.
+		if (getAppVersionOverride(pin.appId) !== null) {
+			console.error(`[shell] could not clear the pin on ${pin.appId} (v${pin.pinned}) — not reloading`);
+			return;
+		}
+		window.location.reload();
+	};
+
+	return (
+		<div style={styles.chip} role="status">
+			<span style={styles.text}>
+				{pin.name} is pinned to v{pin.pinned} — v{pin.latest} is current
+			</span>
+			<button type="button" style={styles.button} onClick={useLatest}>
+				Use v{pin.latest}
+			</button>
+		</div>
+	);
+};
+
+export default VersionPinNotice;

--- a/packages/shell/src/util/appLoader.ts
+++ b/packages/shell/src/util/appLoader.ts
@@ -123,6 +123,52 @@ export function isRemoteLoaded(moduleId: string): boolean {
 	return loadedModules.has(moduleId);
 }
 
+// =============================================================================
+// PINS THAT ARE BEHIND — the tab is running old code and says nothing
+// =============================================================================
+// A session pin is a deliberate choice and stays honoured. What it must not be
+// is UNNOTICED. A pin now lives in the address bar (see versionOverride), which
+// makes it findable — but a URL carrying `&version=` still looks like an
+// ordinary link, and the bytes behind a version are immutable, so the pinned
+// app works perfectly. It is simply the app as it was, and every explanation
+// the developer reaches for (a stale build, a missed copy, a bad seed) is
+// wrong.
+//
+// Recorded at registration, where both numbers are in hand, and read by the
+// chrome so the fact is on SCREEN. A console warning alone was the state of the
+// art here, and a console is precisely where nobody looks.
+
+/** One app pinned below the version the server would have served. */
+export interface StalePin {
+	appId: string;
+	name: string;
+	/** The version this document loads. */
+	pinned: number;
+	/** What the server resolves for this caller. */
+	latest: number;
+}
+
+const stalePins = new Map<string, StalePin>();
+
+/**
+ * The pin holding one app behind, if any.
+ *
+ * @param appId - The app id.
+ * @returns The pin, or null when the app loads the server's own answer.
+ */
+export function getStalePin(appId: string): StalePin | null {
+	return stalePins.get(appId) ?? null;
+}
+
+/**
+ * Every app currently held behind by a session pin.
+ *
+ * @returns The pins, in registration order.
+ */
+export function listStalePins(): StalePin[] {
+	return [...stalePins.values()];
+}
+
 /**
  * Force re-register an MF container at a new entry URL (version override
  * apply/boot). Refuses dev-owned containers — the live dev build always
@@ -658,6 +704,26 @@ export function registerAndMapApps(serverApps: ServerAppEntry[]): AppManifestEnt
 
 	// Record the registered URLs so resetRemote() can rebuild a container.
 	for (const { app, url } of registrable) registeredEntries.set(app.moduleId, url);
+
+	// Which apps a pin is holding BEHIND — see StalePin. Refreshed for the apps
+	// in THIS call only, so clearing a pin and re-registering clears the notice
+	// with it. Not a rebuild: a registration can be partial — post-auth, Shell
+	// registers only the apps the probe did not list — and clearing everything
+	// would silently drop a probed app's notice.
+	for (const a of serverApps) stalePins.delete(a.id);
+	// `resolved` is what `validApps` was before this merge: the server entries
+	// whose load URL resolved. Same filter, restructured to carry the URL with
+	// the entry — a pin cannot hold back an app that was never registered.
+	for (const { app: a } of resolved) {
+		const pin = overrideOf(a);
+		if (!pin || typeof a.registryVersion !== 'number') continue;
+		if (pin.version >= a.registryVersion) continue;
+		stalePins.set(a.id, { appId: a.id, name: a.name, pinned: pin.version, latest: a.registryVersion });
+		console.warn(
+			`[shell] ${a.name} is pinned to v${pin.version}; the server would serve v${a.registryVersion}. ` +
+			'This tab loads the pinned version until the pin is cleared — rebuilding cannot change it.',
+		);
+	}
 
 	// Map server entries to runtime AppManifestEntry objects with lazy loaders
 	return resolved.map(({ app: a }) => ({

--- a/packages/shell/src/util/versionOverride.ts
+++ b/packages/shell/src/util/versionOverride.ts
@@ -21,17 +21,24 @@
 // SOFTWARE.
 
 /**
- * App version overrides — the desktop version selector's session state.
+ * App version overrides — a pin that lives in the ADDRESS BAR.
  *
  * A user picking a specific app version (tile drop list, or a
- * `?appid=X&version=1.3.0` deep link) creates a SESSION-ONLY override:
- * stored in sessionStorage, dies with the tab, never persisted server-side
- * (persistent personal pins were rejected — they go stale silently).
+ * `?appid=X&version=7` deep link) pins that app to that registry version.
+ * The pin is held in the URL and nowhere else, which is a deliberate change
+ * from the sessionStorage map this used to be.
  *
- * Resolution order (top wins): URL `?version=` → session override →
- * dev overlay → the server's scope-walk default in the manifest entry.
- * URL parsing simply seeds/replaces the session override at boot, so the
- * rest of the shell only ever consults ONE place.
+ * WHY THE URL. A pin in sessionStorage is state with no address: invisible,
+ * unshareable, surviving every reload and dying only with the tab. Bytes are
+ * immutable per version, so a pinned app keeps working perfectly — it is
+ * simply the app as it was on the day it was pinned, and no error, no failed
+ * request and no amount of rebuilding says otherwise. Days have gone into
+ * "my change will not show" that were one forgotten pin. In the URL the pin
+ * can be seen, copied, sent to someone else, and left behind by navigating —
+ * which is what everyone already assumes a temporary choice does.
+ *
+ * Resolution order (top wins): URL pin → dev overlay → the server's
+ * scope-walk default in the manifest entry.
  *
  * Entry URLs are CONSTRUCTED, never minted: every version serves from the
  * stable immutable `/apps/<appId>/v<N>/remoteEntry.js` route, entitlement
@@ -48,11 +55,45 @@
 import { repointRemote, isRemoteLoaded, invalidateAppDescriptor, isDevRemote } from './appLoader';
 
 // =============================================================================
-// STORAGE
+// STORAGE — the query string
 // =============================================================================
 
-/** sessionStorage key holding the per-app override map. */
-const SS_OVERRIDES_KEY = 'rr:appVersionOverrides';
+/** The app a pin names. Already the deep-link parameter for "open this app". */
+const APP_PARAM = 'appid';
+/** The registry version it is pinned to. Ints only. */
+const VERSION_PARAM = 'version';
+/** The artifact's semver, carried only so the chip can print it. */
+const APPVER_PARAM = 'appver';
+
+/**
+ * Read the query string of the document.
+ *
+ * @returns The params, or an empty set when there is no document (SSR/tests).
+ */
+function params(): URLSearchParams {
+	try {
+		return new URLSearchParams(window.location.search);
+	} catch {
+		return new URLSearchParams();
+	}
+}
+
+/**
+ * Rewrite the query string in place, without navigating.
+ *
+ * `replaceState` rather than `pushState`: a pin is a property of what you are
+ * looking at, not a place you travelled to, so Back should leave the app —
+ * not step through the versions you tried.
+ *
+ * @param next - The params to put in the address bar.
+ */
+function writeParams(next: URLSearchParams): void {
+	try {
+		const query = next.toString();
+		const url = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+		window.history.replaceState(window.history.state, '', url);
+	} catch { /* no history API — the pin simply does not stick */ }
+}
 
 /**
  * The stable serving URL of one registry version's entry.
@@ -75,7 +116,7 @@ export function versionedEntryUrl(appId: string, version: number): string {
 }
 
 /**
- * One app's session version override.
+ * One app's version pin.
  *
  * `version` is the registry version number (a `?version=` semver deep link
  * is resolved to its registry int before it lands here). The record holds
@@ -91,45 +132,28 @@ export interface AppVersionOverride {
 }
 
 /**
- * Overrides whose write to sessionStorage FAILED — an embedded frame with
- * storage denied, or a full quota. They stand in for the storage row so THIS
- * document still resolves the pick (a deep link would otherwise seed nothing
- * and the reconciliation would find no override at all).
+ * Reads the pins in the address bar.
  *
- * The mirror only ever ADDS: an entry that survives in storage is what the
- * next boot resolves, so a delete that failed to persist must keep reading as
- * present. The failing-override drop path depends on that — it verifies the
- * clear before reloading, and a mirror that masked the surviving storage row
- * would turn a bounded reload into a loop.
- */
-const memoryOverrides: Record<string, AppVersionOverride> = {};
-
-/**
- * Writes the override map to sessionStorage.
+ * ONE app at a time, by construction: the URL names an app and a version. The
+ * map shape is kept because every caller reads it by app id, and because a
+ * second pinning scheme could be added here without touching them.
  *
- * @param map - The full map to persist.
- * @returns True when storage accepted the write.
- */
-function persistOverrides(map: Record<string, AppVersionOverride>): boolean {
-	try {
-		sessionStorage.setItem(SS_OVERRIDES_KEY, JSON.stringify(map));
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Reads the full override map from sessionStorage.
+ * REGISTRY INTS ONLY — a value with any trailing non-digit (`?version=7abc`)
+ * is rejected outright rather than silently pinned to 7 by prefix parsing, and
+ * so is one past the safe-integer range, which would parse to a neighbouring
+ * number instead of the one written.
  *
- * @returns App id → override; empty object when none or storage unavailable.
+ * @returns App id → pin; empty object when nothing is pinned.
  */
 export function getAppVersionOverrides(): Record<string, AppVersionOverride> {
-	let stored: Record<string, AppVersionOverride> = {};
-	try {
-		stored = JSON.parse(sessionStorage.getItem(SS_OVERRIDES_KEY) ?? '{}') as Record<string, AppVersionOverride>;
-	} catch { /* storage unavailable — the in-memory mirror stands in */ }
-	return { ...stored, ...memoryOverrides };
+	const search = params();
+	const appId = search.get('appId') || search.get(APP_PARAM) || '';
+	const raw = search.get(VERSION_PARAM) ?? '';
+	if (!appId || !/^\d+$/.test(raw)) return {};
+	const version = Number(raw);
+	if (!Number.isSafeInteger(version) || version <= 0) return {};
+	const appVersion = search.get(APPVER_PARAM) || undefined;
+	return { [appId]: appVersion ? { version, appVersion } : { version } };
 }
 
 /**
@@ -143,37 +167,39 @@ export function getAppVersionOverride(appId: string): AppVersionOverride | null 
 }
 
 /**
- * Writes (or replaces) one app's session version override.
+ * Pins one app to one version, by putting it in the address bar.
+ *
+ * The app parameter is written too: a version without the app it belongs to
+ * means nothing, and the pair is exactly the existing deep-link shape, so a
+ * pinned URL opens the same thing when it is pasted somewhere else.
  *
  * @param appId - The app id.
- * @param override - The override record to store.
+ * @param override - The version to pin to.
  */
 export function setAppVersionOverride(appId: string, override: AppVersionOverride): void {
-	const map = getAppVersionOverrides();
-	map[appId] = override;
-	// A refused write keeps the pick in memory so THIS document still resolves
-	// it (a deep link would otherwise seed nothing at all); it dies with the
-	// document, exactly like the session storage it stands in for.
-	if (persistOverrides(map)) {
-		delete memoryOverrides[appId];
-	} else {
-		memoryOverrides[appId] = override;
-	}
+	const next = params();
+	next.delete('appId');           // the accepted alternate spelling, so one wins
+	next.set(APP_PARAM, appId);
+	next.set(VERSION_PARAM, String(override.version));
+	if (override.appVersion) next.set(APPVER_PARAM, override.appVersion);
+	else next.delete(APPVER_PARAM);
+	writeParams(next);
 }
 
 /**
- * Removes one app's session version override.
+ * Unpins one app: the version leaves the address bar.
  *
- * @param appId - The app id.
+ * The app parameter STAYS — it is also "which app is open", and dropping it
+ * would navigate away from the thing being unpinned.
+ *
+ * @param appId - The app id. Ignored when a different app is pinned.
  */
 export function clearAppVersionOverride(appId: string): void {
-	const map = getAppVersionOverrides();
-	delete map[appId];
-	// The mirror goes first and unconditionally: a mirrored override must
-	// never outlive the clear that removed it. A storage row that survives a
-	// failed write stays visible on read — that is what the drop path checks.
-	delete memoryOverrides[appId];
-	persistOverrides(map);
+	if (!getAppVersionOverrides()[appId]) return;
+	const next = params();
+	next.delete(VERSION_PARAM);
+	next.delete(APPVER_PARAM);
+	writeParams(next);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

App version pins move to the URL and show on screen, with one-click update to the current version.

- **The problem.** A pin lived in `sessionStorage`: invisible, unshareable, and it survived every reload. A registry version is an immutable snapshot, so a pinned app keeps working perfectly. It is just the app as it was on the day it was pinned, which means a rebuilt change "never shows" and nothing says why.
- **The pin now lives in the address bar.** The existing `?appid=X&version=7` deep link is the only place a pin is kept.
  - Reading a pin parses the query string, accepting registry integers only, in the safe-integer range.
  - Setting a pin uses `replaceState`, so Back leaves the app instead of stepping through versions.
  - Clearing a pin drops the version and keeps the app.
- **Stale pins are shown.** Registration records any app pinned *below* the version the server would serve. It refreshes per registration, so the partial post-auth registration keeps a probed app's notice. A `VersionPinNotice` chip names both versions and has one button that clears the pin, checks that the clear took, and reloads onto the current version.

The frozen v1 contract is unaffected: no new shell API names, and `shell:check` passes without a freeze.

## Type

Feature

## Testing

- [ ] Tests added or updated: `packages/shell` has no React test harness
- [x] Tested locally: `tsc --noEmit` on `packages/shell` has 0 errors; `shell:freeze --check` is up to date with v1
- [ ] `./builder test` passes (left to CI)
- [ ] Manual: open an app with `?appid=<id>&version=<older N>`. The chip should appear, and "Use vN" should drop the pin and reload.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Breaking changes documented: pins no longer persist in `sessionStorage`; this is the intended change

## Linked Issue

Part of RR-456. Split out of #2213; no GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeK8j3apAhKber2Ac6xAsg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version pins are now stored in the URL, making them shareable and preserved when opening deep links.
  - Added a notice when an app is displayed at an older pinned version, showing the latest version and offering a one-click update.
- **Improvements**
  - Version pins are validated for valid, safe version numbers.
  - Clearing a pin now removes the version setting while preserving the selected app.
  - The shell detects and tracks apps whose pinned versions are behind the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->