### PR TITLE
fix(shell): proxy /apps to the engine in dev so app remotes can load

### DIFF
--- a/packages/shell/rsbuild.config.mts
+++ b/packages/shell/rsbuild.config.mts
@@ -131,6 +131,8 @@ export default defineConfig(({ command }) => {
 					'/task': { target: 'http://localhost:5565', ws: true },
 					'/auth': { target: 'http://localhost:5565' },
 					'/api': { target: 'http://localhost:5565', ws: true },
+					// App remotes (/apps/<appId>/v<N>/remoteEntry.js) are engine-served.
+					'/apps': { target: 'http://localhost:5565' },
 					'/marketplace': { target: 'http://localhost:5565' },
 					'/sitemap.xml': { target: 'http://localhost:5565' },
 					'/robots.txt': { target: 'http://localhost:5565' },

--- a/packages/shell/rsbuild.config.mts
+++ b/packages/shell/rsbuild.config.mts
@@ -132,7 +132,7 @@ export default defineConfig(({ command }) => {
 					'/auth': { target: 'http://localhost:5565' },
 					'/api': { target: 'http://localhost:5565', ws: true },
 					// App remotes (/apps/<appId>/v<N>/remoteEntry.js) are engine-served.
-					'/apps': { target: 'http://localhost:5565' },
+					'/apps/': { target: 'http://localhost:5565' },
 					'/marketplace': { target: 'http://localhost:5565' },
 					'/sitemap.xml': { target: 'http://localhost:5565' },
 					'/robots.txt': { target: 'http://localhost:5565' },


### PR DESCRIPTION
## Summary

- Adds `/apps` to the shell dev server's proxy list so app remotes reach the engine instead of falling through to the SPA html fallback.
- Without it, `server:dev` answered `/apps/<appId>/v<N>/remoteEntry.js` with `index.html`; Module Federation then tried to execute HTML and the shell showed "Could not load RocketRide Cloud".
- Dev only — production serves the shell and the engine from a single origin, so no proxy is involved.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified against a running stack — the same URL from both ports:

| | status | content-type | size |
| --- | --- | --- | --- |
| `:5565/apps/rocketride.home/v2/remoteEntry.js` | 200 | `text/javascript` | 256058 b |
| `:3000/…` before | 200 | `text/html` | 1183 b |
| `:3000/…` after | 200 | `text/javascript` | 256058 b |

The app was always built and served correctly; only the dev proxy was missing. No tests added: the gap is a dev-server proxy entry, which the suite does not exercise.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none

## Notes

The proxy matches on path prefix, so nothing under `/apps` was forwarded whatever the API version in the URL — `v1` failed the same way `v2` did.

Found while bringing #1897 onto current develop; unrelated to that work, which is why it comes on its own.

## Linked Issue

Fixes #2255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development loading of Module Federation app remote entries by routing `/apps` requests to the engine instead of the development server’s SPA fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->