### PR TITLE
fix(build): avoid task port collision between client-python and client-mcp test servers (#1879)

### DIFF
--- a/packages/client-mcp/scripts/tasks.js
+++ b/packages/client-mcp/scripts/tasks.js
@@ -178,7 +178,7 @@ function makeStartTestServerAction(options = {}) {
             const result = await startServer({
                 script: 'ai/eaas.py',
                 trace: options.trace,
-                basePort: 20000,
+                basePort: 50000,
                 onOutput: (text) => {
                     if (taskComplete) return;
                     const lines = text.trim().split('\n');


### PR DESCRIPTION
Closes #1879

### Summary of changes
In packages/client-mcp/scripts/tasks.js, startServer was configured with asePort: 20000, which was identical to the port range used by packages/client-python/scripts/tasks.js (20000). Meanwhile, client-typescript uses 30000 and 
odes uses 40000.

This PR sets asePort: 50000 for client-mcp, ensuring completely disjoint port ranges across all package test suites and preventing port conflict errors during parallel testing or CI runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test server’s requested base port from 20,000 to 50,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->