### PR TITLE
feat(build): engine log file, local node path, and app build verification (RR-456)

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -1413,6 +1413,49 @@ module.exports = {
 						args.push('--saas');
 					}
 
+					// --logfile[=PATH] → write the engine's log to a file.
+					//
+					// OPT-IN, because the engine's own wording is "log to file INSTEAD
+					// of stdout": turning it on by default would empty the dev console,
+					// which is where everyone actually reads this.
+					//
+					// Worth having at all because without it a node failure exists only
+					// in whichever terminal happened to be open. Two failures in this
+					// tree — a settings outage and a model credential — had to be
+					// reconstructed by reproducing them against the database, because
+					// the exception that said so had already scrolled away.
+					//
+					// The timestamp rides along: a log whose lines cannot be placed in
+					// time does not settle "is this error still happening", which is
+					// the first question asked of one.
+					//
+					// An explicit PATH is resolved here, against the caller's directory:
+					// the engine runs with cwd set to dist/server, so a relative path
+					// passed through as-is would land there instead.
+					if (options.logfile) {
+						const logPath =
+							options.logfile === true ? path.join(DIST_DIR, 'engine.log') : path.resolve(options.logfile);
+						args.push(`--log.file=${logPath}`);
+						args.push('--log.includeDateTime');
+					}
+
+					// An overlay repository can carry workspace-local nodes in a
+					// `local_nodes` folder at its root, and the engine scans that folder
+					// only when --node_path names its parent. The flag has to be on argv:
+					// the option is read with application::Opt, which never looks at the
+					// environment, so there is no env or config equivalent. Task
+					// subprocesses inherit it from here (task_engine.py, "Inherit parent
+					// engine's --node_path"), so the parent process is the only place it
+					// needs setting.
+					//
+					// Without it the nodes load silently as nothing: the engine logs "No
+					// local_nodes directory under --node_path", and the first pipeline
+					// naming one of those providers fails validation with "references a
+					// provider with no registered service definition".
+					if (options.overlayRoot && (await exists(path.join(options.overlayRoot, 'local_nodes')))) {
+						args.push(`--node_path=${path.resolve(options.overlayRoot)}`);
+					}
+
 					// --modelserver: true means local (default address), string means use given address
 					if (options.modelserver === true) {
 						args.push('--modelserver=localhost:5590');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -169,6 +169,13 @@ function parseArgs(args) {
 		} else if (arg.startsWith('--modelserver=')) {
 			// --modelserver=host:port or port: use an existing model server at that address
 			options.modelserver = arg.substring('--modelserver='.length);
+		} else if (arg === '--logfile') {
+			// Bare --logfile: engine writes its log to dist/server/engine.log
+			// INSTEAD of stdout, which is why it is opt-in — see server:dev.
+			options.logfile = true;
+		} else if (arg.startsWith('--logfile=')) {
+			// --logfile=PATH: same, to a chosen path.
+			options.logfile = arg.substring('--logfile='.length);
 		} else if (arg.startsWith('--version=')) {
 			options.buildVersion = arg.substring('--version='.length);
 		} else if (arg.startsWith('--hash=')) {

--- a/scripts/lib/appModule.js
+++ b/scripts/lib/appModule.js
@@ -46,7 +46,9 @@
 
 'use strict';
 
+const crypto = require('crypto');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const {
 	execCommand,
@@ -103,6 +105,96 @@ function readAppId(appRoot, fallback) {
 		console.warn(`  Warning: could not read appManifest.id from ${appRoot} package.json — serving under "${fallback}"; apps_static will 403 at runtime (no matching catalog entry)`);
 		return fallback;
 	}
+}
+
+/**
+ * SHA-256 of a file, or '' when it is not there.
+ *
+ * @param {string} file - Absolute path.
+ * @returns {string} Hex digest, or '' when absent.
+ */
+function sha256(file) {
+	try {
+		return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * The newest published snapshot of one app in the local file store.
+ *
+ * Versions live at `<store>/orgs/<org>/files/.deployments/<appId>/v0000NN-<sha>/dist/`,
+ * which is exactly the tree the versioned serving route streams. Every org is
+ * searched because the developer namespace that owns an app is not knowable
+ * from here — a laptop has one, and taking the highest version across them is
+ * the same answer the seed's own "latest" is.
+ *
+ * @param {string} appId - The app id.
+ * @returns {{version: number, dir: string}|null} The newest snapshot, or null.
+ */
+function latestSnapshot(appId) {
+	const store = process.env.ROCKETLIB_STORE || path.join(os.homedir(), '.rocketlib', 'store');
+	const orgs = path.join(store, 'orgs');
+	let best = null;
+	let orgDirs = [];
+	try {
+		orgDirs = fs.readdirSync(orgs);
+	} catch {
+		return null;
+	}
+	for (const org of orgDirs) {
+		const appDir = path.join(orgs, org, 'files', '.deployments', appId);
+		let entries = [];
+		try {
+			entries = fs.readdirSync(appDir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			// Each snapshot directory has a `v<N>-<sha>.json` record beside it.
+			// Picking the record hashes `<record>.json/dist/remoteEntry.js`, which
+			// is absent — an empty digest, and a false "not published".
+			if (!entry.isDirectory()) continue;
+			const match = /^v(\d+)-/.exec(entry.name);
+			if (!match) continue;
+			const version = Number.parseInt(match[1], 10);
+			if (!best || version > best.version) best = { version, dir: path.join(appDir, entry.name) };
+		}
+	}
+	return best;
+}
+
+/**
+ * Whether the newest published version already carries what is built.
+ *
+ * The question `<app>:verify` asks, minus the throwing — a caller deciding
+ * WHETHER to seed wants a boolean, not an exception.
+ *
+ * Compares the file the seeder would actually copy, out of
+ * `dist/server/static/apps/<id>/`, rather than `build/apps/<id>/`. The two are
+ * the same after a `:copy` step, but dist is what gets published, so dist is
+ * the honest answer to "would seeding change anything".
+ *
+ * @param {string} appId - The app id, as the store names its deployment dir.
+ * @param {string} distAppsDir - The served `apps` directory under dist.
+ * @returns {boolean} True when a seed would publish nothing new. False when
+ *   nothing is built under this id: absent an artifact there is nothing a skip
+ *   could be justified by.
+ */
+function publishedCarriesBuild(appId, distAppsDir) {
+	const built = path.join(distAppsDir, appId, 'remoteEntry.js');
+	// Nothing built under this id: a seed cannot be SKIPPED on the strength of an
+	// artifact that is not there. A wrong `distAppsDir`, or a `:copy` that never
+	// ran, would otherwise read as "already published" and skip the deploy — the
+	// silent no-op deploy this helper and `:verify` exist to catch.
+	// `makeVerifyAction` throws on the same condition; a boolean caller gets the
+	// same answer as "not published".
+	if (!fs.existsSync(built)) return false;
+	const snap = latestSnapshot(appId);
+	// Never published at all: it has to be seeded.
+	if (!snap) return false;
+	return sha256(built) === sha256(path.join(snap.dir, 'dist', 'remoteEntry.js'));
 }
 
 /**
@@ -179,6 +271,64 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 		};
 	}
 
+	/**
+	 * Compare what the browser would be served against what was just built.
+	 *
+	 * The shell loads every remote from `/apps/<appId>/v<N>/remoteEntry.js`, and
+	 * a version is an IMMUTABLE SNAPSHOT taken by the seed — not a view of
+	 * build/. So a build that lands without a seed is invisible: the toolchain
+	 * reports success at every step and the page keeps running the last
+	 * snapshot, which is indistinguishable from a change that "did not work".
+	 * Whole evenings have gone into that gap.
+	 *
+	 * Local files only, deliberately: the check must work with the server down,
+	 * and the snapshot on disk IS what the versioned route streams.
+	 */
+	function makeVerifyAction() {
+		return {
+			run: async (ctx, task) => {
+				const built = path.join(buildDir, 'remoteEntry.js');
+				if (!fs.existsSync(built)) {
+					throw new Error(`${name}: nothing built yet — run ${name}:build first`);
+				}
+
+				// The seeder publishes the STAGED copy under dist/, not build/, and
+				// publishedCarriesBuild() judges by it. A stage behind the build
+				// means a "carries this build" here and a re-seed of the old bytes
+				// there — so the stage has to match before the snapshot is asked.
+				const staged = path.join(serverStaticDir, 'remoteEntry.js');
+				if (!fs.existsSync(staged)) {
+					throw new Error(`${name}: nothing staged yet — run ${name}:copy first`);
+				}
+				if (sha256(staged) !== sha256(built)) {
+					throw new Error(`${name}: the staged bundle in dist/ is not this build — run ${name}:copy before seeding`);
+				}
+
+				const snapshot = latestSnapshot(appId);
+				if (!snapshot) {
+					throw new Error(
+						`${name}: no published version found in the store for "${appId}" — ` +
+						'seed one with `engine extension/saas/tools/appseed.py --force`',
+					);
+				}
+
+				const a = sha256(built);
+				const b = sha256(path.join(snapshot.dir, 'dist', 'remoteEntry.js'));
+				if (a !== b) {
+					throw new Error(
+						`${name}: v${snapshot.version} does NOT carry this build ` +
+						`(built ${a.slice(0, 10)}, published ${b.slice(0, 10)}). ` +
+						'Re-seed: `engine extension/saas/tools/appseed.py --force`',
+					);
+				}
+				// The version number is the point of the success line: it is what
+				// the browser's network tab shows, so a tab loading any other
+				// version is loading a bundle nobody here built.
+				task.output = `v${snapshot.version} carries this build (${a.slice(0, 10)})`;
+			},
+		};
+	}
+
 	// =========================================================================
 	// MODULE DEFINITION
 	// =========================================================================
@@ -188,6 +338,16 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 		{ name: `${name}:bundle`,   action: makeBundleAction },
 		{ name: `${name}:register`, action: () => registerApp(appRoot) },
 		{ name: `${name}:copy`,     action: makeCopyAction },
+
+		// "Is what the browser gets what I just built?" — the one question the
+		// rest of this pipeline cannot answer. Its own action rather than a
+		// step of :build, because the answer only becomes true after the SEED,
+		// which is a separate command run against a running database.
+		{
+			name: `${name}:verify`,
+			action: makeVerifyAction,
+			description: `Check the published version of ${name} carries this build`,
+		},
 
 		// Full build: bundle → register → copy. Every app depends on the
 		// shell, so in repos that CARRY the shell module its build runs
@@ -247,4 +407,4 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 	return { name, description, actions };
 }
 
-module.exports = { createAppModule };
+module.exports = { createAppModule, publishedCarriesBuild };

--- a/scripts/lib/appModule.test.js
+++ b/scripts/lib/appModule.test.js
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for publishedCarriesBuild's snapshot lookup.
+ *
+ * The bug: the store keeps a `v<N>-<sha>.json` record beside every
+ * `v<N>-<sha>/` snapshot directory, and the lookup matched both by name. When it
+ * picked a record, it hashed `<record>.json/dist/remoteEntry.js` — a path that
+ * cannot exist — got an empty digest, and reported a published build as "not
+ * published", so a seed that had nothing to do ran anyway.
+ *
+ * Zero-dependency built-in runner, like sync.test.js. Run:
+ *     node --test scripts/lib/appModule.test.js
+ */
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { publishedCarriesBuild } = require('./appModule');
+
+const APP_ID = 'rocketride.sample';
+const BUNDLE = 'export const answer = 42;\n';
+
+let root;
+let savedStore;
+
+/**
+ * Lay out one published snapshot in the store: `v<N>-<sha>/dist/remoteEntry.js`.
+ * @param {string} name - Snapshot directory name, e.g. 'v000002-abcd1234'
+ * @param {string} content - The published remoteEntry.js bytes
+ */
+function publish(name, content) {
+	const dist = path.join(root, 'store', 'orgs', 'org-1', 'files', '.deployments', APP_ID, name, 'dist');
+	fs.mkdirSync(dist, { recursive: true });
+	fs.writeFileSync(path.join(dist, 'remoteEntry.js'), content);
+}
+
+/**
+ * Write the JSON record the store keeps beside a snapshot directory.
+ * @param {string} name - Record file name, e.g. 'v000002-abcd1234.json'
+ */
+function record(name) {
+	const dir = path.join(root, 'store', 'orgs', 'org-1', 'files', '.deployments', APP_ID);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, name), '{}');
+}
+
+/**
+ * Stage a built bundle where the seeder copies it from.
+ * @param {string} content - The staged remoteEntry.js bytes
+ * @returns {string} The dist apps directory to pass to publishedCarriesBuild
+ */
+function stage(content) {
+	const distApps = path.join(root, 'dist-apps');
+	fs.mkdirSync(path.join(distApps, APP_ID), { recursive: true });
+	fs.writeFileSync(path.join(distApps, APP_ID, 'remoteEntry.js'), content);
+	return distApps;
+}
+
+beforeEach(() => {
+	root = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-appmodule-test-'));
+	savedStore = process.env.ROCKETLIB_STORE;
+	process.env.ROCKETLIB_STORE = path.join(root, 'store');
+});
+
+afterEach(() => {
+	if (savedStore === undefined) delete process.env.ROCKETLIB_STORE;
+	else process.env.ROCKETLIB_STORE = savedStore;
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('a snapshot beside its own JSON record is still found', () => {
+	publish('v000002-abcd1234', BUNDLE);
+	record('v000002-abcd1234.json');
+
+	assert.strictEqual(publishedCarriesBuild(APP_ID, stage(BUNDLE)), true);
+});
+
+test('a record newer than any snapshot directory is not mistaken for one', () => {
+	// The deterministic form of the bug: readdir order no longer matters when
+	// the only v3 entry is a file.
+	publish('v000002-abcd1234', BUNDLE);
+	record('v000002-abcd1234.json');
+	record('v000003-ef567890.json');
+
+	assert.strictEqual(publishedCarriesBuild(APP_ID, stage(BUNDLE)), true);
+});
+
+test('a staged build the newest snapshot does not carry still needs a seed', () => {
+	publish('v000002-abcd1234', BUNDLE);
+	record('v000002-abcd1234.json');
+
+	assert.strictEqual(publishedCarriesBuild(APP_ID, stage('export const answer = 43;\n')), false);
+});
+
+test('records alone are not a publication', () => {
+	record('v000001-abcd1234.json');
+
+	assert.strictEqual(publishedCarriesBuild(APP_ID, stage(BUNDLE)), false);
+});


### PR DESCRIPTION
## Summary

Optional engine log-file output, local node path, and app build verification.

- **`--logfile[=PATH]`** writes the engine's log, with timestamps, to a file. It is opt-in because the engine logs to the file *instead of* stdout. An explicit `PATH` resolves against the directory you ran the builder from; the bare flag writes `dist/server/engine.log`.
- **`--node_path`.** When the overlay repository has a `local_nodes` folder, the engine is launched with `--node_path` so those workspace-local nodes load. Without it they fail silently.
- **`<app>:verify`** reports which published version carries the current build.
  - It first requires the bundle staged in `dist/` to match the build, because the staged copy is what the seeder publishes.
  - It then compares against the newest snapshot in the local store, skipping the `v<N>-<sha>.json` records that sit beside each snapshot directory.
  - `publishedCarriesBuild()` answers the same question as a boolean for seed-skip decisions.

## Type

Feature

## Testing

- [x] Tests added or updated: new `scripts/lib/appModule.test.js` (node:test) covers a snapshot beside its own record, a record newer than any snapshot, a stale staged build, and records with no snapshot directory
- [x] Tested locally: `node --test scripts/lib/appModule.test.js` 4/4; `node --check` on `tasks.js` and `build.js`
- [ ] `./builder test` passes (left to CI)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Breaking changes documented (none; all options are opt-in)

## Linked Issue

Part of RR-456. Split out of #2213; no GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeK8j3apAhKber2Ac6xAsg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional engine log-file output, including configurable paths and automatic date/time logging.
  * Added support for discovering workspace-local nodes through an overlay root.
  * Added a verification action to confirm that built, staged, and published application bundles are consistent.

* **Bug Fixes**
  * Prevented newer deployment records without matching snapshots from being treated as published builds.
  * Added validation for missing, mismatched, or unseeded deployment bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->