### PR TITLE
ci(build): pull MinIO from quay.io - the Docker Hub repo is gone

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -162,13 +162,15 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           set -euo pipefail
+          # quay.io, not Docker Hub: minio/minio on Hub returns zero tags and
+          # empty repository metadata — the whole repo is gone from there, not just
+          # this tag, and Hub reports a missing tag as "pull access denied", which
+          # makes it read like a permissions problem. Same release, same entrypoint,
+          # pulls anonymously. The comment lives ABOVE the command deliberately: a
+          # `#` line inside a `\` continuation ends the command early and docker
+          # never sees the image argument.
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            # quay.io, not Docker Hub: minio/minio on Hub returns zero tags and
-            # empty repository metadata — the whole repo is gone from there, not
-            # just this tag, and Hub reports a missing tag as "pull access denied",
-            # which makes it read like a permissions problem. Same release, same
-            # entrypoint, pulls anonymously.
             quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           for i in $(seq 1 30); do
             if curl -fsS http://localhost:9000/minio/health/live >/dev/null 2>&1; then ready=1; break; fi

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -164,7 +164,12 @@ jobs:
           set -euo pipefail
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            # quay.io, not Docker Hub: minio/minio on Hub returns zero tags and
+            # empty repository metadata — the whole repo is gone from there, not
+            # just this tag, and Hub reports a missing tag as "pull access denied",
+            # which makes it read like a permissions problem. Same release, same
+            # entrypoint, pulls anonymously.
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           for i in $(seq 1 30); do
             if curl -fsS http://localhost:9000/minio/health/live >/dev/null 2>&1; then ready=1; break; fi
             sleep 2


### PR DESCRIPTION
Ryan's #2257 failed with `exit 125` on a message that reads like a permissions problem and isn't one:

```
Unable to find image 'minio/minio:RELEASE.2025-09-07T16-13-09Z' locally
docker: pull access denied for minio/minio ... access to the resource is denied
```

Docker Hub answers "pull access denied" for a tag it can't find on a public repo, which is why the error misleads. And what's missing is bigger than the tag — the registry API returns **zero tags** for `minio/minio` and Hub's repository endpoint returns null metadata. The repository isn't there any more, so bumping to a newer tag wouldn't have helped either.

`quay.io/minio/minio` is public and carries the identical release. Verified by running it rather than by reading an API:

| check | result |
|---|---|
| manifest, anonymous | HTTP 200, multi-arch list incl. `linux/amd64` |
| `docker pull` | succeeds, no login |
| `docker run` with this workflow's exact command | container starts |
| `curl /minio/health/live` | 200 on the second attempt |
| image `version` label | `RELEASE.2025-09-07T16-13-09Z` — same release |
| entrypoint | `/usr/bin/docker-entrypoint.sh` — unchanged |

So this is a registry prefix and nothing else: same release, same entrypoint, no version bump, nothing for the test suite to notice.

**One thing stated as inference, not fact:** the last twelve runs on this repo passed, which I take to mean those runners already had the image cached and never pulled. I did not inspect runner caches. What *is* demonstrated is that a runner without the image cannot obtain it — so this will spread as caches turn over, whatever the exact reason it hasn't yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nTVr6jfSFYm1GppxbjghP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Linux integration-test environment to retrieve the MinIO container image from Quay.io.
  * Existing image version, configuration, health checks, and bucket setup remain unchanged.
  * This maintains the same integration-test behavior while using the updated image registry location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->