### PR TITLE
fix(nodes,vscode,task): CRM tools name their timezone; clearer diagnostics (RR-456)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -666,6 +666,16 @@ function setupConnectionEventHandlers(): void {
 	// Sync service catalog + schemas to .rocketride/ when services are fetched
 	connectionManager?.on('shell:servicesUpdated', (payload: { services: Record<string, unknown>; servicesError?: string }) => {
 		if (payload.servicesError || !payload.services || Object.keys(payload.services).length === 0) {
+			// Not syncing is right — an empty catalogue must not overwrite a good
+			// one on disk. Saying nothing was not: `.rocketride/services-catalog.json`
+			// is written on every successful non-empty fetch, so its ABSENCE is the
+			// reliable signal that a catalogue never arrived. Someone reading the
+			// channel to work out why the palette is empty deserves to be told that
+			// this is why the file they are looking for is not there.
+			getLogger().output(
+				`${icons.warning} Service catalog not synced: ` +
+					`${payload.servicesError ?? 'the engine returned zero services'}.`,
+			);
 			return;
 		}
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -31,6 +31,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getLogger } from './shared/util/output';
 import { icons } from './shared/util/icons';
+import { createCatalogueReporter } from './shared/util/catalogueDiagnostic';
 
 // import { registerDebugger } from './debugger/adapter'; // Disabled: debugger removed from package.json
 import { ConnectionManager, disconnectCloudConnections } from './connection/connection';
@@ -663,19 +664,23 @@ function setupConnectionEventHandlers(): void {
 		});
 	});
 
