### PR TITLE
fix(shell,apps,build): mobile layout, dev app loading, publisher on cards (RR-456)

### DIFF
--- a/apps/hello-ui/src/HomeApp.tsx
+++ b/apps/hello-ui/src/HomeApp.tsx
@@ -722,8 +722,11 @@ const AppCard: React.FC<{ app: AppManifestEntry; onLaunch: (app: AppManifestEntr
 	const [overrideSeq, setOverrideSeq] = React.useState(0);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 
-	// First manifest category, formatted for display (may be absent)
-	const category = app.categories?.[0] ? formatCategory(app.categories[0]) : null;
+	// Who makes it, with the first manifest category as a fallback. The line
+	// under an app's name is where a launcher says who is behind it; the category
+	// stood in there only because the registry carried no publisher, so a card
+	// read "Crm" where a maker's name belongs. An app without one is unchanged.
+	const maker = app.publisher || (app.categories?.[0] ? formatCategory(app.categories[0]) : null);
 
 	// Effective version label — live dev build > session override > manifest.
 	// Bare semver by default; an override shows the OVERRIDDEN version's
@@ -829,7 +832,7 @@ const AppCard: React.FC<{ app: AppManifestEntry; onLaunch: (app: AppManifestEntr
 			    activation over the card's whole area. */}
 			<button type="button" style={styles.launch} aria-label={`Open ${app.name}`} onClick={() => onLaunch(app)} />
 
-			{/* Top row — icon chip + name/category */}
+			{/* Top row — icon chip + name/publisher */}
 			<div style={styles.cardHeader}>
 				<div style={styles.iconChip}>
 					{app.icon
@@ -838,7 +841,7 @@ const AppCard: React.FC<{ app: AppManifestEntry; onLaunch: (app: AppManifestEntr
 				</div>
 				<div style={styles.nameWrap}>
 					<h2 style={styles.appName}>{app.name}</h2>
-					{category && <div style={styles.appCategory}>{category}</div>}
+					{maker && <div style={styles.appCategory}>{maker}</div>}
 				</div>
 			</div>
 

--- a/packages/ai/src/ai/account/app_deploy.py
+++ b/packages/ai/src/ai/account/app_deploy.py
@@ -1062,6 +1062,9 @@ def manifest_snapshot(entry: Dict[str, Any], artifact: Dict[str, Any]) -> Dict[s
     manifest = metadata.get('manifest') if isinstance(metadata.get('manifest'), dict) else {}
     return {
         'name': str(manifest.get('name') or artifact.get('name') or artifact.get('appId') or ''),
+        # Who makes it, shown under the name in the store. Empty when the
+        # manifest declares none — the cards fall back to the first category.
+        'publisher': str(manifest.get('publisher') or ''),
         'description': str(manifest.get('description') or ''),
         'iconPath': str(manifest.get('icon') or ''),
         'readmePath': str(manifest.get('readme') or ''),
@@ -1290,9 +1293,13 @@ async def resolve_app_pins(org_id: str, user_id: Optional[str], team_ids: List[s
             'onDesktop': audience_type != 'public',
         }
         # Omitted (not None) when absent — a present None fails the client
-        # AppManifestEntry dict validation.
+        # AppManifestEntry dict validation. `publisher` is omitted rather than
+        # sent empty for the same reason the store cards want: absence is what
+        # makes them fall back to the first category.
         if snapshot.get('configuration'):
             entry['configuration'] = snapshot.get('configuration')
+        if snapshot.get('publisher'):
+            entry['publisher'] = snapshot.get('publisher')
         resolved[app_id] = entry
     return list(resolved.values())
 

--- a/packages/ai/tests/ai/account/test_app_deploy.py
+++ b/packages/ai/tests/ai/account/test_app_deploy.py
@@ -52,6 +52,7 @@ from ai.account.app_deploy import (
     entitled_version_dirs,
     handle_app_add,
     handle_deploy_app,
+    manifest_snapshot,
     open_version_dirs,
     resolve_app_pins,
 )
@@ -148,12 +149,16 @@ class _FakeRegistry:
         """The fake's audience key (mirrors the backends' encodings)."""
         return f'{audience["type"]}~{audience.get("id", "")}'
 
-    def seed_publish(self, audience, version, art_state=None):
+    def seed_publish(self, audience, version, art_state=None, snapshot=None):
         """Bind one audience to a version (binding born 'enabled').
 
         The REVIEW state lives on the deployment, so ``art_state`` (when
         given) sets that version's deployment state; the read fakes join it
         back onto the row as ``artifactState``.
+
+        ``snapshot`` overrides the row's manifest snapshot — the shape
+        ``manifest_snapshot`` writes at publish time and the resolver reads
+        every listing field back out of.
         """
         if art_state is not None:
             for v in self.versions:
@@ -165,7 +170,7 @@ class _FakeRegistry:
             'audience': dict(audience),
             'version': version,
             'state': 'enabled',
-            'snapshot': {'name': 'Brandy'},
+            'snapshot': snapshot if snapshot is not None else {'name': 'Brandy'},
             'publishedAt': 2000 + version,
         }
 
@@ -1381,3 +1386,47 @@ async def test_resolve_internal_serves_unapproved_but_not_failed(registry):
     registry.versions[0]['state'] = 'failed'
     resolved = await resolve_app_pins('org1', 'u1', ['t1'])
     assert resolved == []
+
+
+# =============================================================================
+# PUBLISHER — who makes the app, shown under its name in the store
+# =============================================================================
+
+
+def test_manifest_snapshot_carries_the_publisher():
+    """The store card reads it off the snapshot; nothing else records it."""
+    entry = {'metadata': {'manifest': {'name': 'Brandy', 'publisher': 'Acme Ltd'}}}
+
+    assert manifest_snapshot(entry, {'appId': 'acme.brandy'})['publisher'] == 'Acme Ltd'
+
+
+def test_manifest_snapshot_publisher_is_empty_when_the_manifest_declares_none():
+    """Empty, not missing: the key is part of the snapshot's shape."""
+    entry = {'metadata': {'manifest': {'name': 'Brandy'}}}
+
+    assert manifest_snapshot(entry, {'appId': 'acme.brandy'})['publisher'] == ''
+
+
+@pytest.mark.asyncio
+async def test_resolve_app_pins_sends_the_publisher(registry):
+    registry.add_version(1, '1.0.0')
+    registry.seed_publish(AUD_PUBLIC, 1, snapshot={'name': 'Brandy', 'publisher': 'Acme Ltd'})
+
+    resolved = await resolve_app_pins('org1', 'u1', ['t1'])
+
+    assert resolved[0]['publisher'] == 'Acme Ltd'
+
+
+@pytest.mark.asyncio
+async def test_resolve_app_pins_omits_an_absent_publisher(registry):
+    """
+    OMITTED, NOT SENT EMPTY — the same rule `configuration` follows. A present
+    None fails the client's AppManifestEntry validation, and absence is what
+    makes the store card fall back to the first category.
+    """
+    registry.add_version(1, '1.0.0')
+    registry.seed_publish(AUD_PUBLIC, 1, snapshot={'name': 'Brandy', 'publisher': ''})
+
+    resolved = await resolve_app_pins('org1', 'u1', ['t1'])
+
+    assert 'publisher' not in resolved[0]

--- a/packages/shell/index.html
+++ b/packages/shell/index.html
@@ -3,7 +3,17 @@
   <head>
     <title>RocketRide</title>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- `interactive-widget=resizes-content`: the shell pins html/body/#root to
+         height:100% and hides overflow, so under the default `resizes-visual` an
+         on-screen keyboard scrolls the visual viewport while the layout stays
+         full height — fixed chrome floats off-screen and a focused input hides
+         behind the keyboard. Shrinking the layout viewport instead makes the
+         flex column re-lay out honestly. iOS Safari ignores the token today, so
+         it is a no-op there and correct on Android.
+         NOT viewport-fit=cover: nothing here reads env(safe-area-inset-*) yet,
+         so opting in would put the status bar under the home indicator and the
+         drawer's edge under the notch. That is its own change. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
     <meta name="description" content="RocketRide" />
     <link rel="icon" href="/shell/favicon.svg" type="image/svg+xml" />
     <script>(function(){try{var h=localStorage.getItem('rr:home:theme'),t=localStorage.getItem('rr:theme');var d=h==='dark'||(h!=='light'&&!!t&&t!=='rocketride-light'&&t!=='light');if(d){document.documentElement.style.setProperty('--rr-bg-default','#080808');document.documentElement.style.background='#080808';}}catch(e){}})();</script>

--- a/packages/shell/rsbuild.config.mts
+++ b/packages/shell/rsbuild.config.mts
@@ -135,6 +135,20 @@ export default defineConfig(({ command }) => {
 					'/sitemap.xml': { target: 'http://localhost:5565' },
 					'/robots.txt': { target: 'http://localhost:5565' },
 					'/llms.txt': { target: 'http://localhost:5565' },
+					// Versioned app bytes (/apps/<id>/v<N>/...) live in the
+					// engine's file store, not in build/ — a SaaS catalog entry
+					// carries a registryVersion and the client constructs that
+					// path, so serving /apps purely from disk here answered every
+					// one of them with index.html and Module Federation failed on
+					// the leading '<'. Only the versioned shape is relayed:
+					// bypass returns the URL for everything else, which falls
+					// through to the static build/ mount above and keeps the
+					// dev-overlay's unversioned /apps/<id>/remoteEntry.js local.
+					'/apps': {
+						target: 'http://localhost:5565',
+						bypass: (req: { url?: string }) =>
+							/^\/apps\/[^/]+\/v\d+\//.test(req.url ?? '') ? undefined : req.url,
+					},
 				},
 			}),
 		},

--- a/packages/shell/src/components/BoxIcon.tsx
+++ b/packages/shell/src/components/BoxIcon.tsx
@@ -103,7 +103,11 @@ export const BxMove = createIcon('M18 11h-5V6h3l-4-4-4 4h3v5H6V8l-4 4 4 4v-3h5v5
 // FILE TREE ICONS
 // =============================================================================
 
-export const BxListUl = createIcon('M4 6h2v2H4zm0 5h2v2H4zm0 5h2v2H4zM20 7H8V5H20v2zm0 5H8v-2h12v2zm0 5H8v-2h12v2z');
+// Boxicons "bx-list-ul", with the bullets moved up a pixel to sit on the rules
+// they belong to. Boxicons draws the dots at y 6/11/16 and the rules at y 5/10/15,
+// so every bullet hung one pixel below the line beside it — visible at any size,
+// and a list icon whose bullets do not line up reads as a rendering fault.
+export const BxListUl = createIcon('M4 5h2v2H4zm0 5h2v2H4zm0 5h2v2H4zM20 7H8V5H20v2zm0 5H8v-2h12v2zm0 5H8v-2h12v2z');
 
 export const BxFolderOpen = createMultiPathIcon(['M20 6h-8l-2-2H4c-1.103 0-2 .897-2 2v12c0 1.103.897 2 2 2h16c1.103 0 2-.897 2-2V8c0-1.103-.897-2-2-2zm0 12H4V8h16v10z']);
 

--- a/packages/shell/src/components/chat/components/MarkdownRenderer.tsx
+++ b/packages/shell/src/components/chat/components/MarkdownRenderer.tsx
@@ -154,13 +154,22 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 						<table style={S.table}>{children}</table>
 					</div>
 				),
-				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, fontSize: '0.92em', color: 'var(--rr-text-secondary)' }}>{children}</th>,
-				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', fontSize: '0.92em' }}>{children}</td>,
+				// No `fontSize` on the cells: `S.table` already carries the 0.92em,
+				// and declaring it again here multiplied the two (13px host -> 11px
+				// cells, where the intent was 12px).
+				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, color: 'var(--rr-text-secondary)' }}>{children}</th>,
+				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)' }}>{children}</td>,
 				// A picture in an answer is bounded by the bubble it is in. Without
 				// this a wide image widens its container instead of fitting it, which
 				// on a phone pushes the whole transcript sideways.
-				img: ({ src, alt }: any) => (
-					<img src={src} alt={alt ?? ''} style={{ maxWidth: '100%', height: 'auto' }} />
+				//
+				// `title`, `width` and `height` are forwarded rather than dropped:
+				// SANITIZE_SCHEMA allows width and height on an img precisely so a
+				// document can state a picture's aspect, and the style below keeps
+				// them honest — the width becomes an upper bound, and `height: auto`
+				// overrides a stated height rather than stretching the image.
+				img: ({ src, alt, title, width, height }: any) => (
+					<img src={src} alt={alt ?? ''} title={title} width={width} height={height} style={{ maxWidth: '100%', height: 'auto' }} />
 				),
 				a: ({ href, children }: any) => {
 					// Only allow safe URL schemes — reject javascript:, data:, vbscript: etc.

--- a/packages/shell/src/components/chat/components/MarkdownRenderer.tsx
+++ b/packages/shell/src/components/chat/components/MarkdownRenderer.tsx
@@ -14,7 +14,16 @@ import { ChartRenderer } from './ChartRenderer';
 
 const S = {
 	wrapper: {
-		fontSize: 13,
+		// INHERITED, not declared. This renders inside somebody else's bubble, and
+		// the bubble is the only thing that knows how big its text should be — an
+		// inline `fontSize` here cannot be overridden from outside without
+		// `!important`, so a host that raised its body copy ended up with a
+		// question at one size and the answer to it at another.
+		//
+		// Every existing caller is unaffected: `MessageBubble` pins 13 on the
+		// bubble itself, and `global.css` puts the document base at
+		// `--rr-font-size-widget`, also 13.
+		fontSize: 'inherit',
 		lineHeight: 1.6,
 		color: 'var(--rr-text-primary)',
 		fontFamily: 'var(--rr-font-family)',
@@ -32,7 +41,9 @@ const S = {
 		width: '100%',
 		borderCollapse: 'collapse' as const,
 		margin: '8px 0',
-		fontSize: 12,
+		// The ratio these already were: 12 ÷ 13. Inside a 13px host they resolve
+		// to 12 and nothing moves; inside a larger one they grow with it.
+		fontSize: '0.92em',
 	} as CSSProperties,
 
 	tableWrapper: {
@@ -45,7 +56,7 @@ const S = {
 		border: '1px solid var(--rr-border)',
 		borderRadius: 3,
 		padding: '1px 4px',
-		fontSize: 12,
+		fontSize: '0.92em',
 		fontFamily: 'var(--rr-font-mono, monospace)',
 		color: 'var(--rr-text-primary)',
 	} as CSSProperties,
@@ -126,7 +137,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 
 					if (!inline && lang) {
 						return (
-							<SyntaxHighlighter style={oneDark} language={lang} PreTag="div" customStyle={{ margin: 0, borderRadius: 6, fontSize: 12 }}>
+							<SyntaxHighlighter style={oneDark} language={lang} PreTag="div" customStyle={{ margin: 0, borderRadius: 6, fontSize: '0.92em' }}>
 								{code}
 							</SyntaxHighlighter>
 						);
@@ -143,8 +154,14 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 						<table style={S.table}>{children}</table>
 					</div>
 				),
-				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, fontSize: 12, color: 'var(--rr-text-secondary)' }}>{children}</th>,
-				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', fontSize: 12 }}>{children}</td>,
+				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, fontSize: '0.92em', color: 'var(--rr-text-secondary)' }}>{children}</th>,
+				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', fontSize: '0.92em' }}>{children}</td>,
+				// A picture in an answer is bounded by the bubble it is in. Without
+				// this a wide image widens its container instead of fitting it, which
+				// on a phone pushes the whole transcript sideways.
+				img: ({ src, alt }: any) => (
+					<img src={src} alt={alt ?? ''} style={{ maxWidth: '100%', height: 'auto' }} />
+				),
 				a: ({ href, children }: any) => {
 					// Only allow safe URL schemes — reject javascript:, data:, vbscript: etc.
 					const safeHref = /^(https?|mailto|tel):/i.test(href ?? '') ? href : undefined;

--- a/packages/shell/src/components/detail-panel/DetailPanel.tsx
+++ b/packages/shell/src/components/detail-panel/DetailPanel.tsx
@@ -145,6 +145,11 @@ export interface IDetailPanelProps {
 	 * {@link MIN_WIDTH} (380 — form-safe for record panels). A non-record drawer
 	 * whose content reads fine narrow (a node/catalog palette) can lower it so
 	 * the user can drag it slim. Ignored for `side: 'bottom'`.
+	 *
+	 * ALSO THE ANSWER ON A PHONE. The floor wins over the usable band — a floor
+	 * that yields is not a floor — so on a 390px host the default 380 leaves a
+	 * 10px sliver of context, which is no context at all. A caller that expects
+	 * to be opened on a narrow viewport should lower this there.
 	 */
 	minWidth?: number;
 	/** Tray height in px (side 'bottom' only). Default {@link DEFAULT_HEIGHT}. */
@@ -568,14 +573,16 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 	};
 
 	/** Reset to the default size: a stacked top resets so the ROOT lands on
-	    the default; a lone panel simply drops its dragged size. */
+	    the default; a lone panel returns to the default, clamped to the band. */
 	const resetSize = (): void => {
 		const { entries, stackedTop } = stackStateNow();
 		if (stackedTop) {
 			stackSharedSize[contained ? 'contained' : 'viewport'] = Math.max(minSize, defaultSize - STACK_OFFSET * (entries.length - 1));
 			notifyStack();
 		} else {
-			setDragSize(null);
+			// Clamped, not dropped: a null falls back to the raw default at render,
+			// which on a narrow host is the off-screen panel the open effect fixed.
+			setDragSize(clampSize(defaultSize));
 			// A keyed lone panel remembers the reset — reopen at the default, not
 			// the last dragged size.
 			persistSize(defaultSize);
@@ -802,13 +809,20 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 		};
 	}, [open]);
 
-	// A restored width (from persistence) may exceed the current usable band if
-	// the owning surface shrank between sessions. Clamp it once on open, after
-	// layout — overlayRef and the stack registry are live by the time an effect
-	// runs, so clampSize resolves against the real host size.
+	// A width may exceed the current usable band: a restored one because the
+	// owning surface shrank between sessions, and the CALLER'S DEFAULT because
+	// nothing ever measured it. Clamp both, once on open, after layout —
+	// overlayRef and the stack registry are live by the time an effect runs, so
+	// clampSize resolves against the real host size.
+	//
+	// The `prev == null` short-circuit this replaces meant a first open never
+	// clamped at all: a caller asking for 640 on a 390px-wide host rendered a
+	// literal 640px panel with 250px of itself, including its own resize handle,
+	// off the right of the screen. Seeding from `defaultSize` makes the first
+	// open behave exactly like every one after it.
 	useEffect(() => {
 		if (!open) return;
-		setDragSize((prev) => (prev == null ? null : clampSize(prev)));
+		setDragSize((prev) => clampSize(prev ?? defaultSize));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open]);
 

--- a/packages/shell/src/components/detail-panel/DetailPanel.tsx
+++ b/packages/shell/src/components/detail-panel/DetailPanel.tsx
@@ -30,13 +30,14 @@
  * focus to whatever was focused before, and Escape closes the drawer.
  */
 
-import React, { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ViewMenuEntry } from '../../types/viewMenu';
 import { ViewMenuBadge } from '../tab-control/ViewMenuBadge';
 import { CLOSE_GLYPH, trapFocus, acquireOverlayLayer, isTopOverlayLayer, releaseOverlayLayer } from '../modal/Modal';
 import { ConfirmDialog } from '../modal/ConfirmDialog';
 import { BxChevronLeft } from '../BoxIcon';
 import { usePrefs } from '../contexts/PrefsContext';
+import { resolveSize, stackedTopSize } from '../../util/panelSize';
 
 // =============================================================================
 // CONSTANTS
@@ -512,19 +513,42 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 		return { entries, stackedTop };
 	};
 
+	/**
+	 * Bring a candidate size inside the band the live host allows.
+	 *
+	 * Measures; {@link resolveSize} does the arithmetic. In a stack the band
+	 * binds the ROOT (deepest, widest) panel: the top may grow only until
+	 * root = top + 40/level still fits.
+	 *
+	 * @param candidate - The size somebody asked for.
+	 * @returns The clamped size.
+	 */
 	const clampSize = (candidate: number): number => {
 		const host = bottom ? (overlayRef.current?.clientHeight ?? window.innerHeight) : (overlayRef.current?.clientWidth ?? window.innerWidth);
-		// In a stack the clamp binds the ROOT (deepest, widest) panel: the top
-		// may grow only until root = top + 40/level still fits the host band.
 		const { entries, stackedTop } = stackStateNow();
-		const allowance = stackedTop ? STACK_OFFSET * (entries.length - 1) : 0;
-		const max = Math.max(minSize, Math.min(host * MAX_HOST_FRACTION, host - CONTEXT_SLIVER) - allowance);
-		return Math.min(Math.max(candidate, minSize), max);
+		return resolveSize(candidate, {
+			hostSize: host,
+			minSize,
+			maxFraction: MAX_HOST_FRACTION,
+			contextSliver: CONTEXT_SLIVER,
+			stackAllowance: stackedTop ? STACK_OFFSET * (entries.length - 1) : 0,
+		});
 	};
 
-	/** Route a resize: a stacked TOP drag drives the shared stack width (the
-	    whole stack reshapes, slivers constant); a lone panel keeps its own. */
-	const applySize = (next: number): void => {
+	/**
+	 * THE ONE WAY A SIZE IS WRITTEN. Clamps, then routes: a stacked TOP drives
+	 * the shared stack width (the whole stack reshapes, slivers constant); a
+	 * lone panel keeps its own.
+	 *
+	 * Both halves live here because splitting them is what let a reset while
+	 * stacked write an unclamped 600 onto a host with room for 380 — the rule
+	 * was remembered at four call sites and forgotten at two.
+	 *
+	 * @param candidate - The size asked for, clamped or not.
+	 * @returns The size actually written, for callers that persist it.
+	 */
+	const applySize = (candidate: number): number => {
+		const next = clampSize(candidate);
 		const { stackedTop } = stackStateNow();
 		if (stackedTop) {
 			stackSharedSize[contained ? 'contained' : 'viewport'] = next;
@@ -532,6 +556,7 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 		} else {
 			setDragSize(next);
 		}
+		return next;
 	};
 
 	/** Begin a drag: capture the pointer and record the starting geometry. */
@@ -547,7 +572,7 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 	const handleResizeMove = (e: React.PointerEvent<HTMLDivElement>): void => {
 		if (!dragRef.current) return;
 		const position = bottom ? e.clientY : e.clientX;
-		applySize(clampSize(dragRef.current.startSize + (dragRef.current.start - position)));
+		applySize(dragRef.current.startSize + (dragRef.current.start - position));
 	};
 
 	/**
@@ -573,18 +598,15 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 	};
 
 	/** Reset to the default size: a stacked top resets so the ROOT lands on
-	    the default; a lone panel returns to the default, clamped to the band. */
+	    the default; a lone panel returns to the default. Both go through
+	    `applySize`, so both are clamped to what the host actually allows. */
 	const resetSize = (): void => {
 		const { entries, stackedTop } = stackStateNow();
-		if (stackedTop) {
-			stackSharedSize[contained ? 'contained' : 'viewport'] = Math.max(minSize, defaultSize - STACK_OFFSET * (entries.length - 1));
-			notifyStack();
-		} else {
-			// Clamped, not dropped: a null falls back to the raw default at render,
-			// which on a narrow host is the off-screen panel the open effect fixed.
-			setDragSize(clampSize(defaultSize));
+		applySize(stackedTop ? stackedTopSize(defaultSize, minSize, STACK_OFFSET, entries.length) : defaultSize);
+		if (!stackedTop) {
 			// A keyed lone panel remembers the reset — reopen at the default, not
-			// the last dragged size.
+			// the last dragged size. The DEFAULT is stored, not the clamped size:
+			// the next host may be wider, and the open effect clamps what it reads.
 			persistSize(defaultSize);
 		}
 	};
@@ -598,14 +620,10 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 		const shrink = bottom ? 'ArrowDown' : 'ArrowRight';
 		if (e.key === grow) {
 			e.preventDefault();
-			const next = clampSize(current + KEY_RESIZE_STEP);
-			applySize(next);
-			persistSize(next);
+			persistSize(applySize(current + KEY_RESIZE_STEP));
 		} else if (e.key === shrink) {
 			e.preventDefault();
-			const next = clampSize(current - KEY_RESIZE_STEP);
-			applySize(next);
-			persistSize(next);
+			persistSize(applySize(current - KEY_RESIZE_STEP));
 		} else if (e.key === 'Home') {
 			e.preventDefault();
 			resetSize();
@@ -711,7 +729,10 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 		const entries = stackScopes[stackScope];
 		if (!bottom && entries.length > 0) {
 			const below = entries[entries.length - 1];
-			stackSharedSize[stackScope] = Math.max(minSize, below.getSize() - STACK_OFFSET);
+			// Clamped like every other write. It has been safe only because the
+			// covered panel's own size was already clamped — safe by accident is
+			// how the reset path lost its clamp.
+			stackSharedSize[stackScope] = clampSize(Math.max(minSize, below.getSize() - STACK_OFFSET));
 		}
 		const entry: IStackEntry = {
 			isDirty: () => dirtyRef.current,
@@ -811,16 +832,20 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 
 	// A width may exceed the current usable band: a restored one because the
 	// owning surface shrank between sessions, and the CALLER'S DEFAULT because
-	// nothing ever measured it. Clamp both, once on open, after layout —
-	// overlayRef and the stack registry are live by the time an effect runs, so
-	// clampSize resolves against the real host size.
+	// nothing ever measured it. Clamp both on open — overlayRef and the stack
+	// registry are live by the time an effect runs, so clampSize resolves
+	// against the real host size.
 	//
 	// The `prev == null` short-circuit this replaces meant a first open never
 	// clamped at all: a caller asking for 640 on a 390px-wide host rendered a
 	// literal 640px panel with 250px of itself, including its own resize handle,
 	// off the right of the screen. Seeding from `defaultSize` makes the first
 	// open behave exactly like every one after it.
-	useEffect(() => {
+	//
+	// BEFORE PAINT, so the correction is not a visible flinch: the first render
+	// draws the unclamped size, and a passive effect can land after the browser
+	// has already painted it.
+	useLayoutEffect(() => {
 		if (!open) return;
 		setDragSize((prev) => clampSize(prev ?? defaultSize));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -843,7 +868,9 @@ export function DetailPanel({ open, onClose, avatar, title, subtitle, tabs, acti
 	const isTop = !stacked || depthFromTop === 0;
 	const hasBelow = stackIndex > 0;
 	const parentTitle = hasBelow ? entries[stackIndex - 1].getTitle() : null;
-	const renderSize = stacked ? (stackSharedSize[stackScope] ?? Math.max(minSize, defaultSize - STACK_OFFSET)) + STACK_OFFSET * depthFromTop : (dragSize ?? defaultSize);
+	const renderSize = stacked
+		? (stackSharedSize[stackScope] ?? clampSize(stackedTopSize(defaultSize, minSize, STACK_OFFSET, entries.length))) + STACK_OFFSET * depthFromTop
+		: (dragSize ?? clampSize(defaultSize));
 	// Mirror for the registry (push seeding) and the resize handlers.
 	sizeRef.current = renderSize;
 

--- a/packages/shell/src/util/panelSize.test.ts
+++ b/packages/shell/src/util/panelSize.test.ts
@@ -1,0 +1,86 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { maxSize, resolveSize, stackedTopSize } from './panelSize';
+
+/** DetailPanel's own numbers: a right drawer with the record-safe floor. */
+const DRAWER = { minSize: 380, maxFraction: 0.85, contextSliver: 120 };
+
+test('a phone-width host clamps the caller default to the floor', () => {
+	// The bug this exists to stop: 640 rendered literally, with 250px of the
+	// panel — including its resize handle — off the right of a 390px screen.
+	assert.equal(resolveSize(640, { ...DRAWER, hostSize: 390 }), 380);
+});
+
+test('the floor wins over the band on a host too narrow for either', () => {
+	// 320 * 0.85 is 272, below the 380 floor. A panel under its floor is broken
+	// in a different way; a caller expecting a phone lowers `minWidth` instead.
+	assert.equal(resolveSize(640, { ...DRAWER, hostSize: 320 }), 380);
+});
+
+test('a comfortable host leaves the caller default alone', () => {
+	assert.equal(resolveSize(640, { ...DRAWER, hostSize: 1600 }), 640);
+});
+
+test('the context sliver binds before the fraction on a mid-width host', () => {
+	// 900 * 0.85 = 765, but 900 - 120 = 780: the smaller of the two wins.
+	assert.equal(maxSize({ ...DRAWER, hostSize: 900 }), 765);
+	assert.equal(resolveSize(900, { ...DRAWER, hostSize: 900 }), 765);
+});
+
+test('a restored size is brought back inside a host that shrank', () => {
+	// The panel was dragged to 900 on a desktop and reopened on a laptop.
+	assert.equal(resolveSize(900, { ...DRAWER, hostSize: 1000 }), 850);
+});
+
+test('a stack reserves room for the panels it covers', () => {
+	// Two levels of 40px sliver come off the top panel's allowance, so the ROOT
+	// — the widest, against the host edge — still fits the band.
+	assert.equal(resolveSize(900, { ...DRAWER, hostSize: 1000, stackAllowance: 80 }), 770);
+});
+
+test('a reset while stacked lands the root on the caller default', () => {
+	// Three panels, 40px per sliver: the top starts 80 narrower so the root
+	// lands on 640.
+	assert.equal(stackedTopSize(640, 380, 40, 3), 560);
+	assert.equal(560 + 40 * 2, 640);
+});
+
+test('a stacked reset never goes under the floor', () => {
+	assert.equal(stackedTopSize(400, 380, 40, 5), 380);
+});
+
+test('a lone panel is its own root', () => {
+	assert.equal(stackedTopSize(640, 380, 40, 1), 640);
+});
+
+test('a stacked reset on a narrow host is still clamped', () => {
+	// CodeRabbit's Major: the stacked branch of resetSize wrote this candidate
+	// straight into the shared size, so a 390px host got 600 where the band
+	// allows 380.
+	const candidate = stackedTopSize(640, 380, 40, 2);
+
+	assert.equal(candidate, 600);
+	assert.equal(resolveSize(candidate, { ...DRAWER, hostSize: 390, stackAllowance: 40 }), 380);
+});

--- a/packages/shell/src/util/panelSize.ts
+++ b/packages/shell/src/util/panelSize.ts
@@ -1,0 +1,104 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// =============================================================================
+// PANEL SIZE — the usable band a drawer or tray may occupy
+// =============================================================================
+//
+// THE ARITHMETIC, WITHOUT THE DOM. `DetailPanel` decides a size in six places —
+// a drag, a keyboard step, a reset (stacked and lone), the stack-join seed and
+// the open correction — and each one previously had to remember the rule on its
+// own. Two of them did not: a reset while stacked wrote 600 where the band
+// allowed 380, and a first open rendered the caller's raw default however narrow
+// the host was. Both shipped a panel whose own resize handle was off-screen.
+//
+// Keeping the arithmetic here does two things: the component has one clamp to
+// route every write through, and the rule is a plain function of numbers, so it
+// can be tested without a browser (see panelSize.test.ts).
+
+/** The measurements that decide how wide (or tall) a panel may be. */
+export interface SizeBand {
+	/** The owning surface's size along the slide axis, in px. */
+	hostSize: number;
+	/** The axis floor — forms and footer verbs break below this. */
+	minSize: number;
+	/** Widest the panel may be as a fraction of the host. */
+	maxFraction: number;
+	/** Host pixels that must stay visible beside the panel. */
+	contextSliver: number;
+	/**
+	 * Room reserved for the panels this one covers, in px.
+	 *
+	 * In a stack the band binds the ROOT (deepest, widest) panel: the top may
+	 * grow only until root = top + one sliver per level still fits. Zero for a
+	 * lone panel.
+	 */
+	stackAllowance?: number;
+}
+
+/**
+ * The largest size the band allows.
+ *
+ * The floor WINS over the band: a host too narrow for `minSize` still gets
+ * `minSize`, because a panel below its floor is unusable in a different way,
+ * and a caller that expects to be opened on a phone should lower the floor.
+ *
+ * @param band - The measurements.
+ * @returns The maximum size in px.
+ */
+export function maxSize(band: SizeBand): number {
+	const usable = Math.min(band.hostSize * band.maxFraction, band.hostSize - band.contextSliver);
+	return Math.max(band.minSize, usable - (band.stackAllowance ?? 0));
+}
+
+/**
+ * A candidate size, brought inside the band.
+ *
+ * @param candidate - The size somebody asked for: a caller's default, a restored
+ *   preference, a drag position or a keyboard step.
+ * @param band - The measurements.
+ * @returns The size to actually render.
+ * @example
+ * resolveSize(640, { hostSize: 390, minSize: 380, maxFraction: 0.85, contextSliver: 120 });
+ * // => 380 — the phone case: 640 would put the resize handle off-screen.
+ */
+export function resolveSize(candidate: number, band: SizeBand): number {
+	return Math.min(Math.max(candidate, band.minSize), maxSize(band));
+}
+
+/**
+ * The shared TOP width that puts the stack's ROOT panel at `defaultSize`.
+ *
+ * Covered panels render one sliver wider per level, so the top has to start
+ * that much narrower for the root — the widest, and the one against the host
+ * edge — to land where the caller asked. Still a candidate: pass it through
+ * {@link resolveSize} before writing it.
+ *
+ * @param defaultSize - The caller's default size for the root panel.
+ * @param minSize - The axis floor.
+ * @param offset - Sliver width per level, in px.
+ * @param levels - Panels in the stack.
+ * @returns The top panel's size in px.
+ */
+export function stackedTopSize(defaultSize: number, minSize: number, offset: number, levels: number): number {
+	return Math.max(minSize, defaultSize - offset * Math.max(0, levels - 1));
+}

--- a/scripts/lib/registerApp.js
+++ b/scripts/lib/registerApp.js
@@ -331,7 +331,19 @@ function registerApp(appRoot) {
 				categories:    appManifest.categories ?? [],
 				// Settings contribution (VSCode contributes.configuration shape)
 				...(configuration ? { configuration } : {}),
-				entry:         `/${APPS_BASE}/${servedName}/remoteEntry.js`,
+				// STAMPED, so a rebuilt remote cannot be served from cache.
+				//
+				// The URL is otherwise identical across builds, and the chunk names
+				// inside remoteEntry.js are content-hashed — so a browser holding
+				// yesterday's remoteEntry keeps asking for yesterday's chunks and the
+				// app looks unchanged however many times it is rebuilt. That cost an
+				// evening: four rounds of "the change is not showing" against code
+				// that was already correct on disk.
+				//
+				// Registration runs once per build, so the stamp changes exactly when
+				// the bytes do. The versioned SaaS path (`/apps/<id>/v<N>/…`) needs no
+				// such thing — its URL already carries the version.
+				entry:         `/${APPS_BASE}/${servedName}/remoteEntry.js?b=${Date.now().toString(36)}`,
 				// Shell contract version this app was built against (for prune analysis).
 				...(shellApiVersion !== null ? { shellApiVersion } : {}),
 				// App monetization mode

--- a/scripts/lib/registerApp.js
+++ b/scripts/lib/registerApp.js
@@ -41,6 +41,7 @@
 
 'use strict';
 
+const crypto = require('node:crypto');
 const fs   = require('node:fs');
 const path = require('node:path');
 const { BUILD_ROOT, DIST_ROOT, setState } = require('./index');
@@ -51,6 +52,27 @@ const APPS_BASE       = process.env.APPS_BASE_URL ?? 'apps';
 
 // Single source of truth for the shell contract version (freeze auto-writes it).
 const APIVER_TS = path.join(__dirname, '..', '..', 'packages', 'shell', 'src', 'apiver.ts');
+
+/**
+ * Cache-busting stamp for an app's dev entry URL: the first 8 hex of the
+ * SHA-256 of the bundle it points at.
+ *
+ * Read from `build/apps/<appId>/remoteEntry.js`, which the bundle step has
+ * written by the time registration runs. A bundle that is not there yet (an
+ * icon-only or manifest-only registration, or a first run where the build
+ * failed) stamps `0`: the URL stays stable rather than inventing a value that
+ * would change on the next call.
+ *
+ * @param {string} buildDir - The app's build output directory.
+ * @returns {string} The stamp.
+ */
+function entryStamp(buildDir) {
+	try {
+		return crypto.createHash('sha256').update(fs.readFileSync(path.join(buildDir, 'remoteEntry.js'))).digest('hex').slice(0, 8);
+	} catch {
+		return '0';
+	}
+}
 
 // Memoized across calls: apiver.ts is process-global and does not change during
 // a build run, so it is read and parsed once (including a memoized null). This
@@ -340,10 +362,17 @@ function registerApp(appRoot) {
 				// evening: four rounds of "the change is not showing" against code
 				// that was already correct on disk.
 				//
-				// Registration runs once per build, so the stamp changes exactly when
-				// the bytes do. The versioned SaaS path (`/apps/<id>/v<N>/…`) needs no
-				// such thing — its URL already carries the version.
-				entry:         `/${APPS_BASE}/${servedName}/remoteEntry.js?b=${Date.now().toString(36)}`,
+				// The stamp is the BYTES, not the clock. Registration runs once per
+				// build, but the bundle step ahead of it does not: `makeBundleAction`
+				// returns early when nothing changed, so a clock stamp would move on
+				// every build of anything, re-fetching remotes nobody rebuilt — and
+				// would make `dist/server/static/apps.json` differ between two builds
+				// of the same commit. A content hash changes exactly when the bytes do
+				// and keeps the release archive reproducible.
+				//
+				// The versioned SaaS path (`/apps/<id>/v<N>/…`) needs none of this —
+				// its URL already carries the version.
+				entry:         `/${APPS_BASE}/${servedName}/remoteEntry.js?b=${entryStamp(buildDir)}`,
 				// Shell contract version this app was built against (for prune analysis).
 				...(shellApiVersion !== null ? { shellApiVersion } : {}),
 				// App monetization mode


### PR DESCRIPTION
## Summary

Mobile layout behavior, app loading cache invalidation, and publisher display on app cards.

- **Mobile layout**
  - `index.html` sets `interactive-widget=resizes-content`, so an on-screen keyboard shrinks the layout instead of pushing fixed chrome off-screen and hiding the focused input.
  - `MarkdownRenderer`: answer text inherits the bubble's size (secondary text is `0.92em` of it), and images are limited to the bubble's width.
  - `DetailPanel`: the caller's default width is clamped to the host on first open and on reset. Before, a 640px panel on a 390px host rendered half off-screen.
  - `BxListUl`: the bullets now line up with their rules; Boxicons draws them 1px low.
- **App loading**
  - `registerApp` adds a per-build stamp to the dev `/apps/<id>/remoteEntry.js` URL, so a browser holding an old entry can no longer request stale chunks.
  - The dev server relays versioned `/apps/<id>/v<N>/` requests to the engine, which serves those bytes from its file store. Everything else under `/apps` still comes from `build/`.
- **Publisher**
  - `app_deploy` copies the manifest's `publisher` into the publish snapshot, and the pin resolver emits it (omitted when empty).
  - The hello-ui launcher card shows the publisher, falling back to the first category.

## Type

Fix

## Testing

- [x] Tests added or updated: `packages/ai/tests/ai/account/test_app_deploy.py` checks that the publisher is carried and omitted when empty
- [x] Tested locally: `test_app_deploy.py` 58 passed; `tsc --noEmit` on `packages/shell` has 0 errors; `shell:freeze --check` is up to date with v1
- [ ] `./builder test` passes (left to CI)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Breaking changes documented (none)

## Linked Issue

Part of RR-456. Split out of #2213; no GitHub issue.

**Not changed:** in #2213 review, CodeRabbit asked for the dev `/apps` proxy to follow `ROCKETRIDE_URI`. All the other dev proxies (`/task`, `/api`, `/auth`, …) target `localhost:5565` too, so changing only this one would split a page's traffic across two engines. That was declined there; if the dev server should follow `ROCKETRIDE_URI`, all routes should move together in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeK8j3apAhKber2Ac6xAsg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - App cards now show the publisher, or the first category when no publisher is available.
  - Markdown content scales with its container, and images fit within chat bubbles.

- **Bug Fixes**
  - Improved Android layout behavior when the on-screen keyboard opens.
  - Prevented detail panels from appearing oversized on narrow screens and improved reset behavior.
  - Corrected list icon alignment.
  - Improved app loading reliability by refreshing cached entry points.

- **Improvements**
  - Updated development routing to better serve versioned app assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->