### PR TITLE
fix(server): warn when JRE staging is skipped and fetch JRE during tool setup

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -26,6 +26,7 @@
  *
  * Handles downloading pre-built server binaries or compiling from source.
  */
+
 const path = require('path');
 const os = require('os');
 const { glob } = require('glob');
@@ -777,6 +778,10 @@ function makeSetupJreAction() {
 			const result = await copyJavaJre();
 			if (!result.copied) {
 				task.output = result.reason;
+				// A silent no-op here means the engine starts without jvm.dll
+				// and every pipeline task fails; warn loudly so the missing
+				// JRE is diagnosable from the build log.
+				console.warn(`WARNING: JRE not staged into dist — ${result.reason}`);
 			} else {
 				task.output = result.stats ? formatSyncStats(result.stats) : 'Synced JRE';
 			}
@@ -1098,7 +1103,7 @@ function makeBuildCoreAction() {
 			whenNot({
 				name: 'ready',
 				condition: (ctx) => ctx.serverReady,
-				then: [parallel(['server:setup-tools', 'vcpkg:submodule-build', 'java:setup-jdk'], 'Setup build tools'), 'server:configure', 'server:compile-engine', parallel(['server:setup-python', 'server:setup-jre'], 'Setup dependencies'), parallel(['server:setup-runtime-libs', 'server:setup-samba'], 'Setup runtime'), 'tika:submodule-build'],
+				then: [parallel(['server:setup-tools', 'vcpkg:submodule-build', 'java:setup-jdk', 'java:setup-jre'], 'Setup build tools'), 'server:configure', 'server:compile-engine', parallel(['server:setup-python', 'server:setup-jre'], 'Setup dependencies'), parallel(['server:setup-runtime-libs', 'server:setup-samba'], 'Setup runtime'), 'tika:submodule-build'],
 			}),
 		],
 	};


### PR DESCRIPTION
## Summary
- Warn loudly in the build log when `server:setup-jre` skips staging the JRE — previously a silent no-op left `dist` without `jvm.dll` and every pipeline task failed with nothing diagnosable in the log
- Add `java:setup-jre` to the build-tools parallel group in `server:build-core` so the JRE is downloaded before the staging step runs

## Test plan
- Run `./builder build server` on a clean tree and confirm the JRE is fetched during tool setup and staged into dist
- Remove the JRE source dir and rebuild; confirm the `WARNING: JRE not staged into dist` line appears in the build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Java runtime setup now runs as part of the standard build-tool preparation process, helping ensure required Java components are available during builds.
  - Build preparation can complete setup tasks more efficiently by running compatible tool installation steps in parallel.

- **Diagnostics**
  - Improved warnings provide clearer feedback when staging the Java runtime fails, making build setup issues easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->