### PR TITLE
fix(ai): support single-component validation without pipeline envelope wrap (#2263)

### DIFF
--- a/packages/ai/src/ai/modules/pipe/pipe_validate.py
+++ b/packages/ai/src/ai/modules/pipe/pipe_validate.py
@@ -20,6 +20,10 @@ async def pipe_Validate(request: Request, pipeline: Dict[str, Any], source: Opti
         ResultBase: A standardized response indicating success or failure.
     """
     try:
+        if 'component' in pipeline:
+            data = validatePipeline(pipeline)
+            return response(data)
+
         # Resolve source: explicit param > pipeline field > implied from components
         resolved_source = source or pipeline.get('source', None)
         if not resolved_source:

--- a/packages/ai/src/ai/modules/task/commands/cmd_misc.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_misc.py
@@ -263,24 +263,29 @@ class MiscCommands(DAPConn):
             # Resolve ${ROCKETRIDE_*} variables before validation
             pipeline = resolve_pipeline_env(pipeline, merged_env)
 
-            # Resolve source: explicit arg > pipeline field > implied from components
-            source = args.get('source', None) or pipeline.get('source', None)
-            if not source:
-                source = resolve_implied_source(pipeline)
+            if 'component' in pipeline:
+                # Single-component form (node config panel). validatePipelineOrComponent
+                # dispatches on a root-level 'component'; wrapping it hides that key.
+                data = validatePipeline(pipeline)
+            else:
+                # Resolve source: explicit arg > pipeline field > implied from components
+                source = args.get('source', None) or pipeline.get('source', None)
+                if not source:
+                    source = resolve_implied_source(pipeline)
 
-            # Build the C++ payload with resolved source and default version.
-            # The engine's config loader requires the FILE-form root
-            # ({'pipeline': <config>}) — handing it the flat config rejects
-            # every wire-correct client with "'pipeline' is missing or
-            # invalid". Clients send the flat config per the DAP contract
-            # above; the wrap happens HERE.
-            inner = {**pipeline, 'version': pipeline.get('version', 1)}
-            if source:
-                inner['source'] = source
+                # Build the C++ payload with resolved source and default version.
+                # The engine's config loader requires the FILE-form root
+                # ({'pipeline': <config>}) — handing it the flat config rejects
+                # every wire-correct client with "'pipeline' is missing or
+                # invalid". Clients send the flat config per the DAP contract
+                # above; the wrap happens HERE.
+                inner = {**pipeline, 'version': pipeline.get('version', 1)}
+                if source:
+                    inner['source'] = source
 
-            # Same envelope pipe_Validate (modules/pipe) builds — the version
-            # rides INSIDE the wrapped config (see the FILE-form note above).
-            data = validatePipeline({'pipeline': inner})
+                # Same envelope pipe_Validate (modules/pipe) builds — the version
+                # rides INSIDE the wrapped config (see the FILE-form note above).
+                data = validatePipeline({'pipeline': inner})
 
             # Return the results
             return self.build_response(request, body=data)

--- a/packages/ai/tests/ai/modules/task/commands/test_cmd_misc.py
+++ b/packages/ai/tests/ai/modules/task/commands/test_cmd_misc.py
@@ -331,6 +331,39 @@ async def test_on_rrext_validate_does_not_double_wrap_enveloped_config(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_on_rrext_validate_does_not_wrap_single_component_payload(monkeypatch):
+    """A {'version', 'component'} payload reaches validatePipeline unwrapped.
+
+    The C++ validatePipeline dispatcher keys off root 'component' to run
+    single-component validation (used by the canvas node config panel).
+    Wrapping it in {'pipeline': ...} hides that key and triggers
+    "'pipeline.components' must be an array" (#2263).
+    """
+    captured = {}
+    monkeypatch.setattr(
+        cmd_misc,
+        'validatePipeline',
+        lambda payload: captured.update(payload) or {'ok': True},
+    )
+
+    conn = _make_conn()
+    single_comp = {
+        'version': 1,
+        'component': {
+            'id': 'llm_openai_1',
+            'provider': 'llm_openai',
+            'config': {'model': 'gpt-4o'},
+        },
+    }
+    await MiscCommands.on_rrext_validate(conn, {'arguments': {'pipeline': single_comp}})
+
+    assert 'component' in captured
+    assert 'pipeline' not in captured
+    assert captured['component']['id'] == 'llm_openai_1'
+    assert captured['version'] == 1
+
+
+@pytest.mark.asyncio
 async def test_on_rrext_validate_propagates_validate_pipeline_errors(monkeypatch):
     """A raise from validatePipeline is logged and re-raised."""
     monkeypatch.setattr(cmd_misc, 'resolve_implied_source', lambda p: 'src')

--- a/packages/ai/tests/ai/modules/task/conftest.py
+++ b/packages/ai/tests/ai/modules/task/conftest.py
@@ -55,8 +55,21 @@ def _stub_module(name: str, **attrs) -> None:
 _stub_module('depends', depends=lambda *_args, **_kwargs: None)
 
 # dist/server shared logging/args helpers used by task_engine and friends.
+class _FakeIJson:
+    @staticmethod
+    def toDict(x):
+        return x if isinstance(x, dict) else {}
+
 _stub_module(
     'rocketlib',
     debug=lambda *_args, **_kwargs: None,
+    error=lambda *_args, **_kwargs: None,
+    warning=lambda *_args, **_kwargs: None,
     args=types.SimpleNamespace(),
+    ILoader=type('ILoader', (), {}),
+    IJson=_FakeIJson,
+    getServiceDefinition=lambda *_args, **_kwargs: None,
+    getServiceDefinitions=lambda *_args, **_kwargs: {},
+    validatePipeline=lambda *_args, **_kwargs: {'ok': True},
+    getVersion=lambda *_args, **_kwargs: '3.3.0',
 )

--- a/packages/ai/tests/ai/modules/thin/test_thin_modules.py
+++ b/packages/ai/tests/ai/modules/thin/test_thin_modules.py
@@ -122,6 +122,33 @@ async def test_pipe_validate_preserves_explicit_version(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pipe_validate_does_not_wrap_single_component_payload(monkeypatch):
+    """A {'version', 'component'} payload reaches validatePipeline unwrapped."""
+    captured = {}
+    monkeypatch.setattr(
+        pipe_validate_mod,
+        'validatePipeline',
+        lambda payload: captured.setdefault('payload', payload) or {'ok': True},
+    )
+
+    single_comp = {
+        'version': 1,
+        'component': {
+            'id': 'llm_openai_1',
+            'provider': 'llm_openai',
+            'config': {'model': 'gpt-4o'},
+        },
+    }
+    result = await pipe_validate_mod.pipe_Validate(MagicMock(), single_comp)
+    body = result.body.decode() if hasattr(result, 'body') else str(result)
+    assert 'OK' in body
+    assert 'component' in captured['payload']
+    assert 'pipeline' not in captured['payload']
+    assert captured['payload']['component']['id'] == 'llm_openai_1'
+    assert captured['payload']['version'] == 1
+
+
+@pytest.mark.asyncio
 async def test_pipe_validate_wraps_validate_pipeline_errors(monkeypatch):
     """A validatePipeline RuntimeError comes back as an error envelope."""
 


### PR DESCRIPTION
## Summary
- Supports single-component validation payloads (\{'version': 1, 'component': {...}}\) in \on_rrext_validate\ and \pipe_Validate\ by passing them directly to \alidatePipeline\ without wrapping them in the full-pipeline envelope (\{'pipeline': inner}\).
- The C++ engine dispatcher (\alidate_pipeline.cpp\) keys off root-level \component\ to invoke \alidateComponent()\. Unconditionally wrapping every payload hid the \component\ key, causing single-component validation from the visual canvas node config panel to fail with \'pipeline.components' must be an array\ and preventing node config saves.

## Type
fix

## Testing
- Added regression test \	est_on_rrext_validate_does_not_wrap_single_component_payload\ in \packages/ai/tests/ai/modules/task/commands/test_cmd_misc.py\.
- Verified all validation tests pass.
- Verified \uff check\ clean.

## Linked Issue
Fixes #2263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-component configurations are now validated directly, preserving their top-level component and version information.
  * Multi-component pipeline validation continues to use the existing source resolution and version behavior.

* **Tests**
  * Added coverage to verify that single-component validation payloads are not incorrectly wrapped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->