### PR TITLE
fix(ai.web): drop phantom ObjectPipe from __all__

### DIFF
--- a/packages/ai/src/ai/web/__init__.py
+++ b/packages/ai/src/ai/web/__init__.py
@@ -80,7 +80,6 @@ __all__ = [
     'File',
     'formatException',
     'Header',
-    'ObjectPipe',
     'Query',
     'Request',
     'response',


### PR DESCRIPTION
### Problem

`packages/ai/src/ai/web/__init__.py` lists `'ObjectPipe'` in `__all__`, but
the name is never imported or defined in the module — in fact `ObjectPipe`
appears nowhere else in the repository.

Because the module defines no module-level `__getattr__`, a wildcard import
fails hard:

```python
>>> from ai.web import *
AttributeError: module 'ai.web' has no attribute 'ObjectPipe'
```

`__all__` is the explicit export contract for `import *`, so every listed
name must resolve.

### Fix

Remove the stray `'ObjectPipe'` entry from `__all__`. No other code
references it; all remaining names are imported above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed `ObjectPipe` from the package’s publicly exported names. Other exports and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->