### PR TITLE
chore(security): bump mcp/apps vitest declaration to ^4.1.11 (#2243)

### DIFF
--- a/packages/ai/src/ai/modules/mcp/apps/package.json
+++ b/packages/ai/src/ai/modules/mcp/apps/package.json
@@ -22,6 +22,6 @@
 		"typescript": "^5.5.0",
 		"vite": "^6.0.0",
 		"vite-plugin-singlefile": "^2.0.0",
-		"vitest": "^3.0.0"
+		"vitest": "^4.1.11"
 	}
 }


### PR DESCRIPTION
Closes #2243

### Summary of changes
Bumps vitest declaration in packages/ai/src/ai/modules/mcp/apps/package.json to ^4.1.11 to resolve security vulnerability warnings and align with workspace tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing tooling used by the MCP apps widget package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->