### PR TITLE
docs: add docker start to deployment instructions (#2191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ _Whether you build web apps, integrate APIs, or run backend services, you alread
      ```bash
      docker pull ghcr.io/rocketride-org/rocketride-engine:latest
      docker create --name rocketride-engine -p 5565:5565 ghcr.io/rocketride-org/rocketride-engine:latest
+     docker start rocketride-engine
      ```
 
    - **Local Deployment** - Download your preferred runtime as a standalone process from the **Deploy** page in the `Connection Manager`.

--- a/apps/rocket-ui/src/README.md
+++ b/apps/rocket-ui/src/README.md
@@ -95,6 +95,7 @@ _Drop pipelines into any Python or TypeScript app with a few lines of code, no i
      ```bash
      docker pull ghcr.io/rocketride-org/rocketride-engine:latest
      docker create --name rocketride-engine -p 5565:5565 ghcr.io/rocketride-org/rocketride-engine:latest
+     docker start rocketride-engine
      ```
 
    - **Local Deployment** - Download your preferred runtime as a standalone process from the **Deploy** page in the `Connection Manager`.


### PR DESCRIPTION
Closes #2191

### Summary of changes
In README.md and pps/rocket-ui/src/README.md, running docker create configures the container but does not start it. Users following the instructions were unable to connect to the engine without an explicit start step.

This PR adds docker start rocketride-engine directly after the docker create command in both README files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Docker deployment instructions to include starting the container after creation.
  - Added the same container startup step to the “Building Your First Pipe” guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->