-	// Sync service catalog + schemas to .rocketride/ when services are fetched
+	// Sync service catalog + schemas to .rocketride/ when services are fetched.
+	//
+	// The ONE place a catalogue problem is reported: this listener sees every
+	// update exactly once, however many editors are open. See
+	// catalogueDiagnostic for what is said and what is deliberately not.
+	const reportCatalogue = createCatalogueReporter();
 	connectionManager?.on('shell:servicesUpdated', (payload: { services: Record<string, unknown>; servicesError?: string }) => {
+		const diagnostic = reportCatalogue(payload);
+		if (diagnostic?.level === 'error') {
+			getLogger().error(diagnostic.message);
+		} else if (diagnostic) {
+			getLogger().output(`${icons.warning} ${diagnostic.message}`);
+		}
+
+		// Not syncing is right — an empty catalogue must not overwrite a good
+		// one on disk.
 		if (payload.servicesError || !payload.services || Object.keys(payload.services).length === 0) {
-			// Not syncing is right — an empty catalogue must not overwrite a good
-			// one on disk. Saying nothing was not: `.rocketride/services-catalog.json`
-			// is written on every successful non-empty fetch, so its ABSENCE is the
-			// reliable signal that a catalogue never arrived. Someone reading the
-			// channel to work out why the palette is empty deserves to be told that
-			// this is why the file they are looking for is not there.
-			getLogger().output(
-				`${icons.warning} Service catalog not synced: ` +
-					`${payload.servicesError ?? 'the engine returned zero services'}.`,
-			);
 			return;
 		}
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -219,6 +219,28 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	// =========================================================================
 
 	private broadcastServicesToAllEditors(payload: { services: Record<string, unknown>; icons?: Record<string, string>; servicesError?: string }): void {
+		// SAY WHY THE PALETTE IS EMPTY.
+		//
+		// A catalogue that failed and a catalogue that is genuinely empty both
+		// render as an empty node palette, and the difference is the entire
+		// diagnosis: "Not connected", "authentication failed" and "the engine
+		// loaded zero services" are three different problems with three
+		// different fixes. This error was recorded on the way in and then read
+		// by nobody, so the one place a person looks for a reason said nothing
+		// at all.
+		if (payload.servicesError) {
+			this.logger.error(
+				`Node catalogue unavailable: ${payload.servicesError}. ` +
+					'The node palette will be empty until this is resolved.',
+			);
+		} else if (Object.keys(payload.services).length === 0) {
+			this.logger.output(
+				'Node catalogue is empty: the engine returned zero services. ' +
+					'One malformed node definition empties the whole catalogue — ' +
+					'restart the engine with --trace=Services to see which.',
+			);
+		}
+
 		for (const editorState of this.editorStates.values()) {
 			if (editorState.isReady && !editorState.isDisposed && editorState.webviewPanel.webview) {
 				editorState.webviewPanel.webview

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -219,28 +219,6 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	// =========================================================================
 
 	private broadcastServicesToAllEditors(payload: { services: Record<string, unknown>; icons?: Record<string, string>; servicesError?: string }): void {
-		// SAY WHY THE PALETTE IS EMPTY.
-		//
-		// A catalogue that failed and a catalogue that is genuinely empty both
-		// render as an empty node palette, and the difference is the entire
-		// diagnosis: "Not connected", "authentication failed" and "the engine
-		// loaded zero services" are three different problems with three
-		// different fixes. This error was recorded on the way in and then read
-		// by nobody, so the one place a person looks for a reason said nothing
-		// at all.
-		if (payload.servicesError) {
-			this.logger.error(
-				`Node catalogue unavailable: ${payload.servicesError}. ` +
-					'The node palette will be empty until this is resolved.',
-			);
-		} else if (Object.keys(payload.services).length === 0) {
-			this.logger.output(
-				'Node catalogue is empty: the engine returned zero services. ' +
-					'One malformed node definition empties the whole catalogue — ' +
-					'restart the engine with --trace=Services to see which.',
-			);
-		}
-
 		for (const editorState of this.editorStates.values()) {
 			if (editorState.isReady && !editorState.isDisposed && editorState.webviewPanel.webview) {
 				editorState.webviewPanel.webview

--- a/apps/vscode/src/shared/util/catalogueDiagnostic.ts
+++ b/apps/vscode/src/shared/util/catalogueDiagnostic.ts
@@ -1,0 +1,107 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+// SAY WHY THE PALETTE IS EMPTY.
+//
+// A catalogue that failed and a catalogue that is genuinely empty both render
+// as an empty node palette, and the difference is the entire diagnosis:
+// "authentication failed" and "the engine loaded zero services" are different
+// problems with different fixes. Kept free of `vscode` imports so the decision
+// can be tested with node:test, like the other helpers in this folder.
+
+/** The `shell:servicesUpdated` payload fields this looks at. */
+export type CataloguePayload = {
+	services?: Record<string, unknown>;
+	servicesError?: string;
+};
+
+/** What the output channel should say about one catalogue update. */
+export type CatalogueDiagnostic = {
+	level: 'error' | 'warning';
+	message: string;
+};
+
+/**
+ * The error `refreshServices` reports before a connection exists.
+ *
+ * A state, not a failure: every startup passes through it, once per open
+ * editor, before the connection is up. Reporting it at all — worse, at error
+ * level — makes it read like the authentication failure this exists to
+ * distinguish.
+ */
+export const NOT_CONNECTED = 'Not connected';
+
+/**
+ * Classify one catalogue update.
+ *
+ * @param payload - The `shell:servicesUpdated` payload.
+ * @returns The line to log, or null when there is nothing worth saying.
+ * @example
+ * catalogueDiagnostic({ services: {}, servicesError: 'HTTP 401' });
+ * // => { level: 'error', message: 'Node catalogue unavailable: HTTP 401. …' }
+ */
+export function catalogueDiagnostic(payload: CataloguePayload): CatalogueDiagnostic | null {
+	if (payload.servicesError === NOT_CONNECTED) {
+		return null;
+	}
+	if (payload.servicesError) {
+		return {
+			level: 'error',
+			message: `Node catalogue unavailable: ${payload.servicesError}. The node palette stays empty and .rocketride/services-catalog.json is not written until this is resolved.`,
+		};
+	}
+	if (!payload.services || Object.keys(payload.services).length === 0) {
+		return {
+			level: 'warning',
+			message: 'Node catalogue is empty: the engine returned zero services, so .rocketride/services-catalog.json is not written. One malformed node definition empties the whole catalogue — restart the engine with --trace=Services to see which.',
+		};
+	}
+	return null;
+}
+
+/**
+ * A reporter that says each thing once.
+ *
+ * Every editor that becomes ready triggers its own catalogue refresh, so one
+ * cause arrives as one event per open editor. The reporter returns a
+ * diagnostic only when it differs from the last one it returned; a healthy
+ * catalogue (or a disconnect) resets it, so the next failure is reported again.
+ *
+ * @returns A function taking each payload and returning the line to log, or null.
+ * @example
+ * const report = createCatalogueReporter();
+ * report({ services: {} }); // => { level: 'warning', … }
+ * report({ services: {} }); // => null (already said)
+ */
+export function createCatalogueReporter(): (payload: CataloguePayload) => CatalogueDiagnostic | null {
+	let lastMessage: string | null = null;
+	return (payload) => {
+		const diagnostic = catalogueDiagnostic(payload);
+		const message = diagnostic?.message ?? null;
+		if (message === lastMessage) {
+			return null;
+		}
+		lastMessage = message;
+		return diagnostic;
+	};
+}

--- a/apps/vscode/src/test/catalogueDiagnostic.test.ts
+++ b/apps/vscode/src/test/catalogueDiagnostic.test.ts
@@ -1,0 +1,74 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { catalogueDiagnostic, createCatalogueReporter, NOT_CONNECTED } from '../shared/util/catalogueDiagnostic';
+
+test('a failed catalogue is an error that names the reason', () => {
+	const diagnostic = catalogueDiagnostic({ services: {}, servicesError: 'HTTP 401: invalid API key' });
+
+	assert.equal(diagnostic?.level, 'error');
+	assert.match(diagnostic?.message ?? '', /HTTP 401: invalid API key/);
+});
+
+test('an empty catalogue is a warning that points at the node definitions', () => {
+	const diagnostic = catalogueDiagnostic({ services: {} });
+
+	assert.equal(diagnostic?.level, 'warning');
+	assert.match(diagnostic?.message ?? '', /zero services/);
+	assert.match(diagnostic?.message ?? '', /--trace=Services/);
+});
+
+test('a healthy catalogue says nothing', () => {
+	assert.equal(catalogueDiagnostic({ services: { llm_openai: {} } }), null);
+});
+
+test('not being connected yet is a state, not a failure, and says nothing', () => {
+	assert.equal(catalogueDiagnostic({ services: {}, servicesError: NOT_CONNECTED }), null);
+});
+
+test('the reporter says each thing once, however many editors ask', () => {
+	const report = createCatalogueReporter();
+	const failed = { services: {}, servicesError: 'HTTP 401' };
+
+	assert.notEqual(report(failed), null);
+	assert.equal(report(failed), null);
+	assert.equal(report(failed), null);
+});
+
+test('the reporter says it again after the catalogue recovers', () => {
+	const report = createCatalogueReporter();
+	const failed = { services: {}, servicesError: 'HTTP 401' };
+
+	report(failed);
+	assert.equal(report({ services: { llm_openai: {} } }), null);
+	assert.notEqual(report(failed), null);
+});
+
+test('the reporter says a different failure straight away', () => {
+	const report = createCatalogueReporter();
+
+	report({ services: {}, servicesError: 'HTTP 401' });
+	assert.equal(report({ services: {} })?.level, 'warning');
+});

--- a/nodes/src/nodes/tool_gohighlevel/tools/messages.py
+++ b/nodes/src/nodes/tool_gohighlevel/tools/messages.py
@@ -334,8 +334,15 @@ class MessagesMixin(GoHighLevelToolsBase):
                 'entries, and excludes email, so pass "Email" explicitly to export email.',
                 ('Call', 'SMS', 'Email', 'WhatsApp', 'Instagram', 'Facebook'),
             ),
-            startDate=STR('Earliest message to include, as an ISO 8601 timestamp.'),
-            endDate=STR('Latest message to include, as an ISO 8601 timestamp.'),
+            # A bare local timestamp is the same trap `_APPOINTMENT_TIMEZONE_DESC` names on
+            # the write side: with no zone in the string, the zone is whatever the far end
+            # assumes, and the only symptom is a range that quietly ends in the wrong place.
+            startDate=STR(
+                'Earliest message to include, as an ISO 8601 timestamp carrying its zone - a trailing Z '
+                'for UTC, or a numeric offset. Without one the timestamp is read in whichever timezone '
+                'GoHighLevel assumes, so the range silently starts somewhere else.'
+            ),
+            endDate=STR('Latest message to include, in the same form as startDate.'),
             sortBy=ENUM('Field to sort on. Defaults to createdAt.', ('createdAt', 'updatedAt')),
             sortOrder=ENUM('Sort direction. Defaults to desc.', ('asc', 'desc')),
         ),

--- a/nodes/src/nodes/tool_gohighlevel/tools/messages.py
+++ b/nodes/src/nodes/tool_gohighlevel/tools/messages.py
@@ -342,7 +342,13 @@ class MessagesMixin(GoHighLevelToolsBase):
                 'for UTC, or a numeric offset. Without one the timestamp is read in whichever timezone '
                 'GoHighLevel assumes, so the range silently starts somewhere else.'
             ),
-            endDate=STR('Latest message to include, in the same form as startDate.'),
+            # The format is repeated, not referenced: "the same form as startDate"
+            # names no format, so zone_audit would skip the field instead of
+            # checking it, and a later edit here could drop the zone unnoticed.
+            endDate=STR(
+                'Latest message to include, in the same form as startDate: an ISO 8601 timestamp '
+                'carrying its zone, either a trailing Z for UTC or a numeric offset.'
+            ),
             sortBy=ENUM('Field to sort on. Defaults to createdAt.', ('createdAt', 'updatedAt')),
             sortOrder=ENUM('Sort direction. Defaults to desc.', ('asc', 'desc')),
         ),

--- a/nodes/src/nodes/tool_pipedrive/README.md
+++ b/nodes/src/nodes/tool_pipedrive/README.md
@@ -95,6 +95,31 @@ create and update tool accepts:
 `extra` is merged into the request body after the typed parameters, so it also
 reaches any API parameter this node does not model explicitly.
 
+### Times are UTC, in both directions
+
+Every field carrying a time of day — an activity's `due_date` and `due_time`, a
+record's `add_time` — is UTC on the wire. Pipedrive displays those values in each
+viewer's own timezone, and validates none of them, so a local wall-clock time sent
+here is not rejected. It is stored, and from then on it reads as a real time.
+
+A meeting asked for at 12:30 in California and written as `12:30` comes back to the
+person who asked for it as 05:30.
+
+Convert before writing and convert back before reporting. The hour moves the **date**
+as well: 20:00 Pacific on a Wednesday is 03:00 UTC on the Thursday, so a converted
+time beside an unconverted date is a booking on the wrong day — take both from the
+same rendering. The `tool_datetime` node returns `utc_date` and `utc_time` next to
+`date` and `time` for exactly this.
+
+Two things this does **not** apply to. A `duration` is a length, not an instant:
+`02:00` is two hours in every timezone there is, and converting it corrupts it. A
+pure date with no time — `expected_close_date`, a goal's period — names no instant,
+so no zone can be wrong about it.
+
+The `start_date` / `end_date` filters on `activity_list` and `note_list` compare
+against those same UTC values, so a range that means one whole local day may need
+widening by a day at each end.
+
 ---
 
 ## Authentication

--- a/nodes/src/nodes/tool_pipedrive/tools/_base.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/_base.py
@@ -49,6 +49,35 @@ EXTRA_DESC = (
     'request body after the typed parameters.'
 )
 
+#: Appended to the description of every field that carries a TIME OF DAY.
+#:
+#: WHY EVERY SUCH FIELD SAYS THIS. Pipedrive takes and returns these in UTC and
+#: displays them in each viewer's own timezone. The API validates none of them,
+#: so a local wall-clock time sent here is not rejected — it is stored, and it
+#: reads as a real time from then on. A meeting asked for at 12:30 in California
+#: and written as "12:30" came back to the person who asked for it as 05:30.
+#:
+#: The hour also moves the DATE. 20:00 Pacific on a Wednesday is 03:00 UTC on the
+#: Thursday, so a converted time and an unconverted date is a booking on the
+#: wrong day — take both from the same rendering or neither.
+#:
+#: A pure DATE with no time (`expected_close_date`, a goal's period) names no
+#: instant and needs none of this. A DURATION is a length, not a time of day, and
+#: converting one is a corruption rather than a correction.
+#:
+#: `tool_gohighlevel` already states its own zones this way
+#: (`appointments._APPOINTMENT_TIMEZONE_DESC`, `contact_tasks._DUE_DATE_DESC`) —
+#: which is the convention, and which Pipedrive was the one node not following.
+#: The two CRMs want different formats, so the shared rule is that a node names
+#: the zone of its own time fields, not that any one zone is right.
+UTC_TIME_DESC = (
+    'Pipedrive reads and returns this in UTC, and shows it to each viewer in their own '
+    'timezone - so send the UTC value, not the local wall-clock one, and convert it back '
+    'before reporting it to a person. The datetime tool returns utc_date and utc_time '
+    'beside date and time for exactly this: write those, and never shift an hour yourself. '
+    'Converting can move the date as well as the time; take both from the same rendering.'
+)
+
 
 # ---------------------------------------------------------------------------
 # Schema builders

--- a/nodes/src/nodes/tool_pipedrive/tools/activities.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/activities.py
@@ -37,6 +37,7 @@ from ._base import (
     INT,
     PAGING,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -73,9 +74,15 @@ _ACTIVITY_WRITE_PROPS = {
     'type': STR(
         'Activity type key, e.g. "call", "meeting", "task", "deadline", "email", "lunch". See activity_type_list for the keys configured in this account.'
     ),
-    'due_date': STR('Due date, YYYY-MM-DD.'),
-    'due_time': STR('Due time, HH:MM.'),
-    'duration': STR('Duration, HH:MM.'),
+    # `due_date` carries the zone note too, and not only `due_time`: the pair is
+    # one instant, and converting the hour past midnight moves the day with it.
+    # A converted time beside an unconverted date is a booking on the wrong day.
+    'due_date': STR(f'Due date, YYYY-MM-DD. {UTC_TIME_DESC}'),
+    'due_time': STR(f'Due time, HH:MM. {UTC_TIME_DESC}'),
+    'duration': STR(
+        'Duration, HH:MM. A LENGTH, not a time of day - no timezone applies and converting '
+        'it is a corruption. A two-hour meeting is "02:00" wherever it is held.'
+    ),
     'done': INT('0 for not done, 1 for done.'),
     'busy_flag': BOOL('Whether the activity marks the user as busy in the calendar.'),
     'note': STR('Note body (HTML is accepted).'),
@@ -112,8 +119,11 @@ class ActivitiesMixin(PipedriveToolsBase):
             filter_id=INT('Apply a saved filter by id (see filter_list).'),
             type=STR('Comma-separated activity type keys to include, e.g. "call,meeting".'),
             done=INT('0 for pending activities, 1 for completed. Omit for both.'),
-            start_date=STR('Only activities due on or after this date, YYYY-MM-DD.'),
-            end_date=STR('Only activities due on or before this date, YYYY-MM-DD.'),
+            start_date=STR(
+                'Only activities due on or after this date, YYYY-MM-DD. Filters the UTC due_date, '
+                'so a range that means a whole day to a person may need widening by one day at each end.'
+            ),
+            end_date=STR('Only activities due on or before this date, YYYY-MM-DD. Same UTC caveat as start_date.'),
         ),
         description='List activities, optionally filtered by owner, type, completion state or due-date range.',
     )

--- a/nodes/src/nodes/tool_pipedrive/tools/deals.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/deals.py
@@ -49,6 +49,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -94,7 +95,7 @@ _DEAL_WRITE_PROPS = {
     'lost_reason': STR('Free-text reason, only meaningful when status is "lost".'),
     'visible_to': ENUM('Visibility group id.', ['1', '3', '5', '7']),
     'label': STR('Deal label id, or a comma-separated list of label ids.'),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/src/nodes/tool_pipedrive/tools/notes.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/notes.py
@@ -34,6 +34,7 @@ from ._base import (
     INT,
     PAGING,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -68,7 +69,7 @@ _NOTE_WRITE_PROPS = {
     'lead_id': STR('Lead uuid the note is attached to.'),
     'project_id': INT('Project the note is attached to.'),
     'user_id': INT('Author user id. Defaults to the authenticated user.'),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'pinned_to_deal_flag': ENUM('Pin the note to the deal.', ['0', '1']),
     'pinned_to_person_flag': ENUM('Pin the note to the person.', ['0', '1']),
     'pinned_to_organization_flag': ENUM('Pin the note to the organization.', ['0', '1']),
@@ -88,8 +89,11 @@ class NotesMixin(PipedriveToolsBase):
             person_id=INT('Only notes attached to this person.'),
             org_id=INT('Only notes attached to this organization.'),
             lead_id=STR('Only notes attached to this lead uuid.'),
-            start_date=STR('Only notes added on or after this date, YYYY-MM-DD.'),
-            end_date=STR('Only notes added on or before this date, YYYY-MM-DD.'),
+            start_date=STR(
+                'Only notes added on or after this date, YYYY-MM-DD. Filters the UTC add_time, so a '
+                'range that means a whole day to a person may need widening by one day at each end.'
+            ),
+            end_date=STR('Only notes added on or before this date, YYYY-MM-DD. Same UTC caveat as start_date.'),
             sort=STR('Sort clause, e.g. "add_time DESC".'),
         ),
         description='List notes, optionally filtered by the record they are attached to or by date.',

--- a/nodes/src/nodes/tool_pipedrive/tools/organizations.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/organizations.py
@@ -48,6 +48,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -68,7 +69,7 @@ _ORG_WRITE_PROPS = {
     'address': STR('Postal address as a single line.'),
     'label': INT('Organization label id.'),
     'visible_to': ENUM('Visibility group id.', ['1', '3', '5', '7']),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/src/nodes/tool_pipedrive/tools/persons.py
+++ b/nodes/src/nodes/tool_pipedrive/tools/persons.py
@@ -47,6 +47,7 @@ from ._base import (
     PAGING,
     PAGING_V2,
     STR,
+    UTC_TIME_DESC,
     PipedriveToolsBase,
     args_of,
     body_from,
@@ -88,7 +89,7 @@ _PERSON_WRITE_PROPS = {
     'marketing_status': ENUM(
         'Consent status for marketing emails.', ['no_consent', 'unsubscribed', 'subscribed', 'archived']
     ),
-    'add_time': STR('Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record.'),
+    'add_time': STR(f'Creation timestamp, YYYY-MM-DD HH:MM:SS. Use to backdate an imported record. {UTC_TIME_DESC}'),
     'extra': EXTRA(),
 }
 

--- a/nodes/test/test_zone_audit.py
+++ b/nodes/test/test_zone_audit.py
@@ -1,0 +1,108 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Tests for `zone_audit` itself, run once rather than once per node that uses it.
+
+Each CRM node's own suite asserts only its verdict (`audit_time_fields(IInstance,
+ALLOWED) == []`). Whether the audit can fail at all, and how exemptions are
+scoped, is a property of the helper and lives here.
+"""
+
+import pytest
+
+from test.zone_audit import audit_time_fields
+
+
+def _node(**tools):
+    """A stand-in node class: one published tool per keyword, mapping field -> description."""
+    attrs = {}
+    for tool, fields in tools.items():
+
+        def method(self):
+            pass
+
+        method.__tool_meta__ = {
+            'input_schema': {'properties': {field: {'description': text} for field, text in fields.items()}}
+        }
+        attrs[tool] = method
+    return type('Node', (), attrs)
+
+
+def test_the_audit_can_actually_fail():
+    """
+    The guard on the guard.
+
+    A matcher that silently stopped matching would leave every node's audit
+    passing for ever while saying nothing, which is the failure mode of every
+    audit written against a live surface.
+    """
+    node = _node(book={'due_time': 'Due time, HH:MM.'})
+
+    assert audit_time_fields(node) == ['book.due_time']
+
+
+def test_a_field_that_names_its_zone_passes():
+    node = _node(book={'due_time': 'Due time, HH:MM, in UTC.'})
+
+    assert audit_time_fields(node) == []
+
+
+def test_a_calendar_date_needs_no_zone():
+    """A bare YYYY-MM-DD names no instant, so no zone can be wrong about it."""
+    node = _node(deal={'expected_close_date': 'Expected close date, YYYY-MM-DD.'})
+
+    assert audit_time_fields(node) == []
+
+
+def test_an_exemption_covers_exactly_one_tool_parameter():
+    """
+    Scoped to `tool.parameter`, never a bare name.
+
+    A bare `duration` would also exempt a same-named field on another tool that
+    does carry a time of day — silently, since the exemption would still look
+    like the decision it was made for.
+    """
+    node = _node(
+        activity_create={'duration': 'Duration, HH:MM.'},
+        shift_create={'duration': 'Shift start, HH:MM.'},
+    )
+
+    assert audit_time_fields(node, ('activity_create.duration',)) == ['shift_create.duration']
+
+
+def test_a_bare_field_name_is_not_an_exemption():
+    node = _node(activity_create={'duration': 'Duration, HH:MM.'})
+
+    with pytest.raises(ValueError, match='duration'):
+        audit_time_fields(node, ('duration',))
+
+
+def test_an_exemption_that_names_nothing_fails_loudly():
+    """A renamed tool or a removed field must not leave an exemption behind that exempts nothing."""
+    node = _node(activity_create={'due_time': 'Due time, HH:MM, in UTC.'})
+
+    with pytest.raises(ValueError, match='activity_update.duration'):
+        audit_time_fields(node, ('activity_update.duration',))

--- a/nodes/test/tool_gohighlevel/test_gohighlevel.py
+++ b/nodes/test/tool_gohighlevel/test_gohighlevel.py
@@ -33,6 +33,17 @@ import pytest
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
+# sys.path: the test packages under it are named `tool_pipedrive` and
+# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
+# shadow the very nodes these tests import.
+_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
+)
+zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
+_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
+audit_time_fields = zone_audit.audit_time_fields
+
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
 
@@ -1739,3 +1750,47 @@ class TestIGlobalGroupWarnings:
             logged = self._logged(warning_mock)
             assert 'unknown tool group' in logged
             assert 'fail to start' in logged
+
+
+# ---------------------------------------------------------------------------
+# Every field that carries a time of day names its zone
+# ---------------------------------------------------------------------------
+# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
+# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
+# meeting asked for at 12:30 in California was written as "12:30" and shown back
+# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
+# looks exactly like a right one.
+#
+# A model cannot infer a field's zone. It reads the description, and where the
+# description is silent it writes the words the person said.
+#
+# The same audit runs against `tool_gohighlevel`, which was already keeping this
+# rule when Pipedrive was not. Two CRMs, two different correct answers, one
+# obligation — which is what makes this the CRM-agnostic half of the fix.
+
+
+class TestEveryTimeFieldNamesItsZone:
+    #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
+    #: there is, and converting it would turn a duration into a wrong duration.
+    #: Exempt by decision rather than by the matcher missing it.
+    ALLOWED = ('duration',)
+
+    def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
+        assert audit_time_fields(IInstance, self.ALLOWED) == []
+
+    def test_the_audit_can_actually_fail(self):
+        """
+        The guard on the guard.
+
+        A matcher that silently stopped matching would leave the test above
+        passing for ever while saying nothing, which is the failure mode of
+        every audit written against a live surface.
+        """
+
+        class Silent:
+            def book(self):
+                pass
+
+            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
+
+        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/tool_gohighlevel/test_gohighlevel.py
+++ b/nodes/test/tool_gohighlevel/test_gohighlevel.py
@@ -32,17 +32,9 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from test.zone_audit import audit_time_fields
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
-# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
-# sys.path: the test packages under it are named `tool_pipedrive` and
-# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
-# shadow the very nodes these tests import.
-_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
-    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
-)
-zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
-_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
-audit_time_fields = zone_audit.audit_time_fields
 
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
@@ -1755,42 +1747,15 @@ class TestIGlobalGroupWarnings:
 # ---------------------------------------------------------------------------
 # Every field that carries a time of day names its zone
 # ---------------------------------------------------------------------------
-# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
-# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
-# meeting asked for at 12:30 in California was written as "12:30" and shown back
-# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
-# looks exactly like a right one.
-#
-# A model cannot infer a field's zone. It reads the description, and where the
-# description is silent it writes the words the person said.
-#
-# The same audit runs against `tool_gohighlevel`, which was already keeping this
-# rule when Pipedrive was not. Two CRMs, two different correct answers, one
-# obligation — which is what makes this the CRM-agnostic half of the fix.
+# The rule, the bug behind it and the audit's own tests live with the helper:
+# nodes/test/zone_audit.py and nodes/test/test_zone_audit.py. What is this
+# node's own is the verdict and its exemptions.
 
 
 class TestEveryTimeFieldNamesItsZone:
-    #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
-    #: there is, and converting it would turn a duration into a wrong duration.
-    #: Exempt by decision rather than by the matcher missing it.
-    ALLOWED = ('duration',)
+    #: Nothing to exempt: no GoHighLevel parameter carries a time of day
+    #: without naming its zone.
+    ALLOWED = ()
 
     def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
         assert audit_time_fields(IInstance, self.ALLOWED) == []
-
-    def test_the_audit_can_actually_fail(self):
-        """
-        The guard on the guard.
-
-        A matcher that silently stopped matching would leave the test above
-        passing for ever while saying nothing, which is the failure mode of
-        every audit written against a live surface.
-        """
-
-        class Silent:
-            def book(self):
-                pass
-
-            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
-
-        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/tool_pipedrive/test_pipedrive.py
+++ b/nodes/test/tool_pipedrive/test_pipedrive.py
@@ -9,6 +9,7 @@ env-gated live suite.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 import traceback
@@ -22,6 +23,17 @@ import pytest
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
+# sys.path: the test packages under it are named `tool_pipedrive` and
+# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
+# shadow the very nodes these tests import.
+_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
+    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
+)
+zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
+_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
+audit_time_fields = zone_audit.audit_time_fields
+
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
 
@@ -1090,3 +1102,47 @@ class TestCursorPagination:
         result = _instance().person_search({'term': 'ada', 'cursor': 'page1'})
         assert mock_request.call_args[1]['params']['cursor'] == 'page1'
         assert result['next_cursor'] == 'page2'
+
+
+# ---------------------------------------------------------------------------
+# Every field that carries a time of day names its zone
+# ---------------------------------------------------------------------------
+# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
+# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
+# meeting asked for at 12:30 in California was written as "12:30" and shown back
+# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
+# looks exactly like a right one.
+#
+# A model cannot infer a field's zone. It reads the description, and where the
+# description is silent it writes the words the person said.
+#
+# The same audit runs against `tool_gohighlevel`, which was already keeping this
+# rule when Pipedrive was not. Two CRMs, two different correct answers, one
+# obligation — which is what makes this the CRM-agnostic half of the fix.
+
+
+class TestEveryTimeFieldNamesItsZone:
+    #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
+    #: there is, and converting it would turn a duration into a wrong duration.
+    #: Exempt by decision rather than by the matcher missing it.
+    ALLOWED = ('duration',)
+
+    def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
+        assert audit_time_fields(IInstance, self.ALLOWED) == []
+
+    def test_the_audit_can_actually_fail(self):
+        """
+        The guard on the guard.
+
+        A matcher that silently stopped matching would leave the test above
+        passing for ever while saying nothing, which is the failure mode of
+        every audit written against a live surface.
+        """
+
+        class Silent:
+            def book(self):
+                pass
+
+            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
+
+        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/tool_pipedrive/test_pipedrive.py
+++ b/nodes/test/tool_pipedrive/test_pipedrive.py
@@ -9,7 +9,6 @@ env-gated live suite.
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import sys
 import traceback
@@ -22,17 +21,9 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from test.zone_audit import audit_time_fields
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
-# `zone_audit` is loaded by path, not by import. `nodes/test/` cannot go on
-# sys.path: the test packages under it are named `tool_pipedrive` and
-# `tool_gohighlevel`, so putting that directory ahead of `src/nodes` makes them
-# shadow the very nodes these tests import.
-_ZONE_AUDIT_SPEC = importlib.util.spec_from_file_location(
-    'zone_audit', Path(__file__).resolve().parents[1] / 'zone_audit.py'
-)
-zone_audit = importlib.util.module_from_spec(_ZONE_AUDIT_SPEC)
-_ZONE_AUDIT_SPEC.loader.exec_module(zone_audit)
-audit_time_fields = zone_audit.audit_time_fields
 
 
 _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
@@ -1107,42 +1098,17 @@ class TestCursorPagination:
 # ---------------------------------------------------------------------------
 # Every field that carries a time of day names its zone
 # ---------------------------------------------------------------------------
-# THE BUG THIS PINS. `due_time` was documented as 'Due time, HH:MM.' and nothing
-# more. Pipedrive stores it as UTC and renders it in each viewer's own zone, so a
-# meeting asked for at 12:30 in California was written as "12:30" and shown back
-# to the person who asked for it as 05:30. Nothing rejected it — a wrong hour
-# looks exactly like a right one.
-#
-# A model cannot infer a field's zone. It reads the description, and where the
-# description is silent it writes the words the person said.
-#
-# The same audit runs against `tool_gohighlevel`, which was already keeping this
-# rule when Pipedrive was not. Two CRMs, two different correct answers, one
-# obligation — which is what makes this the CRM-agnostic half of the fix.
+# The rule, the bug behind it and the audit's own tests live with the helper:
+# nodes/test/zone_audit.py and nodes/test/test_zone_audit.py. What is this
+# node's own is the verdict and its exemptions.
 
 
 class TestEveryTimeFieldNamesItsZone:
     #: A LENGTH, not an instant. "A two-hour meeting" is 02:00 in every zone
     #: there is, and converting it would turn a duration into a wrong duration.
-    #: Exempt by decision rather than by the matcher missing it.
-    ALLOWED = ('duration',)
+    #: Exempt by decision rather than by the matcher missing it, and scoped to
+    #: the two tools that publish it.
+    ALLOWED = ('activity_create.duration', 'activity_update.duration')
 
     def test_no_published_parameter_describes_a_time_without_saying_which_zone(self):
         assert audit_time_fields(IInstance, self.ALLOWED) == []
-
-    def test_the_audit_can_actually_fail(self):
-        """
-        The guard on the guard.
-
-        A matcher that silently stopped matching would leave the test above
-        passing for ever while saying nothing, which is the failure mode of
-        every audit written against a live surface.
-        """
-
-        class Silent:
-            def book(self):
-                pass
-
-            book.__tool_meta__ = {'input_schema': {'properties': {'due_time': {'description': 'Due time, HH:MM.'}}}}
-
-        assert audit_time_fields(Silent) == ['book.due_time']

--- a/nodes/test/zone_audit.py
+++ b/nodes/test/zone_audit.py
@@ -1,0 +1,115 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Every tool parameter that carries a time of day must name its timezone.
+
+WHAT THIS EXISTS TO CATCH. Pipedrive's `activity_create` documented `due_time`
+as ``'Due time, HH:MM.'`` and nothing more. The API stores that value as UTC and
+shows it back in each viewer's own zone, so a meeting asked for at 12:30 in
+California was written as "12:30", stored, and displayed to the person who asked
+for it as 05:30. Nothing rejected it — a wrong hour looks exactly like a right
+one — and the only reason anybody found out was that they looked at the calendar.
+
+A model cannot infer a field's zone. It reads the description, and if the
+description does not say, it writes what the person said. So the rule is that
+the description says.
+
+WHY IT IS A SHARED HELPER. The same rule has to hold for every CRM this app
+speaks to, and the CRMs do not agree on the answer: Pipedrive wants a naked UTC
+``HH:MM``, GoHighLevel wants ISO-8601 carrying a numeric offset. There is no
+CRM-neutral value — only a CRM-neutral obligation to state one. `tool_gohighlevel`
+was already keeping it (`appointments._APPOINTMENT_TIMEZONE_DESC`) when Pipedrive
+was not, which is what made this worth pinning rather than remembering.
+
+Keyed on the DESCRIPTION rather than the field name, deliberately. Pipedrive's
+`add_time` names no time in its key but carries one; `expected_close_date` looks
+like a date field and correctly needs no zone. Only the text says which is which.
+
+Pure stdlib and no engine imports, so it is safe to import from test modules that
+install their own stub modules before importing the node under test.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+#: A description mentioning one of these is describing a time of day, not a date.
+#:
+#: `HH:MM` covers the split date/time pairs and `HH:MM:SS` timestamps; the ISO
+#: and RFC names cover the single-string forms. A bare ``YYYY-MM-DD`` is absent
+#: on purpose — a calendar date names no instant, so no zone can be wrong about
+#: it, and demanding one would be noise on every close date in the API.
+CARRIES_A_TIME = ('HH:MM', 'ISO 8601', 'ISO-8601', 'RFC3339', 'RFC 3339')
+
+#: Any one of these, anywhere in the description, settles the question.
+#:
+#: Deliberately generous: this test is here to catch a field that says NOTHING,
+#: which is the failure that actually happened. Judging whether what it says is
+#: correct is a person's job, and a stricter matcher would only teach people to
+#: append the word "UTC" to get past it.
+NAMES_A_ZONE = ('UTC', 'timezone', 'time zone', 'IANA', 'offset', 'Z"', 'local time')
+
+
+def audit_time_fields(instance_class: Any, allowed: Iterable[str] = ()) -> list[str]:
+    """
+    Published parameters that carry a time of day and never say in which zone.
+
+    Args:
+        instance_class: The node's ``IInstance`` class. Every attribute carrying
+            a ``__tool_meta__`` is treated as a published tool.
+        allowed: Parameter names exempt by deliberate decision — a duration is
+            a length rather than an instant, and converting one corrupts it.
+            Kept as an explicit list so an exemption is a choice somebody made
+            and can be read back, rather than a hole in the matcher.
+
+    Returns:
+        ``tool.parameter`` for each offender, sorted. Empty is the passing case.
+    """
+    exempt = set(allowed)
+    offenders = []
+
+    for name in dir(instance_class):
+        tool = getattr(instance_class, name, None)
+        meta = getattr(tool, '__tool_meta__', None)
+        if not isinstance(meta, dict):
+            continue
+
+        schema = meta.get('input_schema')
+        properties = schema.get('properties') if isinstance(schema, dict) else None
+        if not isinstance(properties, dict):
+            continue
+
+        for field, spec in properties.items():
+            if field in exempt or not isinstance(spec, dict):
+                continue
+            description = str(spec.get('description') or '')
+            if not any(token in description for token in CARRIES_A_TIME):
+                continue
+            if any(token in description for token in NAMES_A_ZONE):
+                continue
+            offenders.append(f'{name}.{field}')
+
+    return sorted(offenders)

--- a/nodes/test/zone_audit.py
+++ b/nodes/test/zone_audit.py
@@ -48,8 +48,17 @@ Keyed on the DESCRIPTION rather than the field name, deliberately. Pipedrive's
 `add_time` names no time in its key but carries one; `expected_close_date` looks
 like a date field and correctly needs no zone. Only the text says which is which.
 
+THE ONE WAY OUT, and it is the easy one: a description that carries a time but
+names no FORMAT is never inspected. "In the same form as startDate" is clear to a
+reader and invisible here. So a time-bearing field names its format in its own
+description, even when a sibling already spells it out — that is what keeps a
+later edit to it inside the guard. Widening the trigger instead (on "timestamp",
+or on the field name) would flag epoch fields and calendar dates, where no zone
+can be wrong, and teach people to append "UTC" to get past it.
+
 Pure stdlib and no engine imports, so it is safe to import from test modules that
-install their own stub modules before importing the node under test.
+install their own stub modules before importing the node under test — as
+``from test.zone_audit import audit_time_fields``.
 """
 
 from __future__ import annotations
@@ -80,15 +89,25 @@ def audit_time_fields(instance_class: Any, allowed: Iterable[str] = ()) -> list[
     Args:
         instance_class: The node's ``IInstance`` class. Every attribute carrying
             a ``__tool_meta__`` is treated as a published tool.
-        allowed: Parameter names exempt by deliberate decision — a duration is
-            a length rather than an instant, and converting one corrupts it.
-            Kept as an explicit list so an exemption is a choice somebody made
-            and can be read back, rather than a hole in the matcher.
+        allowed: ``tool.parameter`` pairs exempt by deliberate decision — a
+            duration is a length rather than an instant, and converting one
+            corrupts it. Kept as an explicit list so an exemption is a choice
+            somebody made and can be read back, rather than a hole in the
+            matcher. Scoped to one tool's parameter, never a bare name: a bare
+            name would silently exempt every same-named parameter any tool in
+            the node ever grows, including one that does carry a time of day.
 
     Returns:
         ``tool.parameter`` for each offender, sorted. Empty is the passing case.
+
+    Raises:
+        ValueError: An exemption names no published ``tool.parameter``. A
+            renamed tool or a removed field would otherwise leave an exemption
+            behind that exempts nothing — or, once a new field takes the name,
+            the wrong thing.
     """
     exempt = set(allowed)
+    seen = set()
     offenders = []
 
     for name in dir(instance_class):
@@ -103,13 +122,19 @@ def audit_time_fields(instance_class: Any, allowed: Iterable[str] = ()) -> list[
             continue
 
         for field, spec in properties.items():
-            if field in exempt or not isinstance(spec, dict):
+            key = f'{name}.{field}'
+            seen.add(key)
+            if key in exempt or not isinstance(spec, dict):
                 continue
             description = str(spec.get('description') or '')
             if not any(token in description for token in CARRIES_A_TIME):
                 continue
             if any(token in description for token in NAMES_A_ZONE):
                 continue
-            offenders.append(f'{name}.{field}')
+            offenders.append(key)
+
+    stale = exempt - seen
+    if stale:
+        raise ValueError(f'exemptions name no published tool.parameter: {sorted(stale)}')
 
     return sorted(offenders)

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1573,8 +1573,21 @@ class Task(DAPBase):
             # Send out a status update when needed
             self._status_updated = True
 
-            # If this task is started with tracing
-            if self._pipelineTraceLevel:
+            # If this task is started with tracing.
+            #
+            # `'none'` IS A LEVEL, NOT AN ABSENCE. It is a non-empty string and
+            # so was truthy here, which meant a caller asking for no tracing got
+            # the payload suppressed on the engine side and every enter/leave
+            # still derived, seq-stamped, broadcast and written to the run log —
+            # a flow event carrying `trace: {}`. Roughly 379 bytes of identity
+            # and envelope for no signal, one pair per component per request.
+            #
+            # A settings stream that answers UI clicks and is deliberately kept
+            # out of the Runs timeline had accumulated 325 MB that way, 94% of
+            # it empty-payload flow. The level names are documented as
+            # none/metadata/summary/full, and `none` is documented as "no flow
+            # traces"; this is the code catching up with that.
+            if self._pipelineTraceLevel and self._pipelineTraceLevel != 'none':
                 # Clamp oversized payloads HERE, before the rebuilt body
                 # fans out to the broadcast, the derived flow, and the
                 # run-log continuum.

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -1281,3 +1281,91 @@ async def test_on_event_exit_still_defaults_when_no_code_is_sent():
     await Task.on_event(t, {'event': 'apaevt_exit', 'body': {'message': 'Malformed exit message'}})
 
     assert t._status.exitCode == 1
+
+
+# ---------------------------------------------------------------------------
+# on_event / apaevt_trace — the trace level that means "no traces"
+# ---------------------------------------------------------------------------
+
+
+def _trace_task(level):
+    """A task ready to take one apaevt_trace, with the fan-out captured."""
+    from unittest.mock import AsyncMock
+
+    from rocketride import TASK_STATUS
+
+    t = _task(status=TASK_STATUS())
+    t._last_event_time = 0.0
+    t._status_updated = False
+    t._pipelineTraceLevel = level
+    t.build_event = MagicMock(
+        side_effect=lambda name, body=None, event_time=None: {
+            'event': name,
+            'body': dict(body or {}, eventTime=event_time),
+        }
+    )
+    t._accumulate_analytics = MagicMock()
+    t._forward_task_event = AsyncMock()
+    return t
+
+
+_TRACE_MESSAGE = {
+    'event': 'apaevt_trace',
+    'body': {
+        'op': 'enter',
+        'id': 0,
+        'pipe_id': 'parse',
+        'total_pipes': 1,
+        'trace': {'text': 'hello'},
+        'eventTime': 1_000.0,
+    },
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('level', ['metadata', 'summary', 'full'])
+async def test_a_real_trace_level_still_derives_a_flow_event(level):
+    """The levels that ask for tracing keep every part of the fan-out."""
+    t = _trace_task(level)
+
+    await Task.on_event(t, dict(_TRACE_MESSAGE))
+
+    t._forward_task_event.assert_awaited_once()
+    t._accumulate_analytics.assert_called_once()
+    assert t.build_event.call_args.kwargs['body']['trace'] == {'text': 'hello'}
+
+
+@pytest.mark.asyncio
+async def test_the_none_level_emits_no_flow_at_all():
+    """
+    `'none'` IS A LEVEL, NOT AN ABSENCE — and a non-empty string is truthy.
+    Read as "tracing on with the payload suppressed", every enter/leave was
+    still derived, seq-stamped, broadcast and written to the run log: a flow
+    event carrying `trace: {}`, roughly 379 bytes of envelope for no signal,
+    one pair per component per request. A settings stream kept deliberately out
+    of the Runs timeline had accumulated 325 MB that way.
+
+    Nothing else about the event changes: the pipe stack is still tracked and
+    the status is still marked for update.
+    """
+    t = _trace_task('none')
+
+    await Task.on_event(t, dict(_TRACE_MESSAGE))
+
+    t._forward_task_event.assert_not_awaited()
+    t._accumulate_analytics.assert_not_called()
+    t.build_event.assert_not_called()
+    # The parts that are NOT gated on the trace level.
+    assert t._status_updated is True
+    assert t._status.pipeflow.totalPipes == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('level', ['', None])
+async def test_an_absent_trace_level_still_emits_nothing(level):
+    """The original behaviour, unchanged: no level means no flow."""
+    t = _trace_task(level)
+
+    await Task.on_event(t, dict(_TRACE_MESSAGE))
+
+    t._forward_task_event.assert_not_awaited()


### PR DESCRIPTION
## Summary

Clearer CRM timezone guidance and service diagnostics.

- **`tool_pipedrive`: every parameter carrying a time of day now says it is UTC,** via a shared `UTC_TIME_DESC`. That covers activity `due_date` / `due_time`, the `add_time` columns, and the list-filter ranges. `duration` stays exempt because it is a length, not a time.
  - Before this, a 12:30 California meeting was written as 12:30 UTC and shown back as 05:30.
  - The Pipedrive README documents the convention and points at the `tool_datetime` node's `utc_date` / `utc_time` (#2247). That is a prose reference only; nothing here depends on it.
- **`tool_gohighlevel`:** the `message_export` range gets the same treatment `appointments` already had (offset-bearing local strings).
- **`nodes/test/zone_audit.py`:** walks both CRM nodes' published schemas and fails any time-bearing parameter that never names its zone.
- **VS Code:** a service-catalog error, or an empty catalog, is now reported in the output channel. An empty node palette used to look the same whether the cause was "not connected", "authentication failed" or "zero services".
- **`task_engine`:** `pipelineTraceLevel: 'none'` is a non-empty string, so it counted as a trace level and kept deriving and broadcasting empty flow events. One settings stream accumulated 325 MB this way. It now means no flow traces, as documented.

## Type

Fix

## Testing

- [x] Tests added or updated: `zone_audit.py` plus the Pipedrive and GoHighLevel suites; `test_task_engine.py` pins `'none'`, the real levels, and unset
- [x] Tested locally: `test_task_engine.py` 96 passed; zone audit + Pipedrive + GoHighLevel 391 passed, 157 skipped (live-API tests that need `PIPEDRIVE_API_TOKEN` / `GHL_PIT`)
- [ ] `./builder test` passes (left to CI)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Node README updated (`tool_pipedrive`)
- [ ] Breaking changes documented (none)

## Linked Issue

Part of RR-456. Split out of #2213; no GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeK8j3apAhKber2Ac6xAsg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - VS Code now reports service-catalogue errors and warnings, while avoiding repeated duplicate messages.
  - Pipedrive and GoHighLevel tool guidance now clearly specifies UTC and timezone-aware timestamp formats, including date-range considerations.
- **Bug Fixes**
  - Selecting the `none` trace level no longer generates unnecessary flow events or analytics entries.
- **Documentation**
  - Expanded guidance explains UTC conversion, date shifts, duration handling, and ISO 8601 timezone requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->