### PR TITLE
fix(client-python): correct client.use() return dict in SDK docstrings (#2189)

### DIFF
--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -30,8 +30,8 @@ Basic Usage:
     # Connect and execute a pipeline
     client = RocketRideClient(uri="http://localhost:5565")
     result = await client.connect("your_api_key")
-    token = await client.use(filepath="pipeline.json")
-    await client.send(token, "Hello, world!")
+    run = await client.use(filepath="pipeline.json")
+    await client.send(run["token"], "Hello, world!")
     await client.disconnect()
 
     # Chat with AI
@@ -119,8 +119,8 @@ class RocketRideClient(
         client = RocketRideClient(uri="http://localhost:5565")
         result = await client.connect("your_api_key")  # returns ConnectResult
         try:
-            token = await client.use(filepath="my_pipeline.json")
-            await client.send(token, "Process this data")
+            run = await client.use(filepath="my_pipeline.json")
+            await client.send(run["token"], "Process this data")
         finally:
             await client.disconnect()
 
@@ -128,7 +128,8 @@ class RocketRideClient(
         client = RocketRideClient()
         result = await client.connect()
         try:
-            token = await client.use(filepath="my_pipeline.json")
+            run = await client.use(filepath="my_pipeline.json")
+            await client.send(run["token"], "Process this data")
         finally:
             await client.disconnect()
     """

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -36,15 +36,15 @@ Key Features:
 
 Usage:
     # Send simple text data
-    token = await client.use(filepath="text_processor.json")
-    result = await client.send(token, "Process this text")
+    run = await client.use(filepath="text_processor.json")
+    result = await client.send(run["token"], "Process this text")
 
     # Upload multiple files
     files = ["document1.pdf", "data.csv", "image.png"]
-    results = await client.send_files(files, token)
+    results = await client.send_files(files, run["token"])
 
     # Stream large dataset
-    pipe = await client.pipe(token, mimetype="text/csv")
+    pipe = await client.pipe(run["token"], mimetype="text/csv")
     await pipe.open()
     await pipe.write(csv_chunk1)
     await pipe.write(csv_chunk2)
@@ -485,15 +485,15 @@ class DataMixin(DAPClient):
 
         Example:
             # Send text data
-            token = await client.use(filepath="text_analyzer.json")
-            result = await client.send(token, "Analyze this text for sentiment")
+            run = await client.use(filepath="text_analyzer.json")
+            result = await client.send(run["token"], "Analyze this text for sentiment")
             print(f"Sentiment: {result['sentiment']}")
 
             # Send JSON data
             import json
             data = {"name": "John", "age": 30}
             result = await client.send(
-                token,
+                run["token"],
                 json.dumps(data),
                 mimetype="application/json"
             )
@@ -501,7 +501,7 @@ class DataMixin(DAPClient):
             # Send binary data
             with open("data.bin", "rb") as f:
                 binary_data = f.read()
-            result = await client.send(token, binary_data, mimetype="application/octet-stream")
+            result = await client.send(run["token"], binary_data, mimetype="application/octet-stream")
         """
         # Convert string to bytes if needed
         if isinstance(data, str):

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -194,7 +194,7 @@ class DataMixin(DAPClient):
                     keeps failing with a transient connect error past the retry.
 
             Example:
-                pipe = await client.pipe(token, mimetype="text/plain")
+                pipe = await client.pipe(token, mime_type="text/plain")
                 await pipe.open()
                 # Now ready to write data
             """
@@ -314,7 +314,7 @@ class DataMixin(DAPClient):
                 PipeException: If the server reports a failure while finalizing the pipe.
 
             Example:
-                pipe = await client.pipe(token, mimetype="text/csv")
+                pipe = await client.pipe(token, mime_type="text/csv")
                 await pipe.open()
                 await pipe.write(csv_data.encode())
                 results = await pipe.close()

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -44,7 +44,7 @@ Usage:
     results = await client.send_files(files, run["token"])
 
     # Stream large dataset
-    pipe = await client.pipe(run["token"], mimetype="text/csv")
+    pipe = await client.pipe(run["token"], mime_type="text/csv")
     await pipe.open()
     await pipe.write(csv_chunk1)
     await pipe.write(csv_chunk2)
@@ -124,7 +124,7 @@ class DataMixin(DAPClient):
 
         Example:
             # Stream CSV data in chunks
-            pipe = await client.pipe(token, mimetype="text/csv")
+            pipe = await client.pipe(token, mime_type="text/csv")
             async with pipe:  # Automatically opens and closes
                 for chunk in csv_chunks:
                     await pipe.write(chunk.encode())


### PR DESCRIPTION
Closes #2189

### Summary of changes
In ocketride/client.py and ocketride/mixins/data.py, several docstrings and usage examples showed 	oken = client.use(token) and subsequently passing 	oken directly to client.send(token, ...).

However, client.use() returns a dict {'token': ..., 'expires_at': ...}, so passing it directly as a string causes errors and confusion for SDK users.

This PR updates the docstrings and usage examples across both files to reference 	oken['token'] (or extract 'token' from the dictionary returned by client.use()).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Python client usage examples to reflect the current pipeline response format.
  - Examples now extract the pipeline token before sending messages, files, or data through the client.
  - Corrected the data-piping example to use the current `mime_type` argument name.
  - No functional behavior or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->