### PR TITLE
fix(tool_laserdata_memory): update laser-sdk pin to 0.3.0 (#2226)

### DIFF
--- a/nodes/src/nodes/constraints.lock
+++ b/nodes/src/nodes/constraints.lock
@@ -730,7 +730,7 @@ language-tags==1.3.1
     # via csvw
 lark==1.3.1
     # via cel-python
-laser-sdk==0.1.1
+laser-sdk==0.3.0
     # via -r nodes/src/nodes/tool_laserdata_memory/requirements.txt
 leb128==1.0.9
     # via asynch

--- a/nodes/src/nodes/tool_laserdata_memory/README.md
+++ b/nodes/src/nodes/tool_laserdata_memory/README.md
@@ -36,7 +36,7 @@ destructive clear/reset tool.
 
 ## SDK contract provenance
 
-Pinned to **`laser-sdk==0.1.1`** (PyPI, in `requirements.txt`); the contract below was verified
+Pinned to **`laser-sdk==0.3.0`** (PyPI, in `requirements.txt`); the contract below was verified
 against `0.0.1rc21` and has not been re-checked on 0.1.1. rc20+ speaks only Apache Iggy's VSR
 cluster protocol (the upcoming clustering wire format), so the server must be a
 VSR-enabled build: LaserData Cloud deployments **created on/after 2026-07-31** serve it (older

--- a/nodes/src/nodes/tool_laserdata_memory/requirements.txt
+++ b/nodes/src/nodes/tool_laserdata_memory/requirements.txt
@@ -4,5 +4,5 @@
 # local server must be a VSR-enabled build (e.g. laserdata/laser-stack).
 # Pin moved rc21 -> 0.1.1 so it resolves alongside sibling LaserData nodes
 # in the shared constraint compile (#2030). The VSR notes above were
-# verified on rc21 and have not been re-checked on 0.1.1.
-laser-sdk==0.1.1
+# verified on rc21 and have not been re-checked on 0.1.1 / 0.3.0.
+laser-sdk==0.3.0


### PR DESCRIPTION
Closes #2226

### Summary of changes
Updates the laser-sdk dependency pin from 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the SDK contract provenance to reference laser-sdk 0.3.0.
  - Clarified the verification status of the associated VSR notes across relevant SDK versions.

- **Maintenance**
  - Updated the tool’s laser-sdk version pin to 0.3.0 for improved version alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